### PR TITLE
fix: show full session titles

### DIFF
--- a/web-ui.html
+++ b/web-ui.html
@@ -1476,13 +1476,21 @@
             font-size: var(--font-size-body);
             font-weight: var(--font-weight-secondary);
             color: var(--color-text-primary);
-            line-height: 1.35;
+            line-height: 1.45;
             display: -webkit-box;
-            -webkit-line-clamp: 2;
+            -webkit-line-clamp: 3;
             -webkit-box-orient: vertical;
             overflow: hidden;
             word-break: break-word;
             flex: 1;
+            max-height: calc(1.45em * 3);
+        }
+
+        @media (max-width: 768px) {
+            .session-item-title {
+                -webkit-line-clamp: 4;
+                max-height: calc(1.45em * 4);
+            }
         }
 
         .session-item-actions {


### PR DESCRIPTION
## Summary
- allow session list titles to wrap more lines (3 desktop, 4 mobile) to avoid truncation
- adjust line-height/max-height for better readability on various widths

## Testing
- Not run (CSS-only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved session title readability with optimized line spacing and text handling.
  * Enhanced responsive design for session titles on mobile and tablet screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->