### PR TITLE
fix: bootstrap test deps before npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "codexmate",
   "version": "0.0.12",
   "description": "Codex/Claude Code 配置与会话管理 CLI + Web 工具",
@@ -28,7 +28,8 @@
     "start": "node cli.js",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "node tests/unit/run.mjs",
-    "test:e2e": "node tests/e2e/run.js"
+    "test:e2e": "node tests/e2e/run.js",
+    "pretest": "node scripts/ensure-test-deps.js"
   },
   "dependencies": {
     "@iarna/toml": "^2.2.5",

--- a/scripts/ensure-test-deps.js
+++ b/scripts/ensure-test-deps.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.resolve(__dirname, '..');
+const lockfile = path.join(root, 'package-lock.json');
+const packageJson = path.join(root, 'package.json');
+const nodeModules = path.join(root, 'node_modules');
+
+function hasRequiredDeps() {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+    const deps = Object.keys(pkg.dependencies || {});
+    if (!deps.length) return true;
+    return deps.every((name) => {
+      try {
+        require.resolve(name, { paths: [root] });
+        return true;
+      } catch (_) {
+        return false;
+      }
+    });
+  } catch (err) {
+    console.error(`[codexmate] Failed to inspect dependencies: ${err.message || err}`);
+    process.exit(1);
+  }
+}
+
+if (hasRequiredDeps()) {
+  process.exit(0);
+}
+
+const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const installArgs = fs.existsSync(lockfile) ? ['ci'] : ['install'];
+
+console.log(`[codexmate] Missing test dependencies detected under ${nodeModules}. Running \`${npmCmd} ${installArgs.join(' ')}\` before tests...`);
+const result = spawnSync(npmCmd, installArgs, {
+  cwd: root,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (result.error) {
+  console.error(`[codexmate] Failed to install dependencies: ${result.error.message}`);
+  process.exit(1);
+}
+
+process.exit(result.status == null ? 1 : result.status);


### PR DESCRIPTION
## Summary
- add a pretest bootstrap step that checks whether runtime dependencies are installed
- automatically run npm ci (or npm install when no lockfile exists) before npm test if dependencies are missing
- keep the test entrypoint self-contained for fresh clones

## Problem
On a fresh clone, running npm test could fail during E2E setup with Cannot find module '@iarna/toml' because the test command assumed dependencies had already been installed.

## Fix
- add scripts/ensure-test-deps.js to detect missing dependencies using require.resolve
- wire it into pretest so npm test bootstraps dependencies before running unit and E2E suites

## Validation
- removed node_modules and verified npm test now auto-runs npm ci before executing the suites
- verified npm run test:e2e exits with code 0 after dependency bootstrap
