### PR TITLE
feat: add MCP stdio integration with security and regression hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,29 @@ npm link
 | `codexmate add-model <model>` | Add a model |
 | `codexmate delete-model <model>` | Delete a model |
 | `codexmate run` | Start the Web UI |
+| `codexmate mcp [serve] [--transport stdio] [--allow-write\|--read-only]` | Start MCP server over stdio (default read-only) |
 | `codexmate export-session --source <codex|claude> (--session-id <ID>|--file <PATH>) [--output <PATH>] [--max-messages <N|all|Infinity>]` | Export a session to Markdown |
+
+## MCP (stdio)
+
+- Transport: `stdio` only
+- Default mode: read-only tool set
+- Write tools: enable by `--allow-write` or `CODEXMATE_MCP_ALLOW_WRITE=1`
+- Sensitive fields in `codexmate.claude.settings.get` are returned as masked values
+
+```bash
+# Read-only (recommended for external agents)
+codexmate mcp serve --read-only
+
+# Enable write tools explicitly
+codexmate mcp serve --allow-write
+```
+
+Provided MCP domains:
+
+- `tools`: status/provider/model/session/auth/proxy and config operations
+- `resources`: status/providers/sessions snapshots
+- `prompts`: built-in diagnose/switch/export templates
 
 ## Web UI
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,7 +175,29 @@ npm link
 | `codexmate add-model <模型名称>` | 添加模型 |
 | `codexmate delete-model <模型名称>` | 删除模型 |
 | `codexmate run` | 启动 Web 界面 |
+| `codexmate mcp [serve] [--transport stdio] [--allow-write\|--read-only]` | 启动 MCP stdio 服务（默认只读） |
 | `codexmate export-session --source <codex|claude> (--session-id <ID>|--file <PATH>) [--output <PATH>] [--max-messages <N|all|Infinity>]` | 导出指定会话为 Markdown |
+
+## MCP（stdio）
+
+- 传输方式：仅支持 `stdio`
+- 默认模式：只读工具集
+- 写入工具开启方式：`--allow-write` 或 `CODEXMATE_MCP_ALLOW_WRITE=1`
+- `codexmate.claude.settings.get` 的敏感字段默认脱敏返回
+
+```bash
+# 只读（推荐给外部 Agent 接入）
+codexmate mcp serve --read-only
+
+# 显式开启写工具
+codexmate mcp serve --allow-write
+```
+
+当前提供的 MCP 能力：
+
+- `tools`：状态/提供商/模型/会话/认证/代理/配置等操作
+- `resources`：status/providers/sessions 快照资源
+- `prompts`：诊断/安全切换/会话导出模板
 
 ## Web 界面
 

--- a/cli.js
+++ b/cli.js
@@ -53,6 +53,7 @@ const {
     parseMaxMessagesValue,
     resolveMaxMessagesValue
 } = require('./lib/cli-session-utils');
+const { createMcpStdioServer } = require('./lib/mcp-stdio');
 
 const DEFAULT_WEB_PORT = 3737;
 const DEFAULT_WEB_HOST = '127.0.0.1';
@@ -7026,16 +7027,783 @@ async function cmdGemini(args = []) {
     return runProxyCommand('Gemini', ['gemini', 'gemini-cli'], args, 'npm install -g @google/gemini-cli');
 }
 
+function parseMcpOptions(args = []) {
+    const options = {
+        subcommand: 'serve',
+        transport: 'stdio',
+        allowWrite: false,
+        help: false
+    };
+
+    const argv = Array.isArray(args) ? [...args] : [];
+    if (argv.length > 0 && !argv[0].startsWith('-')) {
+        options.subcommand = String(argv.shift() || '').trim().toLowerCase() || 'serve';
+    }
+
+    const envAllowWrite = typeof process.env.CODEXMATE_MCP_ALLOW_WRITE === 'string'
+        && ['1', 'true', 'yes', 'on'].includes(process.env.CODEXMATE_MCP_ALLOW_WRITE.trim().toLowerCase());
+    options.allowWrite = envAllowWrite;
+
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (!arg) continue;
+        if (arg === '--help' || arg === '-h') {
+            options.help = true;
+            continue;
+        }
+        if (arg === '--allow-write' || arg === '--allow-write-tools') {
+            options.allowWrite = true;
+            continue;
+        }
+        if (arg === '--read-only') {
+            options.allowWrite = false;
+            continue;
+        }
+        if (arg.startsWith('--transport=')) {
+            options.transport = arg.slice('--transport='.length).trim().toLowerCase() || options.transport;
+            continue;
+        }
+        if (arg === '--transport') {
+            options.transport = String(argv[i + 1] || '').trim().toLowerCase() || options.transport;
+            i += 1;
+            continue;
+        }
+    }
+
+    return options;
+}
+
+function toMcpToolResult(payload) {
+    const structured = payload === undefined
+        ? {}
+        : (payload && typeof payload === 'object' ? payload : { value: payload });
+    const hasError = !!(structured && typeof structured === 'object' && (
+        (typeof structured.error === 'string' && structured.error.trim())
+        || structured.success === false
+    ));
+    const text = JSON.stringify(structured, null, 2);
+    const result = {
+        content: [{ type: 'text', text }],
+        structuredContent: structured
+    };
+    if (hasError) {
+        result.isError = true;
+    }
+    return result;
+}
+
+function buildMcpStatusPayload() {
+    const statusConfigResult = readConfigOrVirtualDefault();
+    const config = statusConfigResult.config;
+    const serviceTier = typeof config.service_tier === 'string' ? config.service_tier.trim() : '';
+    const modelReasoningEffort = typeof config.model_reasoning_effort === 'string' ? config.model_reasoning_effort.trim() : '';
+    return {
+        provider: config.model_provider || '未设置',
+        model: config.model || '未设置',
+        serviceTier,
+        modelReasoningEffort,
+        configReady: !statusConfigResult.isVirtual,
+        configNotice: statusConfigResult.reason || '',
+        initNotice: consumeInitNotice()
+    };
+}
+
+function buildMcpProviderListPayload() {
+    const listConfigResult = readConfigOrVirtualDefault();
+    const listConfig = listConfigResult.config;
+    const providers = listConfig.model_providers || {};
+    const current = listConfig.model_provider;
+    return {
+        configReady: !listConfigResult.isVirtual,
+        providers: Object.entries(providers).map(([name, p]) => ({
+            name,
+            url: p.base_url || '',
+            key: maskKey(p.preferred_auth_method || ''),
+            hasKey: !!(p.preferred_auth_method && p.preferred_auth_method.trim()),
+            current: name === current,
+            readOnly: isBuiltinProxyProvider(name),
+            nonDeletable: isNonDeletableProvider(name),
+            nonEditable: isNonEditableProvider(name)
+        }))
+    };
+}
+
+function buildMcpClaudeSettingsPayload() {
+    const info = readClaudeSettingsInfo();
+    if (!info || typeof info !== 'object') {
+        return { error: '读取 Claude 配置失败' };
+    }
+    if (info.error) {
+        return info;
+    }
+
+    const apiKey = typeof info.apiKey === 'string' ? info.apiKey : '';
+    const baseUrl = typeof info.baseUrl === 'string' ? info.baseUrl : '';
+    const model = typeof info.model === 'string' ? info.model : '';
+    const maskedApiKey = maskKey(apiKey);
+
+    return {
+        exists: !!info.exists,
+        targetPath: info.targetPath || CLAUDE_SETTINGS_FILE,
+        apiKey: maskedApiKey,
+        apiKeyMasked: maskedApiKey,
+        baseUrl,
+        model,
+        env: {
+            ANTHROPIC_API_KEY: maskedApiKey,
+            ANTHROPIC_BASE_URL: baseUrl,
+            ANTHROPIC_MODEL: model
+        },
+        redacted: true
+    };
+}
+
+function normalizeMcpSource(value) {
+    const source = typeof value === 'string' ? value.trim().toLowerCase() : '';
+    if (!source) return '';
+    if (source === 'codex' || source === 'claude' || source === 'all') {
+        return source;
+    }
+    return null;
+}
+
+function createMcpTools(options = {}) {
+    const allowWrite = !!options.allowWrite;
+    const tools = [];
+
+    const pushTool = (tool) => {
+        if (!tool || typeof tool !== 'object') return;
+        if (!tool.readOnly && !allowWrite) return;
+        tools.push({
+            name: tool.name,
+            description: tool.description,
+            inputSchema: tool.inputSchema || { type: 'object', properties: {}, additionalProperties: false },
+            annotations: {
+                readOnlyHint: !!tool.readOnly
+            },
+            handler: async (args = {}) => {
+                try {
+                    const payload = await tool.handler(args || {});
+                    return toMcpToolResult(payload);
+                } catch (error) {
+                    return toMcpToolResult({
+                        error: error && error.message ? error.message : String(error || 'Tool execution failed')
+                    });
+                }
+            }
+        });
+    };
+
+    pushTool({
+        name: 'codexmate.status.get',
+        description: 'Get current provider/model status, config readiness and startup notice.',
+        readOnly: true,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => buildMcpStatusPayload()
+    });
+
+    pushTool({
+        name: 'codexmate.provider.list',
+        description: 'List configured providers with masked key and active flags.',
+        readOnly: true,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => buildMcpProviderListPayload()
+    });
+
+    pushTool({
+        name: 'codexmate.model.list',
+        description: 'List models from a provider. If provider is omitted, use current provider.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                provider: { type: 'string' }
+            },
+            additionalProperties: false
+        },
+        handler: async (args = {}) => {
+            const rawProvider = typeof args.provider === 'string' ? args.provider.trim() : '';
+            let providerName = rawProvider;
+            if (!providerName) {
+                const cfg = readConfigOrVirtualDefault().config || {};
+                providerName = typeof cfg.model_provider === 'string' ? cfg.model_provider.trim() : '';
+            }
+            if (!providerName) {
+                return { error: 'Provider name is required' };
+            }
+            const res = await fetchProviderModels(providerName);
+            if (res.error) {
+                return { error: res.error, models: [], source: 'remote' };
+            }
+            if (res.unlimited) {
+                return { models: [], source: 'remote', provider: res.provider || '', unlimited: true };
+            }
+            return { models: res.models || [], source: 'remote', provider: res.provider || '' };
+        }
+    });
+
+    pushTool({
+        name: 'codexmate.config.template.get',
+        description: 'Get Codex config template with optional provider/model/service tier/reasoning effort.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                provider: { type: 'string' },
+                model: { type: 'string' },
+                serviceTier: { type: 'string' },
+                reasoningEffort: { type: 'string' }
+            },
+            additionalProperties: false
+        },
+        handler: async (args = {}) => getConfigTemplate(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.claude.settings.get',
+        description: 'Read Claude settings.json env values managed by codexmate.',
+        readOnly: true,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => buildMcpClaudeSettingsPayload()
+    });
+
+    pushTool({
+        name: 'codexmate.openclaw.config.get',
+        description: 'Read OpenClaw config file content and metadata.',
+        readOnly: true,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => readOpenclawConfigFile()
+    });
+
+    pushTool({
+        name: 'codexmate.session.list',
+        description: 'List sessions from codex/claude/all with filters.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                source: { type: 'string' },
+                pathFilter: { type: 'string' },
+                query: { type: 'string' },
+                roleFilter: { type: 'string' },
+                timeRangePreset: { type: 'string' },
+                limit: { type: 'number' },
+                forceRefresh: { type: 'boolean' },
+                queryMode: { type: 'string' },
+                queryScope: { type: 'string' },
+                contentScanLimit: { type: 'number' }
+            },
+            additionalProperties: false
+        },
+        handler: async (args = {}) => {
+            const input = args && typeof args === 'object' ? args : {};
+            const source = normalizeMcpSource(input.source);
+            if (source === null) {
+                return { error: 'Invalid source. Must be codex, claude, or all' };
+            }
+            const normalizedInput = {
+                ...input,
+                source: source || 'all'
+            };
+            return {
+                sessions: listAllSessions(normalizedInput),
+                source: source || 'all'
+            };
+        }
+    });
+
+    pushTool({
+        name: 'codexmate.session.detail',
+        description: 'Read a session detail by source + sessionId/file.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                source: { type: 'string' },
+                sessionId: { type: 'string' },
+                file: { type: 'string' },
+                maxMessages: { type: ['string', 'number'] }
+            },
+            additionalProperties: true
+        },
+        handler: async (args = {}) => readSessionDetail(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.session.export',
+        description: 'Export session as markdown payload.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                source: { type: 'string' },
+                sessionId: { type: 'string' },
+                file: { type: 'string' },
+                maxMessages: { type: ['string', 'number'] }
+            },
+            additionalProperties: true
+        },
+        handler: async (args = {}) => exportSessionData(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.auth.profile.list',
+        description: 'List codex auth profiles.',
+        readOnly: true,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => ({ profiles: listAuthProfilesInfo() })
+    });
+
+    pushTool({
+        name: 'codexmate.proxy.status',
+        description: 'Get builtin proxy runtime status and persisted config.',
+        readOnly: true,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => getBuiltinProxyStatus()
+    });
+
+    pushTool({
+        name: 'codexmate.config.template.apply',
+        description: 'Apply Codex TOML template and sync auth/model pointers.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                template: { type: 'string' }
+            },
+            required: ['template'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => applyConfigTemplate(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.provider.add',
+        description: 'Add provider into config.toml model_providers.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string' },
+                url: { type: 'string' },
+                key: { type: 'string' }
+            },
+            required: ['name', 'url'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => addProviderToConfig(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.provider.update',
+        description: 'Update provider url/key.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string' },
+                url: { type: 'string' },
+                key: { type: 'string' }
+            },
+            required: ['name'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => updateProviderInConfig(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.provider.delete',
+        description: 'Delete provider from config.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string' }
+            },
+            required: ['name'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => deleteProviderFromConfig(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.claude.config.apply',
+        description: 'Apply Claude env config into ~/.claude/settings.json.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                apiKey: { type: 'string' },
+                baseUrl: { type: 'string' },
+                model: { type: 'string' }
+            },
+            required: ['apiKey'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => applyToClaudeSettings(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.openclaw.config.apply',
+        description: 'Apply OpenClaw config content into ~/.openclaw/openclaw.json.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                content: { type: 'string' },
+                lineEnding: { type: 'string' }
+            },
+            required: ['content'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => applyOpenclawConfig(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.session.delete',
+        description: 'Delete one session or selected records in a session.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                source: { type: 'string' },
+                sessionId: { type: 'string' },
+                file: { type: 'string' },
+                recordLineIndex: { type: 'number' },
+                recordLineIndices: { type: 'array', items: { type: 'number' } }
+            },
+            additionalProperties: true
+        },
+        handler: async (args = {}) => deleteSessionData(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.auth.profile.switch',
+        description: 'Switch active auth profile by name.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string' }
+            },
+            required: ['name'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => {
+            const profileName = typeof args.name === 'string' ? args.name.trim() : '';
+            if (!profileName) return { error: '认证名称不能为空' };
+            try {
+                return switchAuthProfile(profileName, { silent: true });
+            } catch (e) {
+                return { error: e.message || '切换认证失败' };
+            }
+        }
+    });
+
+    pushTool({
+        name: 'codexmate.auth.profile.delete',
+        description: 'Delete an auth profile by name.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                name: { type: 'string' }
+            },
+            required: ['name'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => deleteAuthProfile(typeof args.name === 'string' ? args.name : '')
+    });
+
+    pushTool({
+        name: 'codexmate.proxy.start',
+        description: 'Start builtin proxy runtime with optional overrides.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                enabled: { type: 'boolean' },
+                host: { type: 'string' },
+                port: { type: 'number' },
+                provider: { type: 'string' },
+                authSource: { type: 'string' },
+                timeoutMs: { type: 'number' }
+            },
+            additionalProperties: false
+        },
+        handler: async (args = {}) => startBuiltinProxyRuntime(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.proxy.stop',
+        description: 'Stop builtin proxy runtime.',
+        readOnly: false,
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        handler: async () => stopBuiltinProxyRuntime()
+    });
+
+    pushTool({
+        name: 'codexmate.proxy.provider.apply',
+        description: 'Apply builtin proxy provider into codex config.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                switchToProxy: { type: 'boolean' },
+                provider: { type: 'string' }
+            },
+            additionalProperties: true
+        },
+        handler: async (args = {}) => applyBuiltinProxyProvider(args || {})
+    });
+
+    return tools;
+}
+
+function createMcpResources() {
+    return [
+        {
+            uri: 'codexmate://status',
+            name: 'Status',
+            description: 'Current provider/model status snapshot.',
+            mimeType: 'application/json',
+            read: async () => ({
+                contents: [{
+                    uri: 'codexmate://status',
+                    mimeType: 'application/json',
+                    text: JSON.stringify(buildMcpStatusPayload(), null, 2)
+                }]
+            })
+        },
+        {
+            uri: 'codexmate://providers',
+            name: 'Providers',
+            description: 'Configured provider list (masked).',
+            mimeType: 'application/json',
+            read: async () => ({
+                contents: [{
+                    uri: 'codexmate://providers',
+                    mimeType: 'application/json',
+                    text: JSON.stringify(buildMcpProviderListPayload(), null, 2)
+                }]
+            })
+        },
+        {
+            uri: 'codexmate://sessions',
+            name: 'Sessions',
+            description: 'Session listing resource. Query by source/query/pathFilter via URI params.',
+            mimeType: 'application/json',
+            read: async (params = {}) => {
+                const uri = typeof params.uri === 'string' ? params.uri : 'codexmate://sessions';
+                let source = '';
+                let query = '';
+                let pathFilter = '';
+                let roleFilter = '';
+                let timeRangePreset = '';
+                try {
+                    const parsed = new URL(uri);
+                    source = parsed.searchParams.get('source') || '';
+                    query = parsed.searchParams.get('query') || '';
+                    pathFilter = parsed.searchParams.get('pathFilter') || '';
+                    roleFilter = parsed.searchParams.get('roleFilter') || '';
+                    timeRangePreset = parsed.searchParams.get('timeRangePreset') || '';
+                } catch (_) {}
+                const normalizedSource = normalizeMcpSource(source);
+                if (normalizedSource === null) {
+                    return {
+                        contents: [{
+                            uri,
+                            mimeType: 'application/json',
+                            text: JSON.stringify({ error: 'Invalid source. Must be codex, claude, or all' }, null, 2)
+                        }]
+                    };
+                }
+                const payload = {
+                    source: normalizedSource || 'all',
+                    sessions: listAllSessions({
+                        source: normalizedSource || 'all',
+                        query,
+                        pathFilter,
+                        roleFilter,
+                        timeRangePreset
+                    })
+                };
+                return {
+                    contents: [{
+                        uri,
+                        mimeType: 'application/json',
+                        text: JSON.stringify(payload, null, 2)
+                    }]
+                };
+            }
+        }
+    ];
+}
+
+function createMcpPrompts() {
+    return [
+        {
+            name: 'codexmate.diagnose_config',
+            description: 'Generate troubleshooting guidance from current codexmate status/providers.',
+            arguments: [],
+            get: async () => {
+                const status = buildMcpStatusPayload();
+                const providers = buildMcpProviderListPayload();
+                return {
+                    messages: [{
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: [
+                                '请根据以下配置快照进行故障诊断，并给出按优先级排序的修复步骤。',
+                                '要求：先给结论，再给操作清单，最后给风险与回滚建议。',
+                                '',
+                                '[status]',
+                                JSON.stringify(status, null, 2),
+                                '',
+                                '[providers]',
+                                JSON.stringify(providers, null, 2)
+                            ].join('\n')
+                        }
+                    }]
+                };
+            }
+        },
+        {
+            name: 'codexmate.switch_provider_safely',
+            description: 'Guide safe provider switch with pre-check and rollback plan.',
+            arguments: [{
+                name: 'provider',
+                description: 'Target provider name',
+                required: true
+            }],
+            get: async (args = {}) => {
+                const provider = typeof args.provider === 'string' ? args.provider.trim() : '';
+                return {
+                    messages: [{
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: [
+                                `请为 provider "${provider || '(missing)'}" 生成安全切换步骤。`,
+                                '要求：',
+                                '1) 先检查 provider 是否存在与 key 是否可用',
+                                '2) 给出切换后验证项（模型拉取/健康检查）',
+                                '3) 给出失败时回滚流程（回到旧 provider/model）'
+                            ].join('\n')
+                        }
+                    }]
+                };
+            }
+        },
+        {
+            name: 'codexmate.export_session_for_issue',
+            description: 'Prepare issue report template from a selected session export.',
+            arguments: [{
+                name: 'source',
+                description: 'Session source: codex or claude',
+                required: true
+            }, {
+                name: 'sessionId',
+                description: 'Session id',
+                required: true
+            }],
+            get: async (args = {}) => {
+                const source = typeof args.source === 'string' ? args.source.trim() : '';
+                const sessionId = typeof args.sessionId === 'string' ? args.sessionId.trim() : '';
+                return {
+                    messages: [{
+                        role: 'user',
+                        content: {
+                            type: 'text',
+                            text: [
+                                '请根据会话导出内容生成 issue 报告草稿。',
+                                `source: ${source || '(missing)'}`,
+                                `sessionId: ${sessionId || '(missing)'}`,
+                                '',
+                                '报告需包含：问题现象、复现步骤、预期行为、实际行为、可疑配置项。'
+                            ].join('\n')
+                        }
+                    }]
+                };
+            }
+        }
+    ];
+}
+
+async function cmdMcp(args = []) {
+    const options = parseMcpOptions(args);
+    if (options.help) {
+        console.log('\n用法: codexmate mcp [serve] [--transport stdio] [--allow-write|--read-only]');
+        console.log('  默认 transport=stdio，默认 read-only。');
+        console.log('  设置环境变量 CODEXMATE_MCP_ALLOW_WRITE=1 可默认开启写工具。');
+        console.log();
+        return;
+    }
+
+    if (options.subcommand !== 'serve') {
+        throw new Error(`未知 mcp 子命令: ${options.subcommand}`);
+    }
+    if (options.transport !== 'stdio') {
+        throw new Error(`当前仅支持 stdio 传输，收到: ${options.transport}`);
+    }
+
+    const packageVersion = (() => {
+        try {
+            const pkg = require('./package.json');
+            return pkg && pkg.version ? pkg.version : '0.0.0';
+        } catch (_) {
+            return '0.0.0';
+        }
+    })();
+
+    const server = createMcpStdioServer({
+        protocolVersion: '2025-11-25',
+        serverInfo: {
+            name: 'codexmate-mcp',
+            version: packageVersion
+        },
+        tools: createMcpTools({ allowWrite: options.allowWrite }),
+        resources: createMcpResources(),
+        prompts: createMcpPrompts(),
+        logger: (level, message) => {
+            const label = level === 'error' ? 'ERR' : 'INFO';
+            console.error(`[MCP ${label}] ${message}`);
+        }
+    });
+
+    server.start();
+
+    await new Promise((resolve) => {
+        let done = false;
+        const finish = () => {
+            if (done) return;
+            done = true;
+            server.stop();
+            stopBuiltinProxyRuntime().finally(() => resolve());
+        };
+        process.once('SIGINT', finish);
+        process.once('SIGTERM', finish);
+        process.stdin.once('end', finish);
+        process.stdin.once('close', finish);
+    });
+}
+
 // ============================================================================
 // 主程序
 // ============================================================================
 async function main() {
+    const args = process.argv.slice(2);
+    const command = args[0];
+    const isMcpCommand = command === 'mcp';
     const bootstrap = ensureManagedConfigBootstrap();
     if (bootstrap && bootstrap.notice) {
-        console.log(`\n[Init] ${bootstrap.notice}`);
+        // MCP stdio transport requires stdout to be protocol-clean.
+        if (!isMcpCommand) {
+            console.log(`\n[Init] ${bootstrap.notice}`);
+        }
     }
 
-    const args = process.argv.slice(2);
     if (args.length === 0) {
         console.log('\nCodex Mate - Codex 提供商管理工具');
         console.log('\n用法:');
@@ -7056,14 +7824,13 @@ async function main() {
         console.log('  codexmate codex [参数...]  等同于 codex --yolo');
         console.log('  codexmate qwen [参数...]   等同于 qwen --yolo');
         console.log('  codexmate gemini [参数...] 等同于 gemini --yolo');
+        console.log('  codexmate mcp [serve] [--transport stdio] [--allow-write|--read-only]');
         console.log('  codexmate export-session --source <codex|claude> (--session-id <ID>|--file <PATH>) [--output <PATH>] [--max-messages <N|all|Infinity>]');
         console.log('  codexmate zip <路径> [--max:级别]  压缩（系统 zip 优先，其次 zip-lib）');
         console.log('  codexmate unzip <zip文件> [输出目录]  解压（zip-lib）');
         console.log('');
         process.exit(0);
     }
-
-    const command = args[0];
 
     switch (command) {
         case 'status': cmdStatus(); break;
@@ -7099,6 +7866,7 @@ async function main() {
             process.exit(exitCode);
             break;
         }
+        case 'mcp': await cmdMcp(args.slice(1)); break;
         case 'export-session': await cmdExportSession(args.slice(1)); break;
         case 'zip': {
             // 解析 --max:N 参数
@@ -7127,4 +7895,3 @@ main().catch((err) => {
     console.error('错误:', err && err.message ? err.message : err);
     process.exit(1);
 });
-

--- a/lib/mcp-stdio.js
+++ b/lib/mcp-stdio.js
@@ -1,0 +1,440 @@
+const DEFAULT_PROTOCOL_VERSION = '2025-11-25';
+
+function jsonRpcError(code, message, data) {
+    const error = {
+        code,
+        message: String(message || 'Unknown error')
+    };
+    if (data !== undefined) {
+        error.data = data;
+    }
+    return error;
+}
+
+function createToolMap(tools = []) {
+    const map = new Map();
+    for (const tool of Array.isArray(tools) ? tools : []) {
+        if (!tool || typeof tool !== 'object') continue;
+        const name = typeof tool.name === 'string' ? tool.name.trim() : '';
+        if (!name) continue;
+        map.set(name, {
+            name,
+            description: typeof tool.description === 'string' ? tool.description : '',
+            inputSchema: tool.inputSchema && typeof tool.inputSchema === 'object'
+                ? tool.inputSchema
+                : { type: 'object', properties: {}, additionalProperties: false },
+            annotations: tool.annotations && typeof tool.annotations === 'object' ? tool.annotations : undefined,
+            handler: typeof tool.handler === 'function' ? tool.handler : async () => ({})
+        });
+    }
+    return map;
+}
+
+function createResourceMap(resources = []) {
+    const map = new Map();
+    for (const resource of Array.isArray(resources) ? resources : []) {
+        if (!resource || typeof resource !== 'object') continue;
+        const uri = typeof resource.uri === 'string' ? resource.uri.trim() : '';
+        if (!uri) continue;
+        map.set(uri, {
+            uri,
+            name: typeof resource.name === 'string' ? resource.name : uri,
+            description: typeof resource.description === 'string' ? resource.description : '',
+            mimeType: typeof resource.mimeType === 'string' ? resource.mimeType : 'application/json',
+            read: typeof resource.read === 'function'
+                ? resource.read
+                : async () => ({ contents: [] })
+        });
+    }
+    return map;
+}
+
+function createPromptMap(prompts = []) {
+    const map = new Map();
+    for (const prompt of Array.isArray(prompts) ? prompts : []) {
+        if (!prompt || typeof prompt !== 'object') continue;
+        const name = typeof prompt.name === 'string' ? prompt.name.trim() : '';
+        if (!name) continue;
+        map.set(name, {
+            name,
+            description: typeof prompt.description === 'string' ? prompt.description : '',
+            arguments: Array.isArray(prompt.arguments) ? prompt.arguments : [],
+            get: typeof prompt.get === 'function'
+                ? prompt.get
+                : async () => ({ messages: [] })
+        });
+    }
+    return map;
+}
+
+function createMcpRequestRouter(options = {}) {
+    const protocolVersion = typeof options.protocolVersion === 'string' && options.protocolVersion.trim()
+        ? options.protocolVersion.trim()
+        : DEFAULT_PROTOCOL_VERSION;
+    const serverInfo = options.serverInfo && typeof options.serverInfo === 'object'
+        ? options.serverInfo
+        : { name: 'mcp-server', version: '0.0.0' };
+    const logger = typeof options.logger === 'function' ? options.logger : () => {};
+
+    const tools = createToolMap(options.tools);
+    const resources = createResourceMap(options.resources);
+    const prompts = createPromptMap(options.prompts);
+
+    const listTools = () => Array.from(tools.values()).map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+        ...(tool.annotations ? { annotations: tool.annotations } : {})
+    }));
+
+    const listResources = () => Array.from(resources.values()).map((resource) => ({
+        uri: resource.uri,
+        name: resource.name,
+        description: resource.description,
+        mimeType: resource.mimeType
+    }));
+
+    const listPrompts = () => Array.from(prompts.values()).map((prompt) => ({
+        name: prompt.name,
+        description: prompt.description,
+        arguments: prompt.arguments
+    }));
+
+    const capabilities = {};
+    if (tools.size > 0) {
+        capabilities.tools = { listChanged: false };
+    }
+    if (resources.size > 0) {
+        capabilities.resources = { listChanged: false, subscribe: false };
+    }
+    if (prompts.size > 0) {
+        capabilities.prompts = { listChanged: false };
+    }
+
+    const withToolError = (error) => ({
+        content: [{ type: 'text', text: `Error: ${error.message || error}` }],
+        isError: true
+    });
+
+    const normalizeResourceResult = (uri, resource, result) => {
+        if (result && Array.isArray(result.contents)) {
+            return { contents: result.contents };
+        }
+        if (result && typeof result === 'object' && typeof result.text === 'string') {
+            return {
+                contents: [{
+                    uri,
+                    mimeType: result.mimeType || resource.mimeType,
+                    text: result.text
+                }]
+            };
+        }
+        const text = typeof result === 'string'
+            ? result
+            : JSON.stringify(result === undefined ? {} : result, null, 2);
+        return {
+            contents: [{
+                uri,
+                mimeType: resource.mimeType,
+                text
+            }]
+        };
+    };
+
+    const resolveResourceByUri = (uri) => {
+        const exact = resources.get(uri);
+        if (exact) {
+            return exact;
+        }
+        try {
+            const parsed = new URL(uri);
+            parsed.search = '';
+            parsed.hash = '';
+            const baseUri = parsed.toString();
+            if (baseUri && resources.has(baseUri)) {
+                return resources.get(baseUri);
+            }
+        } catch (_) {}
+        return null;
+    };
+
+    const handleRequest = async (request) => {
+        if (!request || typeof request !== 'object') {
+            throw jsonRpcError(-32600, 'Invalid Request');
+        }
+        const method = typeof request.method === 'string' ? request.method : '';
+        const params = request.params && typeof request.params === 'object' ? request.params : {};
+
+        if (method === 'initialize') {
+            return {
+                protocolVersion,
+                capabilities,
+                serverInfo: {
+                    name: serverInfo.name || 'codexmate-mcp',
+                    version: serverInfo.version || '0.0.0'
+                }
+            };
+        }
+
+        if (method === 'ping') {
+            return {};
+        }
+
+        if (method === 'tools/list') {
+            return { tools: listTools() };
+        }
+
+        if (method === 'tools/call') {
+            const name = typeof params.name === 'string' ? params.name.trim() : '';
+            if (!name) {
+                throw jsonRpcError(-32602, 'Missing tool name');
+            }
+            const tool = tools.get(name);
+            if (!tool) {
+                throw jsonRpcError(-32602, `Unknown tool: ${name}`);
+            }
+            try {
+                const args = params.arguments && typeof params.arguments === 'object'
+                    ? params.arguments
+                    : {};
+                const result = await tool.handler(args, request);
+                if (result && Array.isArray(result.content)) {
+                    return result;
+                }
+                return {
+                    content: [{
+                        type: 'text',
+                        text: JSON.stringify(result === undefined ? {} : result, null, 2)
+                    }],
+                    structuredContent: result === undefined ? {} : result
+                };
+            } catch (error) {
+                logger('error', `tools/call failed (${name}): ${error && error.message ? error.message : error}`);
+                return withToolError(error || new Error('Tool execution failed'));
+            }
+        }
+
+        if (method === 'resources/list') {
+            return { resources: listResources() };
+        }
+
+        if (method === 'resources/read') {
+            const uri = typeof params.uri === 'string' ? params.uri.trim() : '';
+            if (!uri) {
+                throw jsonRpcError(-32602, 'Missing resource uri');
+            }
+            const resource = resolveResourceByUri(uri);
+            if (!resource) {
+                throw jsonRpcError(-32602, `Unknown resource: ${uri}`);
+            }
+            try {
+                const result = await resource.read(params, request);
+                return normalizeResourceResult(uri, resource, result);
+            } catch (error) {
+                throw jsonRpcError(-32000, `Resource read failed: ${error && error.message ? error.message : error}`);
+            }
+        }
+
+        if (method === 'prompts/list') {
+            return { prompts: listPrompts() };
+        }
+
+        if (method === 'prompts/get') {
+            const name = typeof params.name === 'string' ? params.name.trim() : '';
+            if (!name) {
+                throw jsonRpcError(-32602, 'Missing prompt name');
+            }
+            const prompt = prompts.get(name);
+            if (!prompt) {
+                throw jsonRpcError(-32602, `Unknown prompt: ${name}`);
+            }
+            try {
+                const args = params.arguments && typeof params.arguments === 'object'
+                    ? params.arguments
+                    : {};
+                const result = await prompt.get(args, request);
+                return {
+                    description: prompt.description,
+                    messages: Array.isArray(result && result.messages) ? result.messages : []
+                };
+            } catch (error) {
+                throw jsonRpcError(-32000, `Prompt get failed: ${error && error.message ? error.message : error}`);
+            }
+        }
+
+        if (method === 'notifications/initialized') {
+            return null;
+        }
+
+        throw jsonRpcError(-32601, `Method not found: ${method}`);
+    };
+
+    return {
+        handleRequest
+    };
+}
+
+function createMcpStdioServer(options = {}) {
+    const logger = typeof options.logger === 'function' ? options.logger : () => {};
+    const stdin = options.stdin || process.stdin;
+    const stdout = options.stdout || process.stdout;
+    const router = createMcpRequestRouter(options);
+    const jsonRpcVersion = '2.0';
+
+    let buffer = Buffer.alloc(0);
+    let started = false;
+    let stopped = false;
+
+    const writeMessage = (payload) => {
+        const text = JSON.stringify(payload);
+        const body = Buffer.from(text, 'utf-8');
+        const header = Buffer.from(`Content-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n`, 'utf-8');
+        stdout.write(Buffer.concat([header, body]));
+    };
+
+    const writeResponse = (id, result) => {
+        writeMessage({
+            jsonrpc: jsonRpcVersion,
+            id,
+            result
+        });
+    };
+
+    const writeError = (id, error) => {
+        const normalized = error && typeof error === 'object' && Number.isFinite(error.code)
+            ? error
+            : jsonRpcError(-32000, error && error.message ? error.message : String(error || 'Unknown error'));
+        writeMessage({
+            jsonrpc: jsonRpcVersion,
+            id,
+            error: normalized
+        });
+    };
+
+    const processMessage = async (rawText) => {
+        let message = null;
+        try {
+            message = JSON.parse(rawText);
+        } catch (error) {
+            writeError(null, jsonRpcError(-32700, 'Parse error'));
+            return;
+        }
+
+        if (!message || typeof message !== 'object') {
+            writeError(null, jsonRpcError(-32600, 'Invalid Request'));
+            return;
+        }
+
+        if (Array.isArray(message)) {
+            writeError(null, jsonRpcError(-32600, 'Batch request is not supported'));
+            return;
+        }
+
+        const hasMethod = typeof message.method === 'string' && message.method.trim().length > 0;
+        const hasId = Object.prototype.hasOwnProperty.call(message, 'id');
+
+        if (!hasMethod) {
+            if (hasId) {
+                writeError(message.id, jsonRpcError(-32600, 'Invalid Request'));
+            } else {
+                writeError(null, jsonRpcError(-32600, 'Invalid Request'));
+            }
+            return;
+        }
+
+        try {
+            const result = await router.handleRequest(message);
+            if (hasId) {
+                writeResponse(message.id, result === null ? {} : result);
+            }
+        } catch (error) {
+            if (hasId) {
+                writeError(message.id, error);
+            } else {
+                logger('error', `MCP notification handling failed: ${error && error.message ? error.message : error}`);
+            }
+        }
+    };
+
+    const parseBuffer = async () => {
+        while (buffer.length > 0) {
+            const headerEnd = buffer.indexOf('\r\n\r\n');
+            if (headerEnd < 0) {
+                return;
+            }
+
+            const headerText = buffer.slice(0, headerEnd).toString('utf-8');
+            const headers = {};
+            for (const line of headerText.split('\r\n')) {
+                const idx = line.indexOf(':');
+                if (idx <= 0) continue;
+                const key = line.slice(0, idx).trim().toLowerCase();
+                const value = line.slice(idx + 1).trim();
+                headers[key] = value;
+            }
+
+            const length = Number.parseInt(headers['content-length'] || '', 10);
+            if (!Number.isFinite(length) || length < 0) {
+                buffer = Buffer.alloc(0);
+                writeError(null, jsonRpcError(-32600, 'Invalid Content-Length header'));
+                return;
+            }
+
+            const bodyOffset = headerEnd + 4;
+            const frameLength = bodyOffset + length;
+            if (buffer.length < frameLength) {
+                return;
+            }
+
+            const body = buffer.slice(bodyOffset, frameLength);
+            buffer = buffer.slice(frameLength);
+            await processMessage(body.toString('utf-8'));
+        }
+    };
+
+    const onData = async (chunk) => {
+        if (stopped) return;
+        buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
+        try {
+            await parseBuffer();
+        } catch (error) {
+            logger('error', `MCP stdio parse failed: ${error && error.message ? error.message : error}`);
+            writeError(null, jsonRpcError(-32000, 'Internal parse failure'));
+        }
+    };
+
+    const onError = (error) => {
+        logger('error', `MCP stdio stream error: ${error && error.message ? error.message : error}`);
+    };
+
+    const start = () => {
+        if (started || stopped) return;
+        started = true;
+        stdin.on('data', onData);
+        stdin.on('error', onError);
+        stdout.on('error', onError);
+        if (stdin.isTTY) {
+            stdin.resume();
+        }
+    };
+
+    const stop = () => {
+        if (stopped) return;
+        stopped = true;
+        stdin.removeListener('data', onData);
+        stdin.removeListener('error', onError);
+        stdout.removeListener('error', onError);
+    };
+
+    return {
+        start,
+        stop
+    };
+}
+
+module.exports = {
+    DEFAULT_PROTOCOL_VERSION,
+    jsonRpcError,
+    createMcpRequestRouter,
+    createMcpStdioServer
+};

--- a/tests/e2e/run.js
+++ b/tests/e2e/run.js
@@ -21,6 +21,7 @@ const testOpenclaw = require('./test-openclaw');
 const testHealthSpeed = require('./test-health-speed');
 const testMessages = require('./test-messages');
 const testAuthProxy = require('./test-auth-proxy');
+const testMcp = require('./test-mcp');
 
 async function main() {
     const realHome = os.homedir();
@@ -108,6 +109,7 @@ async function main() {
         await testHealthSpeed(ctx);
         await testMessages(ctx);
         await testAuthProxy(ctx);
+        await testMcp(ctx);
 
     } finally {
         const waitForExit = new Promise((resolve) => {

--- a/tests/e2e/test-mcp.js
+++ b/tests/e2e/test-mcp.js
@@ -1,0 +1,158 @@
+const { spawnSync } = require('child_process');
+const { assert } = require('./helpers');
+
+function encodeFrame(payload) {
+    const body = Buffer.from(JSON.stringify(payload), 'utf-8');
+    const header = Buffer.from(`Content-Length: ${body.length}\r\n\r\n`, 'utf-8');
+    return Buffer.concat([header, body]);
+}
+
+function decodeFrames(stdoutBuffer) {
+    const messages = [];
+    let offset = 0;
+
+    while (offset < stdoutBuffer.length) {
+        const headerEnd = stdoutBuffer.indexOf('\r\n\r\n', offset, 'utf-8');
+        assert(headerEnd >= 0, 'mcp stdout contains an incomplete frame header');
+
+        const headerText = stdoutBuffer.slice(offset, headerEnd).toString('utf-8');
+        let contentLength = -1;
+        for (const line of headerText.split('\r\n')) {
+            const idx = line.indexOf(':');
+            if (idx <= 0) continue;
+            const key = line.slice(0, idx).trim().toLowerCase();
+            if (key !== 'content-length') continue;
+            contentLength = Number.parseInt(line.slice(idx + 1).trim(), 10);
+            break;
+        }
+        assert(Number.isFinite(contentLength) && contentLength >= 0, 'invalid content-length in mcp response');
+
+        const bodyStart = headerEnd + 4;
+        const bodyEnd = bodyStart + contentLength;
+        assert(bodyEnd <= stdoutBuffer.length, 'mcp stdout contains an incomplete frame body');
+
+        const bodyText = stdoutBuffer.slice(bodyStart, bodyEnd).toString('utf-8');
+        let payload = null;
+        try {
+            payload = JSON.parse(bodyText);
+        } catch (error) {
+            throw new Error(`invalid mcp json payload: ${error.message || error}`);
+        }
+        messages.push(payload);
+        offset = bodyEnd;
+    }
+
+    return messages;
+}
+
+function runMcpExchange(node, cliPath, env, args, requests) {
+    const input = Buffer.concat((requests || []).map(encodeFrame));
+    const result = spawnSync(node, [cliPath, 'mcp', 'serve', ...(args || [])], {
+        env,
+        input,
+        encoding: 'buffer',
+        maxBuffer: 5 * 1024 * 1024
+    });
+
+    if (result.error) {
+        throw result.error;
+    }
+
+    const stderrText = Buffer.isBuffer(result.stderr)
+        ? result.stderr.toString('utf-8')
+        : String(result.stderr || '');
+    assert(result.status === 0, `mcp command failed (${result.status}): ${stderrText}`);
+
+    const stdoutBuffer = Buffer.isBuffer(result.stdout)
+        ? result.stdout
+        : Buffer.from(result.stdout || '', 'utf-8');
+    assert(stdoutBuffer.length > 0, 'mcp command produced empty stdout');
+
+    return decodeFrames(stdoutBuffer);
+}
+
+module.exports = async function testMcp(ctx) {
+    const { env, node, cliPath } = ctx;
+
+    const readOnlyRequests = [
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+        { jsonrpc: '2.0', id: 3, method: 'resources/read', params: { uri: 'codexmate://sessions?source=all' } },
+        {
+            jsonrpc: '2.0',
+            id: 4,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.session.list',
+                arguments: { source: 'CODEX', forceRefresh: true, limit: 20 }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 5,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.claude.settings.get',
+                arguments: {}
+            }
+        }
+    ];
+    const readOnlyResponses = runMcpExchange(node, cliPath, env, ['--read-only'], readOnlyRequests);
+    const readOnlyById = new Map(readOnlyResponses.map((item) => [item.id, item]));
+
+    assert(readOnlyById.has(1), 'mcp initialize response missing');
+    assert(readOnlyById.has(2), 'mcp tools/list response missing');
+    assert(readOnlyById.has(3), 'mcp resources/read response missing');
+    assert(readOnlyById.has(4), 'mcp session.list response missing');
+    assert(readOnlyById.has(5), 'mcp claude.settings.get response missing');
+
+    const initResult = readOnlyById.get(1).result || {};
+    assert(initResult.protocolVersion === '2025-11-25', 'mcp protocol version mismatch');
+
+    const tools = Array.isArray((readOnlyById.get(2).result || {}).tools)
+        ? readOnlyById.get(2).result.tools
+        : [];
+    const toolNames = new Set(tools.map((item) => item && item.name).filter(Boolean));
+    assert(toolNames.has('codexmate.status.get'), 'mcp read-only tools missing codexmate.status.get');
+    assert(!toolNames.has('codexmate.provider.add'), 'mcp read-only tools should not expose write tool');
+
+    const sessionResource = readOnlyById.get(3).result || {};
+    assert(Array.isArray(sessionResource.contents), 'mcp resources/read should return contents');
+
+    const sessionListPayload = ((readOnlyById.get(4).result || {}).structuredContent) || {};
+    assert(sessionListPayload.source === 'codex', 'mcp session.list should normalize source to codex');
+    assert(Array.isArray(sessionListPayload.sessions), 'mcp session.list should return sessions');
+    assert(sessionListPayload.sessions.length > 0, 'mcp session.list should return codex sessions');
+    assert(
+        sessionListPayload.sessions.every((item) => item && item.source === 'codex'),
+        'mcp session.list should not include claude sessions when source=CODEX'
+    );
+
+    const claudeSettingsPayload = ((readOnlyById.get(5).result || {}).structuredContent) || {};
+    assert(claudeSettingsPayload.redacted === true, 'mcp claude.settings.get should mark payload as redacted');
+    assert(claudeSettingsPayload.apiKey !== 'sk-claude', 'mcp claude.settings.get should not return plain api key');
+    assert(
+        typeof claudeSettingsPayload.apiKey === 'string' && !claudeSettingsPayload.apiKey.includes('sk-claude'),
+        'mcp claude.settings.get apiKey should be masked'
+    );
+    assert(
+        typeof ((claudeSettingsPayload.env || {}).ANTHROPIC_API_KEY) === 'string'
+            && !String((claudeSettingsPayload.env || {}).ANTHROPIC_API_KEY).includes('sk-claude'),
+        'mcp claude.settings.get env.ANTHROPIC_API_KEY should be masked'
+    );
+
+    const writeEnabledRequests = [
+        { jsonrpc: '2.0', id: 11, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', id: 12, method: 'tools/list', params: {} }
+    ];
+    const writeEnabledResponses = runMcpExchange(node, cliPath, {
+        ...env,
+        CODEXMATE_MCP_ALLOW_WRITE: '1'
+    }, [], writeEnabledRequests);
+    const writeById = new Map(writeEnabledResponses.map((item) => [item.id, item]));
+    const writeTools = Array.isArray((writeById.get(12).result || {}).tools)
+        ? writeById.get(12).result.tools
+        : [];
+    const writeToolNames = new Set(writeTools.map((item) => item && item.name).filter(Boolean));
+    assert(writeToolNames.has('codexmate.provider.add'), 'mcp write mode should expose codexmate.provider.add');
+};

--- a/tests/unit/mcp-stdio.test.mjs
+++ b/tests/unit/mcp-stdio.test.mjs
@@ -1,0 +1,142 @@
+import assert from 'assert';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const { createMcpRequestRouter } = require(path.join(__dirname, '..', '..', 'lib', 'mcp-stdio.js'));
+
+test('mcp router initialize advertises capabilities', async () => {
+    const router = createMcpRequestRouter({
+        serverInfo: { name: 'codexmate-mcp', version: '0.0.12' },
+        tools: [{
+            name: 'status.get',
+            description: 'Get status',
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+            handler: async () => ({ ok: true })
+        }],
+        resources: [{
+            uri: 'codexmate://status',
+            name: 'Status',
+            read: async () => ({ ok: true })
+        }],
+        prompts: [{
+            name: 'diagnose',
+            description: 'Diagnose',
+            get: async () => ({ messages: [] })
+        }]
+    });
+
+    const result = await router.handleRequest({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {}
+    });
+
+    assert.strictEqual(result.serverInfo.name, 'codexmate-mcp');
+    assert.strictEqual(result.serverInfo.version, '0.0.12');
+    assert.ok(result.capabilities.tools);
+    assert.ok(result.capabilities.resources);
+    assert.ok(result.capabilities.prompts);
+});
+
+test('mcp router supports tools/list and tools/call', async () => {
+    const router = createMcpRequestRouter({
+        tools: [{
+            name: 'status.get',
+            description: 'Get status',
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+            annotations: { readOnlyHint: true },
+            handler: async () => ({ provider: 'local' })
+        }]
+    });
+
+    const listRes = await router.handleRequest({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {}
+    });
+    assert.strictEqual(Array.isArray(listRes.tools), true);
+    assert.strictEqual(listRes.tools.length, 1);
+    assert.strictEqual(listRes.tools[0].name, 'status.get');
+
+    const callRes = await router.handleRequest({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+            name: 'status.get',
+            arguments: {}
+        }
+    });
+    assert.strictEqual(Array.isArray(callRes.content), true);
+    assert.deepStrictEqual(callRes.structuredContent, { provider: 'local' });
+});
+
+test('mcp router supports resources and prompts', async () => {
+    const router = createMcpRequestRouter({
+        resources: [{
+            uri: 'codexmate://providers',
+            name: 'Providers',
+            mimeType: 'application/json',
+            read: async () => ({
+                contents: [{
+                    uri: 'codexmate://providers',
+                    mimeType: 'application/json',
+                    text: '{"items":[]}'
+                }]
+            })
+        }],
+        prompts: [{
+            name: 'switch_provider_safely',
+            description: 'Switch provider safely',
+            arguments: [{
+                name: 'provider',
+                required: true
+            }],
+            get: async (args) => ({
+                messages: [{
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: `Switch to ${args.provider || ''}`
+                    }
+                }]
+            })
+        }]
+    });
+
+    const resourcesRes = await router.handleRequest({
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'resources/read',
+        params: { uri: 'codexmate://providers' }
+    });
+    assert.strictEqual(Array.isArray(resourcesRes.contents), true);
+    assert.strictEqual(resourcesRes.contents[0].uri, 'codexmate://providers');
+
+    const resourcesWithQueryRes = await router.handleRequest({
+        jsonrpc: '2.0',
+        id: 41,
+        method: 'resources/read',
+        params: { uri: 'codexmate://providers?source=all' }
+    });
+    assert.strictEqual(Array.isArray(resourcesWithQueryRes.contents), true);
+    assert.strictEqual(resourcesWithQueryRes.contents[0].uri, 'codexmate://providers');
+
+    const promptRes = await router.handleRequest({
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'prompts/get',
+        params: {
+            name: 'switch_provider_safely',
+            arguments: { provider: 'local' }
+        }
+    });
+    assert.strictEqual(Array.isArray(promptRes.messages), true);
+    assert.strictEqual(promptRes.messages[0].role, 'user');
+});

--- a/tests/unit/run.mjs
+++ b/tests/unit/run.mjs
@@ -10,6 +10,7 @@ globalThis.test = (name, fn) => tests.push({ name, fn });
 await import(pathToFileURL(path.join(__dirname, 'web-ui-logic.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'reset-main.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'session-query.test.mjs')));
+await import(pathToFileURL(path.join(__dirname, 'mcp-stdio.test.mjs')));
 
 let failures = 0;
 for (const { name, fn } of tests) {


### PR DESCRIPTION
## Summary
- Add MCP stdio server support with JSON-RPC framing and request routing for tools/resources/prompts
- Wire `codexmate mcp` into CLI command dispatch and guard stdout bootstrap logs in MCP mode
- Expose MCP tools/resources/prompts for status/provider/model/session/auth/proxy workflows with read-only default and optional write enable flag
- Fix session source normalization in MCP tool calls to avoid cross-source leakage when source casing differs
- Redact sensitive fields in `codexmate.claude.settings.get` and add unit/e2e regression coverage

## Tests
- node --check cli.js
- node --check lib/mcp-stdio.js
- node --check tests/e2e/run.js
- node --check tests/e2e/test-mcp.js
- npm run test:unit
- npm run test:e2e
- npm test
