### PR TITLE
feat: OpenAI-compatible provider bridge + Codex UX improvements

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1835,6 +1835,71 @@ function applyConfigTemplate(params = {}) {
     return { success: true };
 }
 
+function buildConfigTemplateDiff(params = {}) {
+    const template = typeof params.template === 'string' ? params.template : '';
+    if (!template.trim()) {
+        return { error: '模板内容不能为空' };
+    }
+
+    // Validate template format (same constraints as apply) but do not write anything.
+    let parsed;
+    try {
+        parsed = toml.parse(template);
+    } catch (e) {
+        return { error: `模板 TOML 解析失败: ${e.message}` };
+    }
+
+    if (
+        Object.prototype.hasOwnProperty.call(parsed, 'model_context_window')
+        && normalizePositiveIntegerParam(parsed.model_context_window) === null
+    ) {
+        return { error: '模板中的 model_context_window 必须是正整数' };
+    }
+
+    if (
+        Object.prototype.hasOwnProperty.call(parsed, 'model_auto_compact_token_limit')
+        && normalizePositiveIntegerParam(parsed.model_auto_compact_token_limit) === null
+    ) {
+        return { error: '模板中的 model_auto_compact_token_limit 必须是正整数' };
+    }
+
+    if (!parsed.model_provider || typeof parsed.model_provider !== 'string') {
+        return { error: '模板缺少 model_provider' };
+    }
+
+    if (!parsed.model || typeof parsed.model !== 'string') {
+        return { error: '模板缺少 model' };
+    }
+
+    if (!parsed.model_providers || typeof parsed.model_providers !== 'object') {
+        return { error: '模板缺少 model_providers 配置块' };
+    }
+
+    const activeProvider = parsed.model_provider;
+    const activeProviderBlock = parsed.model_providers[activeProvider];
+    if (!activeProviderBlock || typeof activeProviderBlock !== 'object') {
+        return { error: `模板中找不到当前 provider: ${activeProvider}` };
+    }
+
+    let beforeText = '';
+    if (fs.existsSync(CONFIG_FILE)) {
+        try {
+            beforeText = fs.readFileSync(CONFIG_FILE, 'utf-8');
+        } catch (e) {
+            return { error: `读取 config.toml 失败: ${e.message}` };
+        }
+    }
+    const afterText = template.trim() + '\n';
+    const diff = buildLineDiff(beforeText, afterText);
+    const hasChanges = (diff.stats.added || 0) + (diff.stats.removed || 0) > 0;
+    return {
+        diff: {
+            ...diff,
+            hasChanges
+        }
+    };
+}
+
 function addProviderToConfig(params = {}) {
     const name = typeof params.name === 'string' ? params.name.trim() : '';
     const url = typeof params.url === 'string' ? params.url.trim() : '';
@@ -8448,6 +8513,9 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                             break;
                         case 'apply-config-template':
                             result = applyConfigTemplate(params || {});
+                            break;
+                        case 'preview-config-template-diff':
+                            result = buildConfigTemplateDiff(params || {});
                             break;
                         case 'add-provider':
                             result = addProviderToConfig(params || {});

--- a/cli.js
+++ b/cli.js
@@ -6776,6 +6776,12 @@ function cmdAdd(name, baseUrl, apiKey, silent = false, options = {}) {
     const bridgeType = options && typeof options.bridge === 'string' ? options.bridge.trim() : '';
     const useOpenaiBridge = bridgeType === 'openai';
 
+    if (bridgeType && bridgeType !== 'openai') {
+        const msg = `错误: 不支持的 --bridge 值: ${bridgeType}（仅支持: openai）`;
+        if (!silent) console.error(msg);
+        throw new Error(msg);
+    }
+
     if (!providerName || !providerBaseUrl) {
         if (!silent) {
             console.error('用法: codexmate add <名称> <URL> [密钥] [--bridge <openai>]');
@@ -13265,7 +13271,11 @@ async function main() {
         while (cursor < argv.length) {
             const token = String(argv[cursor] || '');
             if (token === '--bridge') {
-                bridge = String(argv[cursor + 1] || '');
+                const nextValue = String(argv[cursor + 1] || '');
+                if (!nextValue || nextValue.startsWith('--')) {
+                    throw new Error('错误: --bridge 需要一个值（例如: --bridge openai）');
+                }
+                bridge = nextValue;
                 cursor += 2;
                 continue;
             }

--- a/cli.js
+++ b/cli.js
@@ -84,6 +84,12 @@ const {
     createBuiltinClaudeProxyRuntimeController
 } = require('./cli/claude-proxy');
 const {
+    createOpenaiBridgeHttpHandler,
+    upsertOpenaiBridgeProvider,
+    readOpenaiBridgeSettings,
+    resolveOpenaiBridgeUpstream
+} = require('./cli/openai-bridge');
+const {
     createOpenclawConfigController
 } = require('./cli/openclaw-config');
 const {
@@ -160,6 +166,7 @@ const CURRENT_MODELS_FILE = path.join(CONFIG_DIR, 'provider-current-models.json'
 const INIT_MARK_FILE = path.join(CONFIG_DIR, 'codexmate-init.json');
 const BUILTIN_PROXY_SETTINGS_FILE = path.join(CONFIG_DIR, 'codexmate-proxy.json');
 const BUILTIN_CLAUDE_PROXY_SETTINGS_FILE = path.join(CONFIG_DIR, 'codexmate-claude-proxy.json');
+const OPENAI_BRIDGE_SETTINGS_FILE = path.join(CONFIG_DIR, 'codexmate-openai-bridge.json');
 const CODEX_SESSIONS_DIR = path.join(CONFIG_DIR, 'sessions');
 const SESSION_TRASH_DIR = path.join(CONFIG_DIR, 'codexmate-session-trash');
 const SESSION_TRASH_FILES_DIR = path.join(SESSION_TRASH_DIR, 'files');
@@ -260,6 +267,14 @@ const CLI_INSTALL_TARGETS = Object.freeze([
 
 const HTTP_KEEP_ALIVE_AGENT = new http.Agent({ keepAlive: true });
 const HTTPS_KEEP_ALIVE_AGENT = new https.Agent({ keepAlive: true });
+
+const openaiBridgeHandler = createOpenaiBridgeHttpHandler({
+    settingsFile: OPENAI_BRIDGE_SETTINGS_FILE,
+    expectedToken: 'codexmate',
+    maxBodySize: MAX_API_BODY_SIZE,
+    httpAgent: HTTP_KEEP_ALIVE_AGENT,
+    httpsAgent: HTTPS_KEEP_ALIVE_AGENT
+});
 
 function resolveWebPort() {
     const raw = process.env.CODEXMATE_PORT;
@@ -1824,6 +1839,7 @@ function addProviderToConfig(params = {}) {
     const name = typeof params.name === 'string' ? params.name.trim() : '';
     const url = typeof params.url === 'string' ? params.url.trim() : '';
     const key = typeof params.key === 'string' ? params.key.trim() : '';
+    const useTransform = !!params.useTransform;
     const allowManaged = !!params.allowManaged;
     const normalizedUrl = normalizeBaseUrl(url);
 
@@ -1876,15 +1892,36 @@ function addProviderToConfig(params = {}) {
 
     const lineEnding = content.includes('\r\n') ? '\r\n' : '\n';
     const safeName = escapeTomlBasicString(name);
-    const safeUrl = escapeTomlBasicString(normalizedUrl);
-    const safeKey = escapeTomlBasicString(key);
+    let baseUrlForConfig = normalizedUrl;
+    let authKeyForConfig = key;
+    const extraLines = [];
+    const requiresOpenaiAuth = useTransform;
+
+    if (useTransform) {
+        const saveRes = upsertOpenaiBridgeProvider(OPENAI_BRIDGE_SETTINGS_FILE, name, normalizedUrl, key);
+        if (saveRes && saveRes.error) {
+            return { error: String(saveRes.error) };
+        }
+        const port = resolveWebPort();
+        // 通过 URL 构造避免出现重复 /（例如 /bridge/openai//v1）
+        baseUrlForConfig = new URL(
+            `/bridge/openai/${encodeURIComponent(name)}/v1`,
+            `http://${DEFAULT_WEB_OPEN_HOST}:${port}`
+        ).toString().replace(/\/+$/g, '');
+        authKeyForConfig = 'codexmate';
+        extraLines.push(`codexmate_bridge = "openai"`);
+    }
+
+    const safeUrl = escapeTomlBasicString(baseUrlForConfig);
+    const safeKey = escapeTomlBasicString(authKeyForConfig);
     const block = [
         buildModelProviderTableHeader(name),
         `name = "${safeName}"`,
         `base_url = "${safeUrl}"`,
         `wire_api = "responses"`,
-        `requires_openai_auth = false`,
+        `requires_openai_auth = ${requiresOpenaiAuth ? 'true' : 'false'}`,
         `preferred_auth_method = "${safeKey}"`,
+        ...extraLines,
         `request_max_retries = 4`,
         `stream_max_retries = 10`,
         `stream_idle_timeout_ms = 300000`
@@ -1907,6 +1944,7 @@ function updateProviderInConfig(params = {}) {
     const key = params.key !== undefined && params.key !== null
         ? String(params.key).trim()
         : undefined;
+    const useTransform = !!params.useTransform;
     const allowManaged = !!params.allowManaged;
 
     if (!name) return { error: '名称不能为空' };
@@ -1921,7 +1959,7 @@ function updateProviderInConfig(params = {}) {
     }
 
     try {
-        cmdUpdate(name, url || undefined, key, true, { allowManaged });
+        cmdUpdate(name, url || undefined, key, true, { allowManaged, useTransform });
         return { success: true };
     } catch (e) {
         return { error: e.message || '更新失败' };
@@ -5924,10 +5962,26 @@ function buildProviderSharePayload(params = {}) {
         return { error: `提供商不存在: ${name}` };
     }
 
-    const baseUrl = typeof provider.base_url === 'string' ? provider.base_url.trim() : '';
-    const apiKey = typeof provider.preferred_auth_method === 'string'
+    const bridgeType = typeof provider.codexmate_bridge === 'string' && provider.codexmate_bridge.trim()
+        ? provider.codexmate_bridge.trim()
+        : '';
+    const isOpenaiBridgeProvider = bridgeType === 'openai'
+        || (typeof provider.base_url === 'string' && provider.base_url.includes('/bridge/openai/'));
+
+    let baseUrl = typeof provider.base_url === 'string' ? provider.base_url.trim() : '';
+    let apiKey = typeof provider.preferred_auth_method === 'string'
         ? provider.preferred_auth_method.trim()
         : '';
+
+    // 对 transform provider：分享出去的应该是“上游 URL/API Key”，而不是本机 bridge URL。
+    // 保持向下兼容：如果无法解析上游配置，则回退为当前 provider.base_url。
+    if (isOpenaiBridgeProvider) {
+        const upstream = resolveOpenaiBridgeUpstream(OPENAI_BRIDGE_SETTINGS_FILE, name);
+        if (!upstream.error) {
+            baseUrl = upstream.baseUrl || baseUrl;
+            apiKey = upstream.apiKey || apiKey;
+        }
+    }
     const currentModels = readCurrentModels();
     const savedModel = currentModels && typeof currentModels[name] === 'string'
         ? currentModels[name].trim()
@@ -5945,7 +5999,8 @@ function buildProviderSharePayload(params = {}) {
             name,
             baseUrl,
             apiKey,
-            model
+            model,
+            bridge: bridgeType || (isOpenaiBridgeProvider ? 'openai' : '')
         }
     };
 }
@@ -6715,15 +6770,18 @@ function cmdUseModel(modelName, silent = false) {
 }
 
 // 添加提供商
-function cmdAdd(name, baseUrl, apiKey, silent = false) {
+function cmdAdd(name, baseUrl, apiKey, silent = false, options = {}) {
     const providerName = typeof name === 'string' ? name.trim() : '';
     const providerBaseUrl = normalizeBaseUrl(baseUrl);
+    const bridgeType = options && typeof options.bridge === 'string' ? options.bridge.trim() : '';
+    const useOpenaiBridge = bridgeType === 'openai';
 
     if (!providerName || !providerBaseUrl) {
         if (!silent) {
-            console.error('用法: codexmate add <名称> <URL> [密钥]');
+            console.error('用法: codexmate add <名称> <URL> [密钥] [--bridge <openai>]');
             console.log('\n示例:');
             console.log('  codexmate add 88code https://api.88code.ai/v1 sk-xxx');
+            console.log('  codexmate add 88code https://api.88code.ai/v1 sk-xxx --bridge openai');
         }
         throw new Error('名称和URL必填');
     }
@@ -6748,6 +6806,32 @@ function cmdAdd(name, baseUrl, apiKey, silent = false) {
     if (config.model_providers && config.model_providers[providerName]) {
         if (!silent) console.error('错误: 提供商已存在:', providerName);
         throw new Error('提供商已存在');
+    }
+
+    // 使用内建转换（可向下兼容：未来新增 bridgeType 仅需在这里扩展分支）
+    if (useOpenaiBridge) {
+        const res = addProviderToConfig({
+            name: providerName,
+            url: providerBaseUrl,
+            key: apiKey || '',
+            useTransform: true
+        });
+        if (res && res.error) {
+            throw new Error(res.error);
+        }
+        // 初始化当前模型（保持与普通 add 行为一致）
+        const currentModels = readCurrentModels();
+        if (!currentModels[providerName]) {
+            currentModels[providerName] = readModels()[0];
+            writeCurrentModels(currentModels);
+        }
+        if (!silent) {
+            console.log('✓ 已添加提供商:', providerName);
+            console.log('  上游 URL:', providerBaseUrl);
+            console.log('  模式: 内建转换 (openai)');
+            console.log();
+        }
+        return;
     }
 
     const safeName = escapeTomlBasicString(providerName);
@@ -6800,6 +6884,7 @@ function cmdDelete(name, silent = false) {
 // 更新提供商
 function cmdUpdate(name, baseUrl, apiKey, silent = false, options = {}) {
     const allowManaged = !!(options && options.allowManaged);
+    const forceUseTransform = !!(options && options.useTransform);
     const normalizedBaseUrl = baseUrl === undefined ? undefined : normalizeBaseUrl(baseUrl);
     if (!name) {
         if (!silent) console.error('错误: 提供商名称必填');
@@ -6819,6 +6904,14 @@ function cmdUpdate(name, baseUrl, apiKey, silent = false, options = {}) {
 
     const content = fs.readFileSync(CONFIG_FILE, 'utf-8');
     const providerConfig = config.model_providers[name];
+    const isTransformProvider = (() => {
+        if (forceUseTransform) return true;
+        if (!providerConfig || typeof providerConfig !== 'object') return false;
+        const bridge = typeof providerConfig.codexmate_bridge === 'string' ? providerConfig.codexmate_bridge.trim() : '';
+        if (bridge === 'openai') return true;
+        const url = typeof providerConfig.base_url === 'string' ? providerConfig.base_url : '';
+        return url.includes('/bridge/openai/');
+    })();
     const providerSegments = providerConfig && Array.isArray(providerConfig.__codexmate_legacy_segments)
         ? providerConfig.__codexmate_legacy_segments
         : null;
@@ -6951,17 +7044,87 @@ function cmdUpdate(name, baseUrl, apiKey, silent = false, options = {}) {
         return next;
     };
 
+    const replaceTomlBooleanField = (block, fieldName, rawValue) => {
+        const boolValue = rawValue ? 'true' : 'false';
+        const escapedFieldName = escapeRegex(fieldName);
+        const multilineRanges = collectTomlMultilineStringRanges(block);
+        const withCommentRegex = new RegExp(`^(\\s*${escapedFieldName}\\s*=\\s*)(true|false)(\\s+#.*)?$`, 'mg');
+        let replaced = false;
+        let next = block.replace(withCommentRegex, (full, prefix, _value, suffix = '', offset) => {
+            if (replaced || isIndexInRanges(offset, multilineRanges)) {
+                return full;
+            }
+            replaced = true;
+            return `${prefix}${boolValue}${suffix}`;
+        });
+        if (!replaced) {
+            const keyIndentMatch = block.match(/^(\s*)[A-Za-z0-9_.-]+\s*=/m);
+            const indent = keyIndentMatch ? keyIndentMatch[1] : '';
+            const lineEnding = block.includes('\r\n') ? '\r\n' : '\n';
+            const tailMatch = block.match(/(\s*)$/);
+            const tail = tailMatch ? tailMatch[1] : '';
+            const body = block.slice(0, block.length - tail.length);
+            const separator = body.endsWith('\n') || body.endsWith('\r') ? '' : lineEnding;
+            next = `${body}${separator}${indent}${fieldName} = ${boolValue}${tail}`;
+        }
+        return next;
+    };
+
+    const computeLocalOpenaiBridgeBaseUrl = () => {
+        const port = resolveWebPort();
+        return new URL(
+            `/bridge/openai/${encodeURIComponent(name)}/v1`,
+            `http://${DEFAULT_WEB_OPEN_HOST}:${port}`
+        ).toString().replace(/\/+$/g, '');
+    };
+
     let newContent = content;
     const sorted = ranges.sort((a, b) => b.start - a.start);
     for (const range of sorted) {
         const providerBlock = newContent.slice(range.start, range.end);
         let updatedBlock = providerBlock;
-        if (normalizedBaseUrl) {
-            updatedBlock = replaceTomlStringField(updatedBlock, 'base_url', normalizedBaseUrl);
+
+        if (isTransformProvider) {
+            // 对 transform provider：UI 的 URL/key 表单代表“上游 OpenAI 兼容服务”，而不是写入 config.toml 的 base_url。
+            // config.toml 仍需保持本地 bridge base_url + 固定 token。
+            const settings = readOpenaiBridgeSettings(OPENAI_BRIDGE_SETTINGS_FILE);
+            const existing = settings && settings.providers ? settings.providers[name] : null;
+            const existingBaseUrl = existing && typeof existing.baseUrl === 'string' ? existing.baseUrl : '';
+            const existingApiKey = existing && typeof existing.apiKey === 'string' ? existing.apiKey : '';
+
+            const upstreamBaseUrl = normalizedBaseUrl !== undefined
+                ? normalizedBaseUrl
+                : normalizeBaseUrl(existingBaseUrl || '');
+            const upstreamApiKey = apiKey !== undefined && apiKey !== ''
+                ? apiKey
+                : existingApiKey;
+
+            if (upstreamBaseUrl) {
+                const saveRes = upsertOpenaiBridgeProvider(OPENAI_BRIDGE_SETTINGS_FILE, name, upstreamBaseUrl, upstreamApiKey);
+                if (saveRes && saveRes.error) {
+                    throw new Error(String(saveRes.error));
+                }
+            } else {
+                // 不提供 URL 且没有已有上游配置时无法更新
+                const resolved = resolveOpenaiBridgeUpstream(OPENAI_BRIDGE_SETTINGS_FILE, name);
+                if (resolved && resolved.error) {
+                    throw new Error(String(resolved.error));
+                }
+            }
+
+            updatedBlock = replaceTomlStringField(updatedBlock, 'base_url', computeLocalOpenaiBridgeBaseUrl());
+            updatedBlock = replaceTomlBooleanField(updatedBlock, 'requires_openai_auth', true);
+            updatedBlock = replaceTomlStringField(updatedBlock, 'preferred_auth_method', 'codexmate');
+            updatedBlock = replaceTomlStringField(updatedBlock, 'codexmate_bridge', 'openai');
+        } else {
+            if (normalizedBaseUrl) {
+                updatedBlock = replaceTomlStringField(updatedBlock, 'base_url', normalizedBaseUrl);
+            }
+            if (apiKey !== undefined) {
+                updatedBlock = replaceTomlStringField(updatedBlock, 'preferred_auth_method', apiKey);
+            }
         }
-        if (apiKey !== undefined) {
-            updatedBlock = replaceTomlStringField(updatedBlock, 'preferred_auth_method', apiKey);
-        }
+
         newContent = newContent.slice(0, range.start) + updatedBlock + newContent.slice(range.end);
     }
 
@@ -8163,6 +8326,9 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
 
     const server = http.createServer((req, res) => {
         const requestPath = (req.url || '/').split('?')[0];
+        if (typeof openaiBridgeHandler === 'function' && openaiBridgeHandler(req, res)) {
+            return;
+        }
         if (requestPath === '/api/import-skills-zip') {
             void handleImportSkillsZipUpload(req, res);
             return;
@@ -8398,6 +8564,21 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                         }
                         case 'provider-chat-check': {
                             result = await runProviderChatCheck(params || {});
+                            break;
+                        }
+                        case 'openai-bridge-get-provider': {
+                            const name = params && typeof params.name === 'string' ? params.name.trim() : '';
+                            if (!name) {
+                                result = { error: 'provider name is required' };
+                                break;
+                            }
+                            const upstream = resolveOpenaiBridgeUpstream(OPENAI_BRIDGE_SETTINGS_FILE, name);
+                            if (upstream.error) {
+                                result = { error: upstream.error };
+                                break;
+                            }
+                            // 不返回 apiKey（敏感信息），仅返回用户填过的上游 URL
+                            result = { baseUrl: upstream.baseUrl, hasApiKey: !!(upstream.apiKey) };
                             break;
                         }
                         case 'list-sessions':
@@ -13051,7 +13232,7 @@ async function main() {
         console.log('  codexmate models           列出所有模型');
         console.log('  codexmate switch <名称>    切换提供商');
         console.log('  codexmate use <模型>       切换模型');
-        console.log('  codexmate add <名称> <URL> [密钥]');
+        console.log('  codexmate add <名称> <URL> [密钥] [--bridge <openai>]');
         console.log('  codexmate delete <名称>    删除提供商');
         console.log('  codexmate claude <BaseURL> <API密钥> [模型]  写入 Claude Code 配置');
         console.log('  codexmate add-model <模型> 添加模型');
@@ -13071,6 +13252,34 @@ async function main() {
         process.exit(0);
     }
 
+    const parseAddCommandArgs = (argv = []) => {
+        const name = argv[0];
+        const url = argv[1];
+        let key = '';
+        let cursor = 2;
+        if (cursor < argv.length && argv[cursor] && !String(argv[cursor]).startsWith('--')) {
+            key = String(argv[cursor]);
+            cursor += 1;
+        }
+        let bridge = '';
+        while (cursor < argv.length) {
+            const token = String(argv[cursor] || '');
+            if (token === '--bridge') {
+                bridge = String(argv[cursor + 1] || '');
+                cursor += 2;
+                continue;
+            }
+            if (token === '--transform') {
+                // legacy alias; equals openai bridge for now
+                bridge = 'openai';
+                cursor += 1;
+                continue;
+            }
+            cursor += 1;
+        }
+        return { name, url, key, bridge };
+    };
+
     switch (command) {
         case '__task-worker': await cmdTaskWorker(args.slice(1)); break;
         case 'status': cmdStatus(); break;
@@ -13079,7 +13288,11 @@ async function main() {
         case 'models': await cmdModels(); break;
         case 'switch': cmdSwitch(args[1]); break;
         case 'use': cmdUseModel(args[1]); break;
-        case 'add': cmdAdd(args[1], args[2], args[3]); break;
+        case 'add': {
+            const parsed = parseAddCommandArgs(args.slice(1));
+            cmdAdd(parsed.name, parsed.url, parsed.key, false, { bridge: parsed.bridge });
+            break;
+        }
         case 'delete': cmdDelete(args[1]); break;
         case 'claude': cmdClaude(args[1], args[2], args[3]); break;
         case 'add-model': cmdAddModel(args[1]); break;

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -1,0 +1,585 @@
+const http = require('http');
+const https = require('https');
+const crypto = require('crypto');
+const { readJsonFile, writeJsonAtomic } = require('../lib/cli-file-utils');
+const { isValidHttpUrl, normalizeBaseUrl, joinApiUrl } = require('../lib/cli-utils');
+
+const DEFAULT_BRIDGE_TOKEN = 'codexmate';
+const SETTINGS_VERSION = 1;
+
+function normalizeText(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeProviderName(value) {
+    // Provider name validation is done elsewhere; keep this conservative.
+    return normalizeText(value);
+}
+
+function normalizeOpenaiUpstreamBaseUrl(rawValue) {
+    const normalized = normalizeBaseUrl(rawValue);
+    if (!normalized) return '';
+    try {
+        const parsed = new URL(normalized);
+        let pathname = String(parsed.pathname || '').replace(/\/+$/g, '');
+
+        // If user accidentally pasted a full endpoint, strip it back to the base URL.
+        // Keep direct provider routes (e.g. /project/ym) intact.
+        pathname = pathname
+            .replace(/\/v1\/chat\/completions$/i, '/v1')
+            .replace(/\/chat\/completions$/i, '')
+            .replace(/\/v1\/responses$/i, '/v1')
+            .replace(/\/responses$/i, '')
+            .replace(/\/v1\/models$/i, '/v1')
+            .replace(/\/models$/i, '');
+
+        // Normalize empty/root path.
+        if (pathname === '/') pathname = '';
+
+        const rebuilt = `${parsed.origin}${pathname}`;
+        return normalizeBaseUrl(rebuilt);
+    } catch (_) {
+        return normalized;
+    }
+}
+
+function normalizeUpstreamEntry(entry) {
+    if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        return null;
+    }
+    const baseUrl = normalizeOpenaiUpstreamBaseUrl(entry.baseUrl || entry.base_url || '');
+    const apiKey = normalizeText(entry.apiKey || entry.api_key || entry.key || '');
+    if (!baseUrl || !isValidHttpUrl(baseUrl)) {
+        return null;
+    }
+    return { baseUrl, apiKey };
+}
+
+function readOpenaiBridgeSettings(filePath) {
+    const parsed = readJsonFile(filePath, null);
+    const providers = parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed.providers
+        : null;
+    const providerMap = providers && typeof providers === 'object' && !Array.isArray(providers)
+        ? providers
+        : {};
+    return {
+        version: SETTINGS_VERSION,
+        providers: providerMap
+    };
+}
+
+function upsertOpenaiBridgeProvider(filePath, providerName, upstreamBaseUrl, apiKey) {
+    const name = normalizeProviderName(providerName);
+    const baseUrl = normalizeOpenaiUpstreamBaseUrl(upstreamBaseUrl);
+    const key = normalizeText(apiKey);
+
+    if (!name) {
+        return { error: 'Provider name is required' };
+    }
+    if (!baseUrl || !isValidHttpUrl(baseUrl)) {
+        return { error: 'Upstream base URL is invalid' };
+    }
+
+    const settings = readOpenaiBridgeSettings(filePath);
+    const next = {
+        version: SETTINGS_VERSION,
+        providers: {
+            ...(settings.providers || {}),
+            [name]: { baseUrl, apiKey: key }
+        }
+    };
+    writeJsonAtomic(filePath, next);
+    return { success: true };
+}
+
+function resolveOpenaiBridgeUpstream(filePath, providerName) {
+    const name = normalizeProviderName(providerName);
+    if (!name) return { error: 'Provider name is required' };
+    const settings = readOpenaiBridgeSettings(filePath);
+    const entry = settings.providers ? settings.providers[name] : null;
+    const normalized = normalizeUpstreamEntry(entry);
+    if (!normalized) {
+        return { error: `OpenAI 转换未配置: ${name}` };
+    }
+    return { provider: name, ...normalized };
+}
+
+function extractAuthorizationToken(req) {
+    const header = typeof req.headers.authorization === 'string' ? req.headers.authorization.trim() : '';
+    if (!header) return '';
+    if (/^bearer\s+/i.test(header)) {
+        return header.replace(/^bearer\s+/i, '').trim();
+    }
+    return header;
+}
+
+function readRequestBody(req, maxBytes) {
+    return new Promise((resolve) => {
+        let body = '';
+        let size = 0;
+        let aborted = false;
+        req.on('data', (chunk) => {
+            if (aborted) return;
+            size += chunk.length;
+            if (Number.isFinite(maxBytes) && maxBytes > 0 && size > maxBytes) {
+                aborted = true;
+                try { req.destroy(); } catch (_) {}
+                resolve({ error: '请求体过大' });
+                return;
+            }
+            body += chunk;
+        });
+        req.on('end', () => {
+            if (aborted) return;
+            resolve({ body });
+        });
+        req.on('error', (err) => resolve({ error: err && err.message ? err.message : 'request failed' }));
+    });
+}
+
+function parseJsonOrError(text) {
+    if (typeof text !== 'string' || !text.trim()) {
+        return { value: null, error: 'empty body' };
+    }
+    try {
+        return { value: JSON.parse(text), error: '' };
+    } catch (e) {
+        return { value: null, error: e && e.message ? e.message : 'invalid json' };
+    }
+}
+
+function extractChatCompletionResult(payload) {
+    if (!payload || typeof payload !== 'object') return { text: '', toolCalls: [] };
+    const choice = Array.isArray(payload.choices) ? payload.choices[0] : null;
+    const message = choice && typeof choice === 'object' ? choice.message : null;
+    const toolCalls = message && typeof message === 'object' && Array.isArray(message.tool_calls)
+        ? message.tool_calls
+        : [];
+    const content = message && typeof message === 'object' ? message.content : '';
+    let text = '';
+    if (typeof content === 'string') {
+        text = content;
+    } else if (Array.isArray(content)) {
+        text = content
+            .map((item) => {
+                if (!item) return '';
+                if (typeof item === 'string') return item;
+                if (typeof item === 'object') {
+                    if (typeof item.text === 'string') return item.text;
+                    if (typeof item.content === 'string') return item.content;
+                }
+                return '';
+            })
+            .filter(Boolean)
+            .join('');
+    }
+    return { text, toolCalls };
+}
+
+function normalizeResponsesInputToChatMessages(input) {
+    if (typeof input === 'string') {
+        return [{ role: 'user', content: input }];
+    }
+    if (!Array.isArray(input)) {
+        return [];
+    }
+
+    const messages = [];
+    for (const item of input) {
+        if (!item || typeof item !== 'object') continue;
+
+        // Tool results (Responses): { type: "function_call_output", call_id, output }
+        // Chat Completions equivalent: { role: "tool", tool_call_id, content }
+        if (typeof item.type === 'string' && item.type === 'function_call_output') {
+            const toolCallId = typeof item.call_id === 'string' ? item.call_id.trim() : '';
+            let content = item.output;
+            if (typeof content !== 'string') {
+                try {
+                    content = JSON.stringify(content);
+                } catch (_) {
+                    content = String(content ?? '');
+                }
+            }
+            if (toolCallId && String(content || '').trim()) {
+                messages.push({
+                    role: 'tool',
+                    tool_call_id: toolCallId,
+                    content: String(content)
+                });
+            }
+            continue;
+        }
+
+        const roleRaw = typeof item.role === 'string' ? item.role.trim().toLowerCase() : '';
+        const role = roleRaw === 'assistant' ? 'assistant' : (roleRaw === 'system' ? 'system' : 'user');
+        const content = item.content;
+        if (typeof content === 'string') {
+            if (content.trim()) messages.push({ role, content });
+            continue;
+        }
+        if (Array.isArray(content)) {
+            const text = content
+                .map((block) => {
+                    if (!block) return '';
+                    if (typeof block === 'string') return block;
+                    if (typeof block === 'object') {
+                        if (typeof block.text === 'string') return block.text;
+                        if (typeof block.content === 'string') return block.content;
+                        if (typeof block.type === 'string' && (block.type === 'input_text' || block.type === 'output_text')
+                            && typeof block.text === 'string') {
+                            return block.text;
+                        }
+                    }
+                    return '';
+                })
+                .filter(Boolean)
+                .join('');
+            if (text.trim()) messages.push({ role, content: text });
+        }
+    }
+    return messages;
+}
+
+function convertResponsesRequestToChatCompletions(payload) {
+    const body = payload && typeof payload === 'object' ? payload : {};
+    const model = typeof body.model === 'string' ? body.model.trim() : '';
+    if (!model) {
+        return { error: 'responses 请求缺少 model' };
+    }
+
+    const messages = normalizeResponsesInputToChatMessages(body.input);
+    if (!messages.length) {
+        // codex sometimes sends empty input for probes; tolerate.
+        messages.push({ role: 'user', content: '' });
+    }
+
+    const maxOutputTokens = Number.parseInt(String(body.max_output_tokens), 10);
+    const stream = body.stream === true;
+
+    const chat = {
+        model,
+        messages,
+        stream: false,
+        temperature: Number.isFinite(body.temperature) ? Number(body.temperature) : undefined,
+        top_p: Number.isFinite(body.top_p) ? Number(body.top_p) : undefined,
+        max_tokens: Number.isFinite(maxOutputTokens) && maxOutputTokens > 0 ? maxOutputTokens : undefined
+    };
+    if (Array.isArray(body.stop) && body.stop.length) {
+        chat.stop = body.stop.filter((item) => typeof item === 'string' && item.trim());
+    }
+    // Best-effort: pass through tool definitions (most OpenAI-compatible providers accept these fields).
+    if (Array.isArray(body.tools) && body.tools.length) {
+        chat.tools = body.tools;
+    }
+    if (body.tool_choice !== undefined) {
+        chat.tool_choice = body.tool_choice;
+    }
+    if (body.response_format !== undefined) {
+        chat.response_format = body.response_format;
+    }
+    if (body.metadata !== undefined) {
+        chat.metadata = body.metadata;
+    }
+
+    // Remove undefined keys
+    Object.keys(chat).forEach((key) => chat[key] === undefined && delete chat[key]);
+
+    return { chat, streamRequested: stream };
+}
+
+function buildResponsesPayloadFromChatResult(model, text, toolCalls, upstreamPayload) {
+    const responseId = `resp_${crypto.randomBytes(10).toString('hex')}`;
+    const usage = upstreamPayload && upstreamPayload.usage && typeof upstreamPayload.usage === 'object'
+        ? upstreamPayload.usage
+        : null;
+    const messageItem = {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text }]
+    };
+    if (Array.isArray(toolCalls) && toolCalls.length) {
+        messageItem.tool_calls = toolCalls;
+    }
+    const output = [messageItem];
+
+    const payload = {
+        id: responseId,
+        object: 'response',
+        model,
+        output
+    };
+
+    if (usage) {
+        payload.usage = usage;
+    }
+
+    return payload;
+}
+
+function isLoopbackAddress(address) {
+    if (!address) return false;
+    const value = String(address);
+    return value === '127.0.0.1' || value === '::1' || value === '::ffff:127.0.0.1';
+}
+
+function writeSse(res, eventName, dataObj) {
+    if (eventName) {
+        res.write(`event: ${eventName}\n`);
+    }
+    if (dataObj === '[DONE]') {
+        res.write('data: [DONE]\n\n');
+        return;
+    }
+    res.write(`data: ${JSON.stringify(dataObj)}\n\n`);
+}
+
+async function proxyRequestJson(targetUrl, options = {}) {
+    const parsed = new URL(targetUrl);
+    const transport = parsed.protocol === 'https:' ? https : http;
+    const bodyText = options.body ? JSON.stringify(options.body) : '';
+    const headers = {
+        'Accept': 'application/json',
+        ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(options.headers || {})
+    };
+    if (options.body) {
+        headers['Content-Length'] = Buffer.byteLength(bodyText, 'utf-8');
+    }
+
+    const timeoutMs = Number.isFinite(options.timeoutMs)
+        ? Math.max(1000, Number(options.timeoutMs))
+        : 30000;
+    return new Promise((resolve) => {
+        let settled = false;
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            resolve(value);
+        };
+        const req = transport.request({
+            protocol: parsed.protocol,
+            hostname: parsed.hostname,
+            port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+            method: options.method || 'GET',
+            path: `${parsed.pathname}${parsed.search}`,
+            headers,
+            agent: parsed.protocol === 'https:' ? options.httpsAgent : options.httpAgent
+        }, (upstreamRes) => {
+            const chunks = [];
+            upstreamRes.on('data', (chunk) => chunk && chunks.push(chunk));
+            upstreamRes.on('end', () => {
+                const text = chunks.length ? Buffer.concat(chunks).toString('utf-8') : '';
+                finish({
+                    ok: true,
+                    status: upstreamRes.statusCode || 0,
+                    headers: upstreamRes.headers || {},
+                    bodyText: text
+                });
+            });
+        });
+        req.setTimeout(timeoutMs, () => {
+            try { req.destroy(new Error('timeout')); } catch (_) {}
+            finish({ ok: false, error: 'timeout' });
+        });
+        req.on('error', (err) => finish({ ok: false, error: err && err.message ? err.message : 'request failed' }));
+        if (bodyText) {
+            req.write(bodyText);
+        }
+        req.end();
+    });
+}
+
+function createOpenaiBridgeHttpHandler(options = {}) {
+    const settingsFile = options.settingsFile;
+    const expectedToken = typeof options.expectedToken === 'string' && options.expectedToken.trim()
+        ? options.expectedToken.trim()
+        : DEFAULT_BRIDGE_TOKEN;
+    const maxBodySize = Number.isFinite(options.maxBodySize) ? options.maxBodySize : 0;
+    const httpAgent = options.httpAgent;
+    const httpsAgent = options.httpsAgent;
+
+    if (!settingsFile) {
+        throw new Error('createOpenaiBridgeHttpHandler 缺少 settingsFile');
+    }
+
+    const matchPath = (requestPath) => {
+        const normalized = String(requestPath || '');
+        const prefix = '/bridge/openai/';
+        if (!normalized.startsWith(prefix)) return null;
+        const rest = normalized.slice(prefix.length);
+        const [provider, ...tail] = rest.split('/').filter((part) => part.length > 0);
+        if (!provider) return null;
+        const tailPath = '/' + tail.join('/');
+        if (!tailPath.startsWith('/v1')) return null;
+        const suffix = tailPath === '/v1' ? '' : tailPath.replace(/^\/v1\/?/, '');
+        return { provider, suffix };
+    };
+
+    const handler = (req, res) => {
+        let parsedUrl;
+        try {
+            parsedUrl = new URL(req.url || '/', 'http://localhost');
+        } catch (_) {
+            return false;
+        }
+        const match = matchPath(parsedUrl.pathname || '/');
+        if (!match) return false;
+
+        void (async () => {
+            try {
+            const token = extractAuthorizationToken(req);
+            // 兼容：某些客户端在自定义 base_url 时可能不带 Authorization。
+            // 为避免在 LAN 暴露无鉴权的代理，这里仅允许 loopback 连接缺省 token。
+            const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+            if (!token && !isLoopbackAddress(remoteAddr)) {
+                res.writeHead(401, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: 'Unauthorized' }));
+                return;
+            }
+            if (token && token !== expectedToken) {
+                res.writeHead(401, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: 'Unauthorized' }));
+                return;
+            }
+
+            const upstream = resolveOpenaiBridgeUpstream(settingsFile, match.provider);
+            if (upstream.error) {
+                res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: upstream.error }));
+                return;
+            }
+
+            const suffix = match.suffix || '';
+            const normalizedSuffix = suffix.replace(/^\/+/, '');
+
+            const authHeader = upstream.apiKey
+                ? (/^bearer\s+/i.test(upstream.apiKey) ? upstream.apiKey : `Bearer ${upstream.apiKey}`)
+                : '';
+
+            if (!normalizedSuffix || normalizedSuffix === 'models') {
+                if ((req.method || 'GET').toUpperCase() !== 'GET') {
+                    res.writeHead(405, { 'Content-Type': 'application/json; charset=utf-8' });
+                    res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+                    return;
+                }
+
+                const url = joinApiUrl(upstream.baseUrl, 'models');
+                const result = await proxyRequestJson(url, {
+                    method: 'GET',
+                    headers: authHeader ? { Authorization: authHeader } : {},
+                    httpAgent,
+                    httpsAgent
+                });
+                if (!result.ok) {
+                    res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
+                    res.end(JSON.stringify({ error: `Upstream request failed: ${result.error}` }));
+                    return;
+                }
+                res.writeHead(result.status || 502, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(result.bodyText || '');
+                return;
+            }
+
+            if (normalizedSuffix !== 'responses') {
+                res.writeHead(404, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: 'Not Found' }));
+                return;
+            }
+
+            if ((req.method || 'GET').toUpperCase() !== 'POST') {
+                res.writeHead(405, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+                return;
+            }
+
+            const { body, error: bodyErr } = await readRequestBody(req, maxBodySize);
+            if (bodyErr) {
+                res.writeHead(413, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: bodyErr }));
+                return;
+            }
+            const parsed = parseJsonOrError(body);
+            if (parsed.error) {
+                res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: `Invalid JSON: ${parsed.error}` }));
+                return;
+            }
+
+            const converted = convertResponsesRequestToChatCompletions(parsed.value);
+            if (converted.error) {
+                res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: converted.error }));
+                return;
+            }
+
+            const upstreamUrl = joinApiUrl(upstream.baseUrl, 'chat/completions');
+            const upstreamResult = await proxyRequestJson(upstreamUrl, {
+                method: 'POST',
+                body: converted.chat,
+                headers: authHeader ? { Authorization: authHeader } : {},
+                httpAgent,
+                httpsAgent
+            });
+            if (!upstreamResult.ok) {
+                res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: `Upstream request failed: ${upstreamResult.error}` }));
+                return;
+            }
+
+            const upstreamJson = parseJsonOrError(upstreamResult.bodyText);
+            if (upstreamResult.status >= 400) {
+                res.writeHead(upstreamResult.status, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(upstreamResult.bodyText || JSON.stringify({ error: 'Upstream error' }));
+                return;
+            }
+            if (upstreamJson.error) {
+                res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: `Upstream JSON parse failed: ${upstreamJson.error}` }));
+                return;
+            }
+
+            const model = typeof converted.chat.model === 'string' ? converted.chat.model : '';
+            const extracted = extractChatCompletionResult(upstreamJson.value);
+            const text = extracted && typeof extracted.text === 'string' ? extracted.text : '';
+            const toolCalls = extracted && Array.isArray(extracted.toolCalls) ? extracted.toolCalls : [];
+            const responsesPayload = buildResponsesPayloadFromChatResult(model, text, toolCalls, upstreamJson.value);
+
+            if (converted.streamRequested) {
+                res.writeHead(200, {
+                    'Content-Type': 'text/event-stream; charset=utf-8',
+                    'Cache-Control': 'no-cache',
+                    'Connection': 'keep-alive',
+                    'X-Accel-Buffering': 'no'
+                });
+                // Use SSE "event:" field for better compatibility with OpenAI Responses streaming clients.
+                writeSse(res, 'response.created', { type: 'response.created', response: { id: responsesPayload.id, model } });
+                writeSse(res, 'response.output_text.delta', { type: 'response.output_text.delta', delta: text });
+                writeSse(res, 'response.output_text.done', { type: 'response.output_text.done', text });
+                writeSse(res, 'response.completed', { type: 'response.completed', response: responsesPayload });
+                writeSse(res, 'done', '[DONE]');
+                res.end();
+                return;
+            }
+
+            res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+            res.end(JSON.stringify(responsesPayload));
+            } catch (e) {
+                res.writeHead(500, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: e && e.message ? e.message : 'Internal Error' }));
+            }
+        })();
+
+        return true;
+    };
+
+    handler.matchPath = matchPath;
+    return handler;
+}
+
+module.exports = {
+    readOpenaiBridgeSettings,
+    upsertOpenaiBridgeProvider,
+    resolveOpenaiBridgeUpstream,
+    createOpenaiBridgeHttpHandler
+};

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -360,29 +360,159 @@ function buildResponsesPayloadFromChatResult(model, text, toolCalls, upstreamPay
     const usage = upstreamPayload && upstreamPayload.usage && typeof upstreamPayload.usage === 'object'
         ? upstreamPayload.usage
         : null;
-    const messageItem = {
-        type: 'message',
-        role: 'assistant',
-        content: [{ type: 'output_text', text }]
-    };
-    if (Array.isArray(toolCalls) && toolCalls.length) {
-        messageItem.tool_calls = toolCalls;
+    const createdAt = Math.floor(Date.now() / 1000);
+    const output = [];
+    const trimmedText = typeof text === 'string' ? text : '';
+    if (trimmedText) {
+        output.push({
+            id: `msg_${crypto.randomBytes(8).toString('hex')}`,
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: trimmedText }]
+        });
     }
-    const output = [messageItem];
+
+    // Convert chat.completions tool_calls into Responses-style function_call output items.
+    // This is important for Codex, which appends function_call + function_call_output back into `input`.
+    if (Array.isArray(toolCalls)) {
+        for (const call of toolCalls) {
+            if (!call || typeof call !== 'object') continue;
+            const callId = typeof call.id === 'string' && call.id.trim() ? call.id.trim() : `call_${crypto.randomBytes(8).toString('hex')}`;
+            const fn = call.function && typeof call.function === 'object' ? call.function : {};
+            const name = typeof fn.name === 'string' ? fn.name : '';
+            const args = typeof fn.arguments === 'string' ? fn.arguments : '';
+            if (!name) continue;
+            output.push({
+                type: 'function_call',
+                call_id: callId,
+                name,
+                arguments: args
+            });
+        }
+    }
 
     const payload = {
         id: responseId,
         object: 'response',
         model,
-        output
+        created_at: createdAt,
+        status: 'completed',
+        output,
+        output_text: trimmedText
     };
 
     if (usage) {
-        payload.usage = usage;
+        // Map chat.completions usage -> responses usage shape when possible.
+        const promptTokens = Number.isFinite(usage.prompt_tokens) ? Number(usage.prompt_tokens) : null;
+        const completionTokens = Number.isFinite(usage.completion_tokens) ? Number(usage.completion_tokens) : null;
+        const totalTokens = Number.isFinite(usage.total_tokens) ? Number(usage.total_tokens) : null;
+        if (promptTokens !== null || completionTokens !== null || totalTokens !== null) {
+            payload.usage = {
+                input_tokens: promptTokens ?? undefined,
+                output_tokens: completionTokens ?? undefined,
+                total_tokens: totalTokens ?? undefined
+            };
+            Object.keys(payload.usage).forEach((key) => payload.usage[key] === undefined && delete payload.usage[key]);
+        } else {
+            payload.usage = usage;
+        }
     }
 
     return payload;
 }
+
+function ensureResponseMetadata(response) {
+    const payload = response && typeof response === 'object' ? response : {};
+    if (typeof payload.created_at !== 'number') {
+        payload.created_at = Math.floor(Date.now() / 1000);
+    }
+    if (typeof payload.status !== 'string' || !payload.status.trim()) {
+        payload.status = 'completed';
+    }
+    if (!Array.isArray(payload.output)) {
+        payload.output = [];
+    }
+    return payload;
+}
+
+function sendResponsesSse(res, responsePayload) {
+    const response = ensureResponseMetadata(responsePayload);
+    const responseId = typeof response.id === 'string' && response.id.trim()
+        ? response.id.trim()
+        : `resp_${crypto.randomBytes(10).toString('hex')}`;
+    const model = typeof response.model === 'string' ? response.model : '';
+
+    let sequence = 0;
+    const nextSeq = () => {
+        sequence += 1;
+        return sequence;
+    };
+
+    writeSse(res, 'response.created', {
+        type: 'response.created',
+        response: {
+            id: responseId,
+            model,
+            created_at: response.created_at
+        }
+    });
+
+    const output = Array.isArray(response.output) ? response.output : [];
+    for (let outputIndex = 0; outputIndex < output.length; outputIndex += 1) {
+        const item = output[outputIndex];
+        if (!item || typeof item !== 'object') continue;
+        const itemType = typeof item.type === 'string' ? item.type : '';
+        const itemId = typeof item.id === 'string' && item.id.trim()
+            ? item.id.trim()
+            : (typeof item.call_id === 'string' && item.call_id.trim() ? item.call_id.trim() : `item_${crypto.randomBytes(8).toString('hex')}`);
+
+        // Emit item added so Codex can anchor subsequent deltas by output_index/content_index/item_id.
+        writeSse(res, 'response.output_item.added', {
+            type: 'response.output_item.added',
+            output_index: outputIndex,
+            item: { ...item, id: itemId }
+        });
+
+        if (itemType === 'message') {
+            const content = Array.isArray(item.content) ? item.content : [];
+            for (let contentIndex = 0; contentIndex < content.length; contentIndex += 1) {
+                const block = content[contentIndex];
+                if (!block || typeof block !== 'object') continue;
+                if (block.type !== 'output_text') continue;
+                const text = typeof block.text === 'string' ? block.text : '';
+                if (text) {
+                    writeSse(res, 'response.output_text.delta', {
+                        type: 'response.output_text.delta',
+                        item_id: itemId,
+                        output_index: outputIndex,
+                        content_index: contentIndex,
+                        delta: text,
+                        sequence_number: nextSeq()
+                    });
+                }
+                writeSse(res, 'response.output_text.done', {
+                    type: 'response.output_text.done',
+                    item_id: itemId,
+                    output_index: outputIndex,
+                    content_index: contentIndex,
+                    text,
+                    sequence_number: nextSeq()
+                });
+            }
+        }
+
+        // Emit item done for all item types (message/function_call/etc).
+        writeSse(res, 'response.output_item.done', {
+            type: 'response.output_item.done',
+            output_index: outputIndex,
+            item: { ...item, id: itemId },
+            sequence_number: nextSeq()
+        });
+    }
+
+    writeSse(res, 'response.completed', { type: 'response.completed', response });
+    writeSse(res, 'done', '[DONE]');
+ }
 
 function extractResponsesOutputText(payload) {
     if (!payload || typeof payload !== 'object') return '';
@@ -650,34 +780,20 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                     return;
                 }
                 const upstreamPayload = upstreamJson.value;
-                const model = typeof upstreamPayload.model === 'string'
-                    ? upstreamPayload.model
-                    : (responsesRequest && typeof responsesRequest.model === 'string' ? responsesRequest.model : '');
-
                 if (streamRequested) {
-                    const text = extractResponsesOutputText(upstreamPayload);
                     res.writeHead(200, {
                         'Content-Type': 'text/event-stream; charset=utf-8',
                         'Cache-Control': 'no-cache',
                         'Connection': 'keep-alive',
                         'X-Accel-Buffering': 'no'
                     });
-                    writeSse(res, 'response.created', {
-                        type: 'response.created',
-                        response: { id: upstreamPayload.id || `resp_${crypto.randomBytes(10).toString('hex')}`, model }
-                    });
-                    if (text) {
-                        writeSse(res, 'response.output_text.delta', { type: 'response.output_text.delta', delta: text });
-                        writeSse(res, 'response.output_text.done', { type: 'response.output_text.done', text });
-                    }
-                    writeSse(res, 'response.completed', { type: 'response.completed', response: upstreamPayload });
-                    writeSse(res, 'done', '[DONE]');
+                    sendResponsesSse(res, upstreamPayload);
                     res.end();
                     return;
                 }
 
                 res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-                res.end(JSON.stringify(upstreamPayload));
+                res.end(JSON.stringify(ensureResponseMetadata(upstreamPayload)));
                 return;
             }
 
@@ -745,20 +861,13 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                     'Connection': 'keep-alive',
                     'X-Accel-Buffering': 'no'
                 });
-                // Use SSE "event:" field for better compatibility with OpenAI Responses streaming clients.
-                writeSse(res, 'response.created', { type: 'response.created', response: { id: responsesPayload.id, model } });
-                if (text) {
-                    writeSse(res, 'response.output_text.delta', { type: 'response.output_text.delta', delta: text });
-                    writeSse(res, 'response.output_text.done', { type: 'response.output_text.done', text });
-                }
-                writeSse(res, 'response.completed', { type: 'response.completed', response: responsesPayload });
-                writeSse(res, 'done', '[DONE]');
+                sendResponsesSse(res, responsesPayload);
                 res.end();
                 return;
             }
 
             res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-            res.end(JSON.stringify(responsesPayload));
+            res.end(JSON.stringify(ensureResponseMetadata(responsesPayload)));
             } catch (e) {
                 res.writeHead(500, { 'Content-Type': 'application/json; charset=utf-8' });
                 res.end(JSON.stringify({ error: e && e.message ? e.message : 'Internal Error' }));

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -49,10 +49,41 @@ function normalizeUpstreamEntry(entry) {
     }
     const baseUrl = normalizeOpenaiUpstreamBaseUrl(entry.baseUrl || entry.base_url || '');
     const apiKey = normalizeText(entry.apiKey || entry.api_key || entry.key || '');
+    const headersRaw = entry.headers || entry.extraHeaders || entry.extra_headers || null;
+    const headers = normalizeHeadersMap(headersRaw);
     if (!baseUrl || !isValidHttpUrl(baseUrl)) {
         return null;
     }
-    return { baseUrl, apiKey };
+    return { baseUrl, apiKey, headers };
+}
+
+function normalizeHeadersMap(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return {};
+    }
+    const forbidden = new Set([
+        'authorization',
+        'host',
+        'content-length',
+        'connection',
+        'transfer-encoding',
+        'keep-alive',
+        'proxy-authenticate',
+        'proxy-authorization',
+        'te',
+        'trailer',
+        'upgrade'
+    ]);
+    const result = {};
+    for (const [rawKey, rawVal] of Object.entries(value)) {
+        const key = typeof rawKey === 'string' ? rawKey.trim() : '';
+        if (!key) continue;
+        const lower = key.toLowerCase();
+        if (forbidden.has(lower)) continue;
+        if (typeof rawVal !== 'string') continue;
+        result[key] = rawVal;
+    }
+    return result;
 }
 
 function readOpenaiBridgeSettings(filePath) {
@@ -69,10 +100,11 @@ function readOpenaiBridgeSettings(filePath) {
     };
 }
 
-function upsertOpenaiBridgeProvider(filePath, providerName, upstreamBaseUrl, apiKey) {
+function upsertOpenaiBridgeProvider(filePath, providerName, upstreamBaseUrl, apiKey, headers) {
     const name = normalizeProviderName(providerName);
     const baseUrl = normalizeOpenaiUpstreamBaseUrl(upstreamBaseUrl);
     const key = normalizeText(apiKey);
+    const nextHeaders = normalizeHeadersMap(headers);
 
     if (!name) {
         return { error: 'Provider name is required' };
@@ -82,11 +114,19 @@ function upsertOpenaiBridgeProvider(filePath, providerName, upstreamBaseUrl, api
     }
 
     const settings = readOpenaiBridgeSettings(filePath);
+    const existing = settings && settings.providers ? settings.providers[name] : null;
+    const existingHeaders = existing && typeof existing === 'object' && !Array.isArray(existing)
+        ? normalizeHeadersMap(existing.headers || existing.extraHeaders || existing.extra_headers || null)
+        : {};
     const next = {
         version: SETTINGS_VERSION,
         providers: {
             ...(settings.providers || {}),
-            [name]: { baseUrl, apiKey: key }
+            [name]: {
+                baseUrl,
+                apiKey: key,
+                headers: Object.keys(nextHeaders).length ? nextHeaders : existingHeaders
+            }
         }
     };
     writeJsonAtomic(filePath, next);
@@ -456,6 +496,9 @@ function createOpenaiBridgeHttpHandler(options = {}) {
             const authHeader = upstream.apiKey
                 ? (/^bearer\s+/i.test(upstream.apiKey) ? upstream.apiKey : `Bearer ${upstream.apiKey}`)
                 : '';
+            const upstreamHeaders = upstream && upstream.headers && typeof upstream.headers === 'object' && !Array.isArray(upstream.headers)
+                ? upstream.headers
+                : {};
 
             if (!normalizedSuffix || normalizedSuffix === 'models') {
                 if ((req.method || 'GET').toUpperCase() !== 'GET') {
@@ -467,7 +510,10 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                 const url = joinApiUrl(upstream.baseUrl, 'models');
                 const result = await proxyRequestJson(url, {
                     method: 'GET',
-                    headers: authHeader ? { Authorization: authHeader } : {},
+                    headers: {
+                        ...(authHeader ? { Authorization: authHeader } : {}),
+                        ...upstreamHeaders
+                    },
                     httpAgent,
                     httpsAgent
                 });
@@ -517,7 +563,10 @@ function createOpenaiBridgeHttpHandler(options = {}) {
             const upstreamResult = await proxyRequestJson(upstreamUrl, {
                 method: 'POST',
                 body: converted.chat,
-                headers: authHeader ? { Authorization: authHeader } : {},
+                headers: {
+                    ...(authHeader ? { Authorization: authHeader } : {}),
+                    ...upstreamHeaders
+                },
                 httpAgent,
                 httpsAgent
             });

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -229,6 +229,28 @@ function normalizeResponsesInputToChatMessages(input) {
     for (const item of input) {
         if (!item || typeof item !== 'object') continue;
 
+        // Tool calls (Responses): { type: "function_call", call_id, name, arguments }
+        // Chat Completions equivalent: assistant message with tool_calls
+        if (typeof item.type === 'string' && item.type === 'function_call') {
+            const callId = typeof item.call_id === 'string' ? item.call_id.trim() : '';
+            const name = typeof item.name === 'string' ? item.name.trim() : '';
+            const args = typeof item.arguments === 'string' ? item.arguments : '';
+            if (callId && name) {
+                messages.push({
+                    role: 'assistant',
+                    tool_calls: [{
+                        id: callId,
+                        type: 'function',
+                        function: {
+                            name,
+                            arguments: args || ''
+                        }
+                    }]
+                });
+            }
+            continue;
+        }
+
         // Tool results (Responses): { type: "function_call_output", call_id, output }
         // Chat Completions equivalent: { role: "tool", tool_call_id, content }
         if (typeof item.type === 'string' && item.type === 'function_call_output') {
@@ -288,7 +310,12 @@ function convertResponsesRequestToChatCompletions(payload) {
         return { error: 'responses 请求缺少 model' };
     }
 
-    const messages = normalizeResponsesInputToChatMessages(body.input);
+    const messages = [];
+    // Align with Maxx/CLIProxyAPI style: map "instructions" to a leading system message.
+    if (typeof body.instructions === 'string' && body.instructions.trim()) {
+        messages.push({ role: 'system', content: body.instructions.trim() });
+    }
+    messages.push(...normalizeResponsesInputToChatMessages(body.input));
     if (!messages.length) {
         // codex sometimes sends empty input for probes; tolerate.
         messages.push({ role: 'user', content: '' });

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -201,11 +201,11 @@ function normalizeResponsesInputToChatMessages(input) {
                     content = String(content ?? '');
                 }
             }
-            if (toolCallId && String(content || '').trim()) {
+            if (toolCallId) {
                 messages.push({
                     role: 'tool',
                     tool_call_id: toolCallId,
-                    content: String(content)
+                    content: String(content || '')
                 });
             }
             continue;

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -384,6 +384,28 @@ function buildResponsesPayloadFromChatResult(model, text, toolCalls, upstreamPay
     return payload;
 }
 
+function extractResponsesOutputText(payload) {
+    if (!payload || typeof payload !== 'object') return '';
+    const output = Array.isArray(payload.output) ? payload.output : [];
+    for (const item of output) {
+        if (!item || typeof item !== 'object') continue;
+        if (item.type !== 'message') continue;
+        const content = Array.isArray(item.content) ? item.content : [];
+        for (const block of content) {
+            if (!block || typeof block !== 'object') continue;
+            if (block.type !== 'output_text') continue;
+            if (typeof block.text === 'string') return block.text;
+        }
+    }
+    if (typeof payload.output_text === 'string') return payload.output_text;
+    return '';
+}
+
+function toUpstreamNonStreamingResponsesPayload(payload) {
+    const body = payload && typeof payload === 'object' ? payload : {};
+    return { ...body, stream: false };
+}
+
 function isLoopbackAddress(address) {
     if (!address) return false;
     const value = String(address);
@@ -579,7 +601,75 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                 return;
             }
 
-            const converted = convertResponsesRequestToChatCompletions(parsed.value);
+            const responsesRequest = parsed.value;
+            const streamRequested = !!(responsesRequest && typeof responsesRequest === 'object' && responsesRequest.stream === true);
+
+            // Maxx-style behavior: prefer upstream /responses if supported.
+            // Fallback to /chat/completions conversion when upstream does not implement /responses (404/405).
+            const upstreamResponsesUrl = joinApiUrl(upstream.baseUrl, 'responses');
+            const upstreamResponsesResult = await proxyRequestJson(upstreamResponsesUrl, {
+                method: 'POST',
+                body: toUpstreamNonStreamingResponsesPayload(responsesRequest),
+                headers: {
+                    ...(authHeader ? { Authorization: authHeader } : {}),
+                    ...upstreamHeaders
+                },
+                httpAgent,
+                httpsAgent
+            });
+
+            if (upstreamResponsesResult.ok && upstreamResponsesResult.status >= 200 && upstreamResponsesResult.status < 300) {
+                const upstreamJson = parseJsonOrError(upstreamResponsesResult.bodyText);
+                if (upstreamJson.error) {
+                    res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
+                    res.end(JSON.stringify({ error: `Upstream JSON parse failed: ${upstreamJson.error}` }));
+                    return;
+                }
+                const upstreamPayload = upstreamJson.value;
+                const model = typeof upstreamPayload.model === 'string'
+                    ? upstreamPayload.model
+                    : (responsesRequest && typeof responsesRequest.model === 'string' ? responsesRequest.model : '');
+
+                if (streamRequested) {
+                    const text = extractResponsesOutputText(upstreamPayload);
+                    res.writeHead(200, {
+                        'Content-Type': 'text/event-stream; charset=utf-8',
+                        'Cache-Control': 'no-cache',
+                        'Connection': 'keep-alive',
+                        'X-Accel-Buffering': 'no'
+                    });
+                    writeSse(res, 'response.created', {
+                        type: 'response.created',
+                        response: { id: upstreamPayload.id || `resp_${crypto.randomBytes(10).toString('hex')}`, model }
+                    });
+                    if (text) {
+                        writeSse(res, 'response.output_text.delta', { type: 'response.output_text.delta', delta: text });
+                        writeSse(res, 'response.output_text.done', { type: 'response.output_text.done', text });
+                    }
+                    writeSse(res, 'response.completed', { type: 'response.completed', response: upstreamPayload });
+                    writeSse(res, 'done', '[DONE]');
+                    res.end();
+                    return;
+                }
+
+                res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify(upstreamPayload));
+                return;
+            }
+
+            if (upstreamResponsesResult.ok && upstreamResponsesResult.status >= 400 && upstreamResponsesResult.status !== 404 && upstreamResponsesResult.status !== 405) {
+                res.writeHead(upstreamResponsesResult.status, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(upstreamResponsesResult.bodyText || JSON.stringify({ error: 'Upstream error' }));
+                return;
+            }
+
+            if (!upstreamResponsesResult.ok) {
+                res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: `Upstream request failed: ${upstreamResponsesResult.error}` }));
+                return;
+            }
+
+            const converted = convertResponsesRequestToChatCompletions(responsesRequest);
             if (converted.error) {
                 res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
                 res.end(JSON.stringify({ error: converted.error }));
@@ -630,8 +720,10 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                 });
                 // Use SSE "event:" field for better compatibility with OpenAI Responses streaming clients.
                 writeSse(res, 'response.created', { type: 'response.created', response: { id: responsesPayload.id, model } });
-                writeSse(res, 'response.output_text.delta', { type: 'response.output_text.delta', delta: text });
-                writeSse(res, 'response.output_text.done', { type: 'response.output_text.done', text });
+                if (text) {
+                    writeSse(res, 'response.output_text.delta', { type: 'response.output_text.delta', delta: text });
+                    writeSse(res, 'response.output_text.done', { type: 'response.output_text.done', text });
+                }
                 writeSse(res, 'response.completed', { type: 'response.completed', response: responsesPayload });
                 writeSse(res, 'done', '[DONE]');
                 res.end();

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -406,6 +406,30 @@ function toUpstreamNonStreamingResponsesPayload(payload) {
     return { ...body, stream: false };
 }
 
+function shouldFallbackFromUpstreamResponses(status, bodyText) {
+    if (!Number.isFinite(status)) return false;
+    // Common "unsupported" status codes for a route.
+    if (status === 404 || status === 405 || status === 501) return true;
+
+    // Some OpenAI-compatible gateways respond with 500 + "not implemented" (e.g. convert_request_failed)
+    // instead of 404/405 for unsupported endpoints. In that case we can safely fallback to chat/completions.
+    const text = String(bodyText || '');
+    if (!text) return false;
+    if (/not implemented/i.test(text)) return true;
+    if (/convert_request_failed/i.test(text)) return true;
+
+    // Best-effort parse for structured error codes.
+    try {
+        const parsed = JSON.parse(text);
+        const code = parsed && parsed.error && typeof parsed.error.code === 'string' ? parsed.error.code : '';
+        const msg = parsed && parsed.error && typeof parsed.error.message === 'string' ? parsed.error.message : '';
+        if (code === 'convert_request_failed') return true;
+        if (/not implemented/i.test(msg)) return true;
+    } catch (_) {}
+
+    return false;
+}
+
 function isLoopbackAddress(address) {
     if (!address) return false;
     const value = String(address);
@@ -657,10 +681,13 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                 return;
             }
 
-            if (upstreamResponsesResult.ok && upstreamResponsesResult.status >= 400 && upstreamResponsesResult.status !== 404 && upstreamResponsesResult.status !== 405) {
-                res.writeHead(upstreamResponsesResult.status, { 'Content-Type': 'application/json; charset=utf-8' });
-                res.end(upstreamResponsesResult.bodyText || JSON.stringify({ error: 'Upstream error' }));
-                return;
+            if (upstreamResponsesResult.ok && upstreamResponsesResult.status >= 400) {
+                if (!shouldFallbackFromUpstreamResponses(upstreamResponsesResult.status, upstreamResponsesResult.bodyText)) {
+                    res.writeHead(upstreamResponsesResult.status, { 'Content-Type': 'application/json; charset=utf-8' });
+                    res.end(upstreamResponsesResult.bodyText || JSON.stringify({ error: 'Upstream error' }));
+                    return;
+                }
+                // fallthrough to chat/completions conversion
             }
 
             if (!upstreamResponsesResult.ok) {

--- a/tests/unit/agents-diff-ui.test.mjs
+++ b/tests/unit/agents-diff-ui.test.mjs
@@ -18,8 +18,8 @@ test('agents modal exposes diff preview hooks in template and script', () => {
     assert.match(template, /快捷键：Esc/);
     assert.match(template, /agentsDiffTruncated/);
     assert.match(template, /@click\.self="!configTemplateApplying && closeConfigTemplateModal\(\)"/);
-    assert.match(template, /:readonly="configTemplateApplying"/);
-    assert.match(template, /<button class="btn btn-cancel" @click="closeConfigTemplateModal" :disabled="configTemplateApplying">取消<\/button>/);
+    assert.match(template, /:readonly="configTemplateApplying \|\| configTemplateDiffLoading"/);
+    assert.match(template, /<button class="btn btn-cancel" @click="closeConfigTemplateModal" :disabled="configTemplateApplying \|\| configTemplateDiffLoading">取消<\/button>/);
     assert.match(template, /:readonly="agentsLoading \|\| agentsSaving"/);
     assert.match(template, /agentsDiffVisible \? '应用'/);
     assert.match(template, /应用中\.\.\./);

--- a/tests/unit/agents-modal-guards.test.mjs
+++ b/tests/unit/agents-modal-guards.test.mjs
@@ -245,7 +245,11 @@ test('openHealthCheckDialog opens unlocked selector by default and locks when pr
         healthCheckDialogSelectedProvider: '',
         healthCheckDialogPrompt: '',
         healthCheckDialogMessages: [{ id: 'stale' }],
-        healthCheckDialogLastResult: { ok: false }
+        healthCheckDialogLastResult: { ok: false },
+        shownMessages: [],
+        showMessage(message, type) {
+            this.shownMessages.push({ message, type });
+        }
     };
 
     methods.openHealthCheckDialog.call(context);
@@ -255,8 +259,12 @@ test('openHealthCheckDialog opens unlocked selector by default and locks when pr
     assert.deepStrictEqual(context.healthCheckDialogMessages, []);
 
     methods.openHealthCheckDialog.call(context, { providerName: 'beta', locked: true });
-    assert.strictEqual(context.healthCheckDialogLockedProvider, 'beta');
-    assert.strictEqual(context.healthCheckDialogSelectedProvider, 'beta');
+    assert.strictEqual(context.healthCheckDialogLockedProvider, '');
+    assert.strictEqual(context.healthCheckDialogSelectedProvider, 'alpha');
+    assert.deepStrictEqual(context.shownMessages, [{
+        message: '请先切换到该提供商再进行健康聊天测试',
+        type: 'info'
+    }]);
 });
 
 test('sendHealthCheckDialogMessage appends transcript and clears prompt after success', async () => {

--- a/tests/unit/agents-modal-guards.test.mjs
+++ b/tests/unit/agents-modal-guards.test.mjs
@@ -35,7 +35,18 @@ test('closeConfigTemplateModal ignores user close attempts while template apply 
 test('applyConfigTemplate force closes the modal after a successful apply', async () => {
     let loadAllCalls = 0;
     const methods = createCodexConfigMethods({
-        api: async () => ({ success: true }),
+        api: async (action) => {
+            if (action === 'preview-config-template-diff') {
+                return {
+                    diff: {
+                        lines: [{ type: 'add', value: 'model = "qwen-plus"' }],
+                        stats: { added: 1, removed: 0, unchanged: 0 },
+                        hasChanges: true
+                    }
+                };
+            }
+            return { success: true };
+        },
         getProviderConfigModeMeta() {
             return null;
         }
@@ -56,6 +67,13 @@ test('applyConfigTemplate force closes the modal after a successful apply', asyn
 
     await methods.applyConfigTemplate.call(context);
 
+    assert.strictEqual(context.showConfigTemplateModal, true);
+    assert.strictEqual(context.configTemplateDiffVisible, true);
+    assert.strictEqual(context.configTemplateApplying, false);
+    assert.strictEqual(loadAllCalls, 0);
+
+    await methods.applyConfigTemplate.call(context);
+
     assert.strictEqual(context.showConfigTemplateModal, false);
     assert.strictEqual(context.configTemplateContent, '');
     assert.strictEqual(context.configTemplateApplying, false);
@@ -68,7 +86,18 @@ test('applyConfigTemplate force closes the modal after a successful apply', asyn
 
 test('applyConfigTemplate keeps the successful apply result when only the refresh fails', async () => {
     const methods = createCodexConfigMethods({
-        api: async () => ({ success: true }),
+        api: async (action) => {
+            if (action === 'preview-config-template-diff') {
+                return {
+                    diff: {
+                        lines: [{ type: 'add', value: 'model = "qwen-plus"' }],
+                        stats: { added: 1, removed: 0, unchanged: 0 },
+                        hasChanges: true
+                    }
+                };
+            }
+            return { success: true };
+        },
         getProviderConfigModeMeta() {
             return null;
         }
@@ -86,6 +115,11 @@ test('applyConfigTemplate keeps the successful apply result when only the refres
             throw new Error('refresh failed');
         }
     };
+
+    await methods.applyConfigTemplate.call(context);
+
+    assert.strictEqual(context.showConfigTemplateModal, true);
+    assert.strictEqual(context.configTemplateDiffVisible, true);
 
     await methods.applyConfigTemplate.call(context);
 

--- a/tests/unit/config-tabs-ui.test.mjs
+++ b/tests/unit/config-tabs-ui.test.mjs
@@ -316,7 +316,10 @@ test('config template keeps expected config tabs in top and side navigation', ()
     assert.doesNotMatch(html, /<span class="selector-title">local 本地端口<\/span>/);
     assert.match(html, /<button class="btn-icon" @click="showModelModal = true" aria-label="Add model" title="添加模型" v-if="modelsSource === 'legacy'">\+<\/button>/);
     assert.match(html, /<button class="btn-icon" @click="showModelListModal = true" aria-label="Manage models" title="管理模型" v-if="modelsSource === 'legacy'">≡<\/button>/);
-    assert.match(html, /<button class="card-action-btn"[^>]*@click="openHealthCheckDialog\(\{ providerName: provider\.name, locked: true \}\)"[^>]*:aria-label="`Open health dialog for \$\{provider\.name\}`"[^>]*title="检测对话">/);
+    assert.match(
+        html,
+        /<button[\s\S]*class="card-action-btn"[\s\S]*@click="openHealthCheckDialog\(\{ providerName: provider\.name, locked: true \}\)"[\s\S]*:disabled="displayCurrentProvider !== provider\.name"[\s\S]*:aria-label="`Open health dialog for \$\{provider\.name\}`"[\s\S]*:title="displayCurrentProvider === provider\.name \? '健康聊天测试' : '请先切换到该提供商'"/
+    );
     assert.match(html, /<button[\s\S]*?@click="openEditModal\(provider\)"[\s\S]*?:aria-label="`Edit provider \$\{provider\.name\}`"[\s\S]*?:title="shouldShowProviderEdit\(provider\) \? '编辑' : '不可编辑'">/);
     assert.match(html, /<button[\s\S]*?@click="deleteProvider\(provider\.name\)"[\s\S]*?:aria-label="`Delete provider \$\{provider\.name\}`"[\s\S]*?:title="shouldShowProviderDelete\(provider\) \? '删除' : '不可删除'">/);
     assert.match(html, /<button class="card-action-btn"[^>]*@click="openEditConfigModal\(name\)"[^>]*:aria-label="`Edit Claude config \$\{name\}`"[^>]*title="编辑">/);

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -1,0 +1,175 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { once } from 'node:events';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { createOpenaiBridgeHttpHandler } = require('../../cli/openai-bridge.js');
+
+function listen(server) {
+    server.listen(0, '127.0.0.1');
+    return once(server, 'listening').then(() => {
+        const addr = server.address();
+        return { port: addr.port, host: addr.address };
+    });
+}
+
+async function requestText(url, { method = 'GET', headers = {}, body } = {}) {
+    return new Promise((resolve, reject) => {
+        const u = new URL(url);
+        const req = http.request({
+            hostname: u.hostname,
+            port: u.port,
+            path: `${u.pathname}${u.search}`,
+            method,
+            headers
+        }, (res) => {
+            const chunks = [];
+            res.on('data', (c) => chunks.push(c));
+            res.on('end', () => resolve({
+                status: res.statusCode || 0,
+                headers: res.headers || {},
+                text: Buffer.concat(chunks).toString('utf-8')
+            }));
+        });
+        req.on('error', reject);
+        if (body !== undefined) {
+            req.write(typeof body === 'string' ? body : JSON.stringify(body));
+        }
+        req.end();
+    });
+}
+
+test('openai-bridge prefers upstream /responses and rewraps SSE when stream requested', async () => {
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                id: 'resp_upstream',
+                model: 'gpt-test',
+                output: [{
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: 'hello-from-upstream' }]
+                }]
+            }));
+            return;
+        }
+        if (req.url === '/v1/models' && req.method === 'GET') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ object: 'list', data: [] }));
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate' });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const base = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
+    const sse = await requestText(base, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer codexmate'
+        },
+        body: {
+            model: 'gpt-test',
+            input: 'ping',
+            stream: true
+        }
+    });
+    assert.equal(sse.status, 200);
+    assert.match(sse.headers['content-type'], /text\/event-stream/i);
+    assert.match(sse.text, /event: response\.completed/);
+    assert.match(sse.text, /data: \[DONE\]/);
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});
+
+test('openai-bridge falls back to upstream /chat/completions when /responses is not supported', async () => {
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses') {
+            res.writeHead(405, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Method Not Allowed' }));
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                id: 'chatcmpl_x',
+                model: 'gpt-test',
+                choices: [{ message: { role: 'assistant', content: 'hello-from-chat' } }]
+            }));
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate' });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const url = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
+    const resp = await requestText(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer codexmate'
+        },
+        body: {
+            model: 'gpt-test',
+            input: 'ping',
+            stream: false
+        }
+    });
+    assert.equal(resp.status, 200);
+    const parsed = JSON.parse(resp.text);
+    assert.equal(parsed.object, 'response');
+    assert.equal(parsed.model, 'gpt-test');
+    assert.ok(Array.isArray(parsed.output));
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});
+

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -102,6 +102,8 @@ test('openai-bridge prefers upstream /responses and rewraps SSE when stream requ
     });
     assert.equal(sse.status, 200);
     assert.match(sse.headers['content-type'], /text\/event-stream/i);
+    assert.match(sse.text, /response\.output_item\.added/);
+    assert.match(sse.text, /response\.output_text\.delta/);
     assert.match(sse.text, /event: response\.completed/);
     assert.match(sse.text, /data: \[DONE\]/);
 

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -173,3 +173,70 @@ test('openai-bridge falls back to upstream /chat/completions when /responses is 
     await rm(tmpDir, { recursive: true, force: true });
 });
 
+test('openai-bridge falls back to /chat/completions when upstream /responses returns 500 not implemented', async () => {
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                error: {
+                    message: 'not implemented (request id: test)',
+                    type: 'new_api_error',
+                    param: '',
+                    code: 'convert_request_failed'
+                }
+            }));
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+                id: 'chatcmpl_x',
+                model: 'gpt-test',
+                choices: [{ message: { role: 'assistant', content: 'hello-from-chat' } }]
+            }));
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate' });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const url = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
+    const resp = await requestText(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer codexmate'
+        },
+        body: {
+            model: 'gpt-test',
+            input: 'ping',
+            stream: false
+        }
+    });
+    assert.equal(resp.status, 200);
+    const parsed = JSON.parse(resp.text);
+    assert.equal(parsed.object, 'response');
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});

--- a/tests/unit/provider-share-command.test.mjs
+++ b/tests/unit/provider-share-command.test.mjs
@@ -112,7 +112,9 @@ test('buildProviderSharePayload includes model for shared provider', () => {
         }),
         readCurrentModels: () => ({
             alpha: 'alpha-share-model'
-        })
+        }),
+        resolveOpenaiBridgeUpstream: () => ({ error: 'missing' }),
+        OPENAI_BRIDGE_SETTINGS_FILE: '/tmp/bridge.json'
     });
 
     const result = buildProviderSharePayload({ name: 'alpha' });
@@ -137,12 +139,47 @@ test('buildProviderSharePayload falls back to active model when saved model is e
         }),
         readCurrentModels: () => ({
             alpha: '   '
-        })
+        }),
+        resolveOpenaiBridgeUpstream: () => ({ error: 'missing' }),
+        OPENAI_BRIDGE_SETTINGS_FILE: '/tmp/bridge.json'
     });
 
     const result = buildProviderSharePayload({ name: 'alpha' });
     assert(result && result.payload, 'share payload should exist');
     assert.strictEqual(result.payload.model, 'alpha-fallback-model');
+});
+
+test('buildProviderSharePayload exports upstream config for openai bridge providers', () => {
+    const source = extractBlockBySignature(cliSource, 'function buildProviderSharePayload(params = {}) {');
+    const buildProviderSharePayload = instantiateFunction(source, 'buildProviderSharePayload', {
+        readConfigOrVirtualDefault: () => ({
+            config: {
+                model_provider: 'alpha',
+                model: 'alpha-fallback-model',
+                model_providers: {
+                    alpha: {
+                        base_url: 'http://127.0.0.1:31337/bridge/openai/alpha/v1',
+                        preferred_auth_method: 'codexmate',
+                        codexmate_bridge: 'openai'
+                    }
+                }
+            }
+        }),
+        readCurrentModels: () => ({ alpha: 'alpha-share-model' }),
+        resolveOpenaiBridgeUpstream: (_file, name) => ({
+            error: '',
+            provider: name,
+            baseUrl: 'https://upstream.example.com/v1',
+            apiKey: 'sk-upstream'
+        }),
+        OPENAI_BRIDGE_SETTINGS_FILE: '/tmp/bridge.json'
+    });
+
+    const result = buildProviderSharePayload({ name: 'alpha' });
+    assert(result && result.payload, 'share payload should exist');
+    assert.strictEqual(result.payload.baseUrl, 'https://upstream.example.com/v1');
+    assert.strictEqual(result.payload.apiKey, 'sk-upstream');
+    assert.strictEqual(result.payload.bridge, 'openai');
 });
 
 test('buildProviderShareCommand appends model switch command when model exists', () => {
@@ -151,7 +188,8 @@ test('buildProviderShareCommand appends model switch command when model exists',
         name: 'alpha',
         baseUrl: 'https://api.example.com/v1',
         apiKey: 'sk-alpha',
-        model: 'alpha-share-model'
+        model: 'alpha-share-model',
+        bridge: ''
     });
 
     assert.strictEqual(
@@ -166,7 +204,8 @@ test('buildProviderShareCommand keeps legacy command when payload model is empty
         name: 'alpha',
         baseUrl: 'https://api.example.com/v1',
         apiKey: 'sk-alpha',
-        model: ''
+        model: '',
+        bridge: ''
     });
 
     assert.strictEqual(command, "npm start add alpha 'https://api.example.com/v1' sk-alpha && npm start switch alpha");
@@ -178,12 +217,29 @@ test('buildProviderShareCommand supports codexmate prefix', () => {
         name: 'alpha',
         baseUrl: 'https://api.example.com/v1',
         apiKey: 'sk-alpha',
-        model: 'alpha-share-model'
+        model: 'alpha-share-model',
+        bridge: ''
     });
 
     assert.strictEqual(
         command,
         "codexmate add alpha 'https://api.example.com/v1' sk-alpha && codexmate switch alpha && codexmate use alpha-share-model"
+    );
+});
+
+test('buildProviderShareCommand adds bridge flag when present', () => {
+    const buildProviderShareCommand = createProviderShareCommandBuilder(appSource, 'codexmate');
+    const command = buildProviderShareCommand({
+        name: 'alpha',
+        baseUrl: 'https://api.example.com/v1',
+        apiKey: 'sk-alpha',
+        model: '',
+        bridge: 'openai'
+    });
+
+    assert.strictEqual(
+        command,
+        "codexmate add alpha 'https://api.example.com/v1' sk-alpha --bridge openai && codexmate switch alpha"
     );
 });
 

--- a/tests/unit/provider-switch-regression.test.mjs
+++ b/tests/unit/provider-switch-regression.test.mjs
@@ -248,7 +248,7 @@ test('updateProvider keeps existing key when edit key input is blank', async () 
         }
     }]);
     assert.strictEqual(context.showEditModal, false);
-    assert.deepStrictEqual(context.editingProvider, { name: '', url: '', key: '', readOnly: false, nonEditable: false });
+    assert.deepStrictEqual(context.editingProvider, { name: '', url: '', key: '', readOnly: false, nonEditable: false, useTransform: false });
     assert.strictEqual(context.loadAllCalls, 1);
     assert.deepStrictEqual(context.messages, [{
         text: '操作成功',

--- a/tests/unit/provider-switch-regression.test.mjs
+++ b/tests/unit/provider-switch-regression.test.mjs
@@ -206,7 +206,7 @@ test('switchProvider reflects the first clicked target immediately while waiting
     assert.strictEqual(context.providerSwitchDisplayTarget, '');
 });
 
-test('performProviderSwitch skips config reapply when provider models fail to load', async () => {
+test('performProviderSwitch keeps provider when provider models fail to load', async () => {
     const context = createProviderSwitchContext();
     context.loadModelsForProvider = async function loadModelsForProvider(name) {
         context.calls.push(['loadModelsForProvider', name]);
@@ -218,14 +218,19 @@ test('performProviderSwitch skips config reapply when provider models fail to lo
 
     await currentMethods.performProviderSwitch.call(context, 'beta');
 
-    assert.strictEqual(context.currentProvider, 'alpha');
+    assert.strictEqual(context.currentProvider, 'beta');
     assert.strictEqual(context.currentModel, 'alpha-model');
-    assert.deepStrictEqual(context.models, ['alpha-model']);
-    assert.strictEqual(context.modelsSource, 'remote');
+    assert.deepStrictEqual(context.models, []);
+    assert.strictEqual(context.modelsSource, 'error');
     assert.strictEqual(context.modelsHasCurrent, true);
     assert.deepStrictEqual(context.calls, [
-        ['loadModelsForProvider', 'beta']
+        ['loadModelsForProvider', 'beta'],
+        ['applyCodexConfigDirect', { silent: true }]
     ]);
+    assert.deepStrictEqual(context.messages, [{
+        text: '模型列表获取失败，但已切换提供商；请检查 URL/密钥或手动设置模型',
+        type: 'error'
+    }]);
 });
 
 test('updateProvider keeps existing key when edit key input is blank', async () => {

--- a/tests/unit/providers-validation.test.mjs
+++ b/tests/unit/providers-validation.test.mjs
@@ -11,7 +11,7 @@ function createContext(overrides = {}, apiImpl = async () => ({ success: true })
         showAddModal: true,
         showEditModal: false,
         resetConfigLoading: false,
-        newProvider: { name: '', url: '', key: '' },
+        newProvider: { name: '', url: '', key: '', useTransform: false },
         editingProvider: { name: '', url: '', key: '', readOnly: false, nonEditable: false },
         claudeConfigs: {},
         showMessage(text, type) {
@@ -78,7 +78,7 @@ test('addProvider normalizes trimmed values and submits sanitized payload', asyn
         }
     }]);
     assert.strictEqual(context.showAddModal, false);
-    assert.deepStrictEqual(context.newProvider, { name: '', url: '', key: '' });
+    assert.deepStrictEqual(context.newProvider, { name: '', url: '', key: '', useTransform: false });
     assert.deepStrictEqual(loadAllCalls, ['loadAll']);
     assert.strictEqual(messages.length, 1);
     assert.deepStrictEqual(messages[0], {

--- a/tests/unit/web-ui-behavior-parity.test.mjs
+++ b/tests/unit/web-ui-behavior-parity.test.mjs
@@ -361,6 +361,16 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'sessionListLoadStep',
         'sessionListVisibleCount'
     ];
+    allowedExtraCurrentKeys.push(
+        'configTemplateDiffVisible',
+        'configTemplateDiffLoading',
+        'configTemplateDiffError',
+        'configTemplateDiffLines',
+        'configTemplateDiffStats',
+        'configTemplateDiffHasChangesValue',
+        'configTemplateDiffFingerprint',
+        '_configTemplateDiffPreviewRequestToken'
+    );
     if (parityAgainstHead) {
         const allowedExtraKeySet = new Set(allowedExtraCurrentKeys);
         const allowedMissingKeySet = new Set(allowedMissingCurrentKeys);
@@ -432,6 +442,13 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'resetTaskOrchestrationDraft',
         'appendTaskWorkflowId'
     ];
+    allowedExtraCurrentMethodKeys.push(
+        'resetConfigTemplateDiffState',
+        'onConfigTemplateContentInput',
+        'buildConfigTemplateDiffFingerprint',
+        'prepareConfigTemplateDiff',
+        'hasConfigTemplateDiffChanges'
+    );
     const allowedMissingCurrentMethodKeys = [
         'closeInstallModal',
         'getFirstNonLocalProviderName',
@@ -476,6 +493,7 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'mainTabKicker',
         'mainTabTitle',
         'mainTabSubtitle',
+        'configTemplateDiffHasChanges',
         'taskOrchestrationSelectedRun',
         'taskOrchestrationSelectedRunNodes',
         'taskOrchestrationQueueStats',

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -74,6 +74,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 confirmDialogResolver: null,
                 configTemplateContent: '',
                 configTemplateApplying: false,
+                configTemplateDiffVisible: false,
+                configTemplateDiffLoading: false,
+                configTemplateDiffError: '',
+                configTemplateDiffLines: [],
+                configTemplateDiffStats: {
+                    added: 0,
+                    removed: 0,
+                    unchanged: 0
+                },
+                configTemplateDiffHasChangesValue: false,
+                configTemplateDiffFingerprint: '',
+                _configTemplateDiffPreviewRequestToken: null,
                 codexApplying: false,
                 _pendingCodexApplyOptions: null,
                 agentsContent: '',

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -210,7 +210,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 providerSwitchDisplayTarget: '',
                 healthCheckDialogLockedProvider: '',
                 healthCheckDialogSelectedProvider: '',
-                healthCheckDialogPrompt: '请简短回复：当前提供商连接正常。',
+                healthCheckDialogPrompt: '请简短回复：连接正常。',
                 healthCheckDialogMessages: [],
                 healthCheckDialogSending: false,
                 healthCheckDialogLastResult: null,
@@ -240,7 +240,7 @@ document.addEventListener('DOMContentLoaded', () => {
                         error: ''
                     }
                 ],
-                newProvider: { name: '', url: '', key: '' },
+                newProvider: { name: '', url: '', key: '', useTransform: false },
                 resetConfigLoading: false,
                 editingProvider: { name: '', url: '', key: '', readOnly: false, nonEditable: false },
                 newModelName: '',

--- a/web-ui/modules/app.computed.dashboard.mjs
+++ b/web-ui/modules/app.computed.dashboard.mjs
@@ -9,6 +9,15 @@ export function createDashboardComputed() {
             const removed = Number(stats.removed || 0);
             return added > 0 || removed > 0;
         },
+        configTemplateDiffHasChanges() {
+            const stats = this.configTemplateDiffStats || {};
+            const added = Number(stats.added || 0);
+            const removed = Number(stats.removed || 0);
+            if (this.configTemplateDiffHasChangesValue !== undefined && this.configTemplateDiffHasChangesValue !== null) {
+                return !!this.configTemplateDiffHasChangesValue;
+            }
+            return added > 0 || removed > 0;
+        },
         claudeModelHasList() {
             return this.claudeModelOptions.length > 0;
         },

--- a/web-ui/modules/app.methods.codex-config.mjs
+++ b/web-ui/modules/app.methods.codex-config.mjs
@@ -106,12 +106,9 @@ export function createCodexConfigMethods(options = {}) {
             this.currentProvider = name;
             await this.loadModelsForProvider(name);
             if (this.modelsSource === 'error') {
-                this.currentProvider = previousProvider;
-                this.currentModel = previousModel;
-                this.models = previousModels;
-                this.modelsSource = previousModelsSource;
-                this.modelsHasCurrent = previousModelsHasCurrent;
-                return;
+                // 允许切换到模型列表获取失败的提供商：有些 OpenAI 兼容服务不实现 /models，
+                // 或 /models 需要不同的鉴权。此时保持切换结果，让用户仍可手动输入/选择模型。
+                this.showMessage('模型列表获取失败，但已切换提供商；请检查 URL/密钥或手动设置模型', 'error');
             }
             if (this.modelsSource === 'remote' && this.models.length > 0 && !this.models.includes(this.currentModel)) {
                 this.currentModel = this.models[0];

--- a/web-ui/modules/app.methods.codex-config.mjs
+++ b/web-ui/modules/app.methods.codex-config.mjs
@@ -479,6 +479,7 @@ export function createCodexConfigMethods(options = {}) {
         },
 
         async openConfigTemplateEditor(options = {}) {
+            this.resetConfigTemplateDiffState();
             const modelContextWindow = this.normalizePositiveIntegerInput(
                 this.modelContextWindowInput,
                 'model_context_window',
@@ -626,11 +627,104 @@ export function createCodexConfigMethods(options = {}) {
 
         closeConfigTemplateModal(options = {}) {
             const force = !!options.force;
-            if (!force && this.configTemplateApplying) {
+            if (!force && (this.configTemplateApplying || this.configTemplateDiffLoading)) {
                 return;
             }
             this.showConfigTemplateModal = false;
             this.configTemplateContent = '';
+            this.resetConfigTemplateDiffState();
+        },
+
+        resetConfigTemplateDiffState() {
+            this.configTemplateDiffVisible = false;
+            this.configTemplateDiffLoading = false;
+            this.configTemplateDiffError = '';
+            this.configTemplateDiffLines = [];
+            this.configTemplateDiffStats = { added: 0, removed: 0, unchanged: 0 };
+            this.configTemplateDiffHasChangesValue = false;
+            this.configTemplateDiffFingerprint = '';
+            this._configTemplateDiffPreviewRequestToken = null;
+        },
+
+        onConfigTemplateContentInput() {
+            if (this.configTemplateDiffVisible || (this.configTemplateDiffLines && this.configTemplateDiffLines.length)) {
+                this.resetConfigTemplateDiffState();
+            }
+        },
+
+        buildConfigTemplateDiffFingerprint() {
+            const content = typeof this.configTemplateContent === 'string' ? this.configTemplateContent : '';
+            return `${content.length}::${content}`;
+        },
+
+        hasConfigTemplateDiffChanges() {
+            if (this.configTemplateDiffHasChangesValue !== undefined && this.configTemplateDiffHasChangesValue !== null) {
+                return !!this.configTemplateDiffHasChangesValue;
+            }
+            const stats = this.configTemplateDiffStats && typeof this.configTemplateDiffStats === 'object'
+                ? this.configTemplateDiffStats
+                : {};
+            const added = Number(stats.added || 0);
+            const removed = Number(stats.removed || 0);
+            return added > 0 || removed > 0;
+        },
+
+        async prepareConfigTemplateDiff() {
+            const requestFingerprint = this.buildConfigTemplateDiffFingerprint();
+            const requestToken = Symbol('config-template-diff-preview');
+            this._configTemplateDiffPreviewRequestToken = requestToken;
+            this.configTemplateDiffVisible = true;
+            this.configTemplateDiffLoading = true;
+            this.configTemplateDiffError = '';
+            this.configTemplateDiffLines = [];
+            this.configTemplateDiffStats = { added: 0, removed: 0, unchanged: 0 };
+            this.configTemplateDiffHasChangesValue = false;
+            try {
+                const shouldApply = () => (
+                    this.configTemplateDiffVisible
+                    && this._configTemplateDiffPreviewRequestToken === requestToken
+                    && this.buildConfigTemplateDiffFingerprint() === requestFingerprint
+                );
+                const res = await api('preview-config-template-diff', {
+                    template: this.configTemplateContent
+                });
+                if (!shouldApply()) {
+                    return;
+                }
+                if (res.error) {
+                    this.configTemplateDiffError = res.error;
+                    return;
+                }
+                const diff = res.diff && typeof res.diff === 'object' ? res.diff : {};
+                const lines = Array.isArray(diff.lines) ? diff.lines : [];
+                this.configTemplateDiffLines = lines.filter(line => line && line.type);
+                const stats = diff.stats && typeof diff.stats === 'object' ? diff.stats : null;
+                if (stats) {
+                    this.configTemplateDiffStats = {
+                        added: Number(stats.added || 0),
+                        removed: Number(stats.removed || 0),
+                        unchanged: Number(stats.unchanged || 0)
+                    };
+                } else {
+                    const nextStats = { added: 0, removed: 0, unchanged: 0 };
+                    for (const line of this.configTemplateDiffLines) {
+                        if (line && line.type === 'add') nextStats.added += 1;
+                        else if (line && line.type === 'del') nextStats.removed += 1;
+                        else nextStats.unchanged += 1;
+                    }
+                    this.configTemplateDiffStats = nextStats;
+                }
+                this.configTemplateDiffHasChangesValue = !!diff.hasChanges;
+                this.configTemplateDiffFingerprint = requestFingerprint;
+            } catch (_) {
+                if (this._configTemplateDiffPreviewRequestToken === requestToken) {
+                    this.configTemplateDiffError = '生成差异失败';
+                }
+            } finally {
+                if (this._configTemplateDiffPreviewRequestToken === requestToken) {
+                    this.configTemplateDiffLoading = false;
+                }
+            }
         },
 
         async applyConfigTemplate() {
@@ -639,6 +733,27 @@ export function createCodexConfigMethods(options = {}) {
             }
             if (!this.configTemplateContent || !this.configTemplateContent.trim()) {
                 this.showMessage('模板不能为空', 'error');
+                return;
+            }
+
+            if (!this.configTemplateDiffVisible) {
+                await this.prepareConfigTemplateDiff();
+                return;
+            }
+            if (this.configTemplateDiffLoading) {
+                return;
+            }
+            if (this.configTemplateDiffError) {
+                this.showMessage(this.configTemplateDiffError, 'error');
+                return;
+            }
+            const fingerprint = this.buildConfigTemplateDiffFingerprint();
+            if (this.configTemplateDiffFingerprint !== fingerprint) {
+                await this.prepareConfigTemplateDiff();
+                return;
+            }
+            if (!this.hasConfigTemplateDiffChanges()) {
+                this.showMessage('未检测到改动', 'info');
                 return;
             }
 

--- a/web-ui/modules/app.methods.codex-config.mjs
+++ b/web-ui/modules/app.methods.codex-config.mjs
@@ -329,7 +329,7 @@ export function createCodexConfigMethods(options = {}) {
         },
 
         buildDefaultHealthCheckPrompt() {
-            return '请简短回复：当前提供商连接正常。';
+            return '请简短回复：连接正常。';
         },
 
         openHealthCheckDialog(options = {}) {
@@ -337,6 +337,12 @@ export function createCodexConfigMethods(options = {}) {
                 ? options.providerName.trim()
                 : '';
             const locked = !!options.locked && !!providerName;
+            if (locked && providerName && providerName !== String(this.currentProvider || '').trim()) {
+                if (typeof this.showMessage === 'function') {
+                    this.showMessage('请先切换到该提供商再进行健康聊天测试', 'info');
+                }
+                return;
+            }
             const nextProvider = providerName
                 || String(this.healthCheckDialogSelectedProvider || '').trim()
                 || String(this.currentProvider || '').trim()
@@ -376,7 +382,7 @@ export function createCodexConfigMethods(options = {}) {
                 return;
             }
             if (!prompt) {
-                this.showMessage('请输入对话内容', 'error');
+                this.showMessage('请输入消息内容', 'error');
                 return;
             }
 
@@ -396,7 +402,7 @@ export function createCodexConfigMethods(options = {}) {
                 this.healthCheckDialogLastResult = res;
 
                 if (hasResponseError(res) || res.ok === false) {
-                    const message = getResponseMessage(res, '健康检测失败');
+                    const message = getResponseMessage(res, '健康聊天测试失败');
                     this.healthCheckDialogMessages.push({
                         id: `assistant-${Date.now()}`,
                         role: 'assistant',
@@ -413,7 +419,7 @@ export function createCodexConfigMethods(options = {}) {
 
                 const reply = typeof res.reply === 'string' && res.reply.trim()
                     ? res.reply.trim()
-                    : '已收到响应，但未解析到可展示文本。';
+                    : '已收到回复，但未解析到可展示文本。';
                 this.healthCheckDialogMessages.push({
                     id: `assistant-${Date.now()}`,
                     role: 'assistant',
@@ -426,7 +432,7 @@ export function createCodexConfigMethods(options = {}) {
                 });
                 this.healthCheckDialogPrompt = '';
             } catch (e) {
-                const message = e && e.message ? e.message : '健康检测失败';
+                const message = e && e.message ? e.message : '健康聊天测试失败';
                 this.healthCheckDialogMessages.push({
                     id: `assistant-${Date.now()}`,
                     role: 'assistant',

--- a/web-ui/modules/app.methods.codex-config.mjs
+++ b/web-ui/modules/app.methods.codex-config.mjs
@@ -104,19 +104,44 @@ export function createCodexConfigMethods(options = {}) {
             const previousModelsSource = this.modelsSource;
             const previousModelsHasCurrent = this.modelsHasCurrent;
             this.currentProvider = name;
-            await this.loadModelsForProvider(name);
-            if (this.modelsSource === 'error') {
-                // 允许切换到模型列表获取失败的提供商：有些 OpenAI 兼容服务不实现 /models，
-                // 或 /models 需要不同的鉴权。此时保持切换结果，让用户仍可手动输入/选择模型。
-                this.showMessage('模型列表获取失败，但已切换提供商；请检查 URL/密钥或手动设置模型', 'error');
-            }
+            const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+            // 不要把“切换提供商”强绑定到 /models 成功与否：
+            // 部分 OpenAI 兼容服务 /models 不可用或很慢，但用户仍希望一次点击即可完成切换。
+            // 这里做“短等待 + 后台补齐”：
+            // 1) 先启动 models 拉取（静默）
+            // 2) 给一个很短的窗口等待它完成，以便能立即选到第一个模型
+            // 3) 无论 models 是否成功，先应用 provider 切换
+            // 4) models 后续若补齐并发现当前 model 不在列表，则自动切到首个 model 并再应用一次
+            const modelsTask = this.loadModelsForProvider(name, { silentError: true })
+                .catch(() => {});
+
+            await Promise.race([modelsTask, delay(250)]);
+
             if (this.modelsSource === 'remote' && this.models.length > 0 && !this.models.includes(this.currentModel)) {
                 this.currentModel = this.models[0];
                 this.modelsHasCurrent = true;
             }
+
             if (getProviderConfigModeMeta(this.configMode)) {
                 await this.waitForCodexApplyIdle();
                 await this.applyCodexConfigDirect({ silent: true });
+            }
+
+            await modelsTask;
+
+            if (this.currentProvider === name) {
+                if (this.modelsSource === 'error') {
+                    this.showMessage('模型列表获取失败，但已切换提供商；请检查 URL/密钥或手动设置模型', 'error');
+                }
+                if (this.modelsSource === 'remote' && this.models.length > 0 && !this.models.includes(this.currentModel)) {
+                    this.currentModel = this.models[0];
+                    this.modelsHasCurrent = true;
+                    if (getProviderConfigModeMeta(this.configMode)) {
+                        await this.waitForCodexApplyIdle();
+                        await this.applyCodexConfigDirect({ silent: true });
+                    }
+                }
             }
         },
 

--- a/web-ui/modules/app.methods.providers.mjs
+++ b/web-ui/modules/app.methods.providers.mjs
@@ -141,11 +141,15 @@ export function createProvidersMethods(options = {}) {
             }
 
             try {
-                const res = await api('add-provider', {
+                const payload = {
                     name: validation.name,
                     url: validation.url,
                     key: this.newProvider.key || ''
-                });
+                };
+                if (this.newProvider && this.newProvider.useTransform) {
+                    payload.useTransform = true;
+                }
+                const res = await api('add-provider', payload);
                 if (res.error) {
                     this.showMessage(res.error, 'error');
                     return;
@@ -236,19 +240,50 @@ export function createProvidersMethods(options = {}) {
             }
         },
 
-        openEditModal(provider) {
+        async openEditModal(provider) {
+            const requestId = Symbol('openEditModal');
+            this._openEditModalRequestId = requestId;
             if (!this.shouldShowProviderEdit(provider)) {
                 this.showMessage('该 provider 为保留项，不可编辑', 'info');
                 return;
             }
+            const isTransformProvider = (() => {
+                if (!provider || typeof provider !== 'object') return false;
+                const bridge = typeof provider.codexmate_bridge === 'string' ? provider.codexmate_bridge.trim() : '';
+                if (bridge === 'openai') return true;
+                const url = String(provider.url || '');
+                return url.includes('/bridge/openai/');
+            })();
             this.editingProvider = {
                 name: provider.name,
                 url: normalizeProviderUrl(provider.url || ''),
                 key: '',
                 readOnly: !!provider.readOnly,
-                nonEditable: this.isNonDeletableProvider(provider)
+                nonEditable: typeof provider.nonEditable === 'boolean'
+                    ? provider.nonEditable
+                    : this.isNonDeletableProvider(provider),
+                useTransform: isTransformProvider
             };
             this.showEditModal = true;
+
+            if (isTransformProvider) {
+                try {
+                    const res = await api('openai-bridge-get-provider', { name: provider.name });
+                    if (
+                        this._openEditModalRequestId === requestId
+                        && this.showEditModal
+                        && this.editingProvider
+                        && this.editingProvider.name === provider.name
+                        && res && !res.error
+                        && typeof res.baseUrl === 'string'
+                        && res.baseUrl.trim()
+                    ) {
+                        this.editingProvider.url = normalizeProviderUrl(res.baseUrl);
+                    }
+                } catch (_) {
+                    // ignore
+                }
+            }
         },
 
         async updateProvider() {
@@ -264,6 +299,9 @@ export function createProvidersMethods(options = {}) {
             }
 
             const params = { name: validation.name, url: validation.url };
+            if (this.editingProvider && this.editingProvider.useTransform) {
+                params.useTransform = true;
+            }
             if (typeof this.editingProvider.key === 'string' && this.editingProvider.key.trim()) {
                 params.key = this.editingProvider.key;
             }
@@ -283,7 +321,7 @@ export function createProvidersMethods(options = {}) {
 
         closeEditModal() {
             this.showEditModal = false;
-            this.editingProvider = { name: '', url: '', key: '', readOnly: false, nonEditable: false };
+            this.editingProvider = { name: '', url: '', key: '', readOnly: false, nonEditable: false, useTransform: false };
         },
 
         async resetConfig() {
@@ -339,7 +377,7 @@ export function createProvidersMethods(options = {}) {
 
         closeAddModal() {
             this.showAddModal = false;
-            this.newProvider = { name: '', url: '', key: '' };
+            this.newProvider = { name: '', url: '', key: '', useTransform: false };
         },
 
         closeModelModal() {

--- a/web-ui/modules/app.methods.session-actions.mjs
+++ b/web-ui/modules/app.methods.session-actions.mjs
@@ -294,6 +294,7 @@ export function createSessionActionMethods(options = {}) {
             const baseUrl = typeof payload.baseUrl === 'string' ? payload.baseUrl.trim() : '';
             const apiKey = typeof payload.apiKey === 'string' ? payload.apiKey : '';
             const model = typeof payload.model === 'string' ? payload.model.trim() : '';
+            const bridge = typeof payload.bridge === 'string' ? payload.bridge.trim() : '';
             if (!name || !baseUrl) return '';
 
             const cli = this.getShareCommandPrefixInvocation();
@@ -301,9 +302,10 @@ export function createSessionActionMethods(options = {}) {
             const urlArg = this.quoteShellArg(baseUrl);
             const keyArg = apiKey ? this.quoteShellArg(apiKey) : '';
             const switchCmd = `${cli} switch ${nameArg}`;
+            const bridgeArgs = bridge ? ` --bridge ${this.quoteShellArg(bridge)}` : '';
             const addCmd = apiKey
-                ? `${cli} add ${nameArg} ${urlArg} ${keyArg}`
-                : `${cli} add ${nameArg} ${urlArg}`;
+                ? `${cli} add ${nameArg} ${urlArg} ${keyArg}${bridgeArgs}`
+                : `${cli} add ${nameArg} ${urlArg}${bridgeArgs}`;
             const modelCmd = model ? ` && ${cli} use ${this.quoteShellArg(model)}` : '';
             return `${addCmd} && ${switchCmd}${modelCmd}`;
         },

--- a/web-ui/partials/index/modal-config-template-agents.html
+++ b/web-ui/partials/index/modal-config-template-agents.html
@@ -4,21 +4,63 @@
 
                 <div class="form-group">
                     <label class="form-label">config.toml 模板</label>
+                    <div v-if="configTemplateDiffVisible" class="agents-diff-container">
+                        <div class="agents-diff-header">
+                            <div class="agents-diff-title">
+                                差异预览（config.toml）
+                                <span v-if="configTemplateDiffLoading" class="agents-diff-subtitle">生成中...</span>
+                                <span v-else-if="configTemplateDiffError" class="agents-diff-subtitle">生成失败</span>
+                                <span v-else-if="!configTemplateDiffHasChanges" class="agents-diff-subtitle">未检测到改动</span>
+                            </div>
+                            <div class="agents-diff-stats">
+                                <span class="agents-diff-stat add">+{{ configTemplateDiffStats.added || 0 }}</span>
+                                <span class="agents-diff-stat del">-{{ configTemplateDiffStats.removed || 0 }}</span>
+                                <span class="agents-diff-stat">={{ configTemplateDiffStats.unchanged || 0 }}</span>
+                            </div>
+                        </div>
+                        <div v-if="configTemplateDiffError" class="agents-diff-error">
+                            {{ configTemplateDiffError }}
+                        </div>
+                        <div v-else class="agents-diff-lines">
+                            <div
+                                v-for="(line, index) in configTemplateDiffLines"
+                                :key="line.key || (line.type + '-' + index)"
+                                :class="['agents-diff-line', line.type]">
+                                <span class="agents-diff-line-sign">
+                                    {{ line.type === 'add' ? '+' : (line.type === 'del' ? '-' : ' ') }}
+                                </span>
+                                <span class="agents-diff-line-text">{{ line.value }}</span>
+                            </div>
+                        </div>
+                    </div>
                     <textarea
+                        v-else
                         v-model="configTemplateContent"
                         class="form-input template-editor"
                         spellcheck="false"
-                        :readonly="configTemplateApplying"
+                        :readonly="configTemplateApplying || configTemplateDiffLoading"
+                        @input="onConfigTemplateContentInput"
                         placeholder="在这里编辑 config.toml 模板内容"></textarea>
                     <div class="template-editor-warning">
-                        工具不会自动改动 `config.toml`。只有点击“确认应用模板”后才写入。
+                        工具不会自动改动 `config.toml`。保存需两步：先点“确认”预览差异，再点“应用”写入。
+                        <div v-if="configTemplateDiffVisible && (configTemplateDiffLoading || configTemplateApplying)" class="agents-diff-hint">正在生成差异或应用中，操作暂不可用。</div>
+                        <div v-else-if="configTemplateDiffVisible && configTemplateDiffError" class="agents-diff-hint">差异预览失败，请返回编辑后重试。</div>
+                        <div v-else-if="configTemplateDiffVisible && !configTemplateDiffHasChanges" class="agents-diff-hint">未检测到改动，可返回编辑继续修改或取消退出。</div>
+                        <div v-else-if="configTemplateDiffVisible" class="agents-diff-hint">当前为预览模式，可点击“应用”写入或“返回编辑”继续修改。</div>
                     </div>
                 </div>
 
                 <div class="btn-group">
-                    <button class="btn btn-cancel" @click="closeConfigTemplateModal" :disabled="configTemplateApplying">取消</button>
-                    <button class="btn btn-confirm" @click="applyConfigTemplate" :disabled="configTemplateApplying">
-                        {{ configTemplateApplying ? '应用中...' : '确认应用模板' }}
+                    <button class="btn btn-cancel" @click="closeConfigTemplateModal" :disabled="configTemplateApplying || configTemplateDiffLoading">取消</button>
+                    <button
+                        v-if="configTemplateDiffVisible"
+                        class="btn"
+                        @click="resetConfigTemplateDiffState"
+                        :disabled="configTemplateApplying || configTemplateDiffLoading">
+                        返回编辑
+                    </button>
+                    <button class="btn btn-confirm" @click="applyConfigTemplate" :disabled="configTemplateApplying || configTemplateDiffLoading || (configTemplateDiffVisible && !configTemplateDiffHasChanges)">
+                        {{ configTemplateApplying ? (configTemplateDiffVisible ? '应用中...' : '确认中...') : (configTemplateDiffVisible ? '应用' : '确认') }}
                     </button>
                 </div>
             </div>

--- a/web-ui/partials/index/modal-health-check.html
+++ b/web-ui/partials/index/modal-health-check.html
@@ -2,8 +2,8 @@
             <div class="modal modal-wide health-check-dialog" role="dialog" aria-modal="true" aria-labelledby="health-check-dialog-title">
                 <div class="modal-header">
                     <div>
-                        <div class="modal-title" id="health-check-dialog-title">健康检测对话</div>
-                        <div class="health-check-dialog-subtitle">发一轮真实对话，直看可用性。</div>
+                        <div class="modal-title" id="health-check-dialog-title">健康聊天测试</div>
+                        <div class="health-check-dialog-subtitle">发一轮真实对话，快速确认可用性。</div>
                     </div>
                     <div v-if="healthCheckDialogLockedProvider" class="health-check-dialog-lock">
                         已锁定：{{ healthCheckDialogLockedProvider }}
@@ -59,13 +59,13 @@
                         :disabled="healthCheckDialogSending"
                         placeholder="例如：请回复“连接正常”。"
                         @keydown.ctrl.enter.prevent="sendHealthCheckDialogMessage"></textarea>
-                    <div class="form-hint">真实接口，单轮发送，不带历史。</div>
+                    <div class="form-hint">真实接口，单轮发送，不带历史上下文。</div>
                 </div>
 
                 <div class="btn-group">
                     <button class="btn btn-cancel" @click="closeHealthCheckDialog()" :disabled="healthCheckDialogSending">关闭</button>
                     <button class="btn btn-confirm" @click="sendHealthCheckDialogMessage" :disabled="healthCheckDialogSending">
-                        {{ healthCheckDialogSending ? '发送中...' : '发送检测' }}
+                        {{ healthCheckDialogSending ? '发送中...' : '发送测试' }}
                     </button>
                 </div>
             </div>

--- a/web-ui/partials/index/modals-basic.html
+++ b/web-ui/partials/index/modals-basic.html
@@ -29,6 +29,15 @@
                     <label class="form-label">认证密钥</label>
                     <input v-model="newProvider.key" class="form-input" type="password" placeholder="sk-...">
                 </div>
+                <div class="form-group">
+                    <label class="form-label">
+                        <input type="checkbox" v-model="newProvider.useTransform">
+                        使用内建转换（兼容 OpenAI 格式）
+                    </label>
+                    <div class="form-hint">
+                        开启后：写入的 <code>base_url</code> 会指向 Codex Mate 内建转换服务；Codex 使用的令牌固定为 <code>codexmate</code>。
+                    </div>
+                </div>
 
                 <div class="btn-group">
                     <button class="btn btn-cancel" @click="closeAddModal">取消</button>

--- a/web-ui/partials/index/panel-config-codex.html
+++ b/web-ui/partials/index/panel-config-codex.html
@@ -145,15 +145,6 @@
 
                 </template>
 
-                <div class="selector-section">
-                    <div class="selector-header">
-                        <span class="selector-title">健康检测</span>
-                    </div>
-                    <button class="btn-tool" @click="openHealthCheckDialog()" :disabled="loading || !!initError">
-                        检测对话
-                    </button>
-                </div>
-
                 <div v-if="!loading && !initError" class="card-list">
                     <div v-for="provider in displayProvidersList" :key="provider.name"
                          :class="['card', { active: displayCurrentProvider === provider.name }]"
@@ -183,7 +174,13 @@
                                 {{ formatLatency(speedResults[provider.name]) }}
                             </span>
                             <div class="card-actions" @click.stop>
-                                <button class="card-action-btn" @click="openHealthCheckDialog({ providerName: provider.name, locked: true })" :aria-label="`Open health dialog for ${provider.name}`" title="检测对话">
+                                <button
+                                    class="card-action-btn"
+                                    @click="openHealthCheckDialog({ providerName: provider.name, locked: true })"
+                                    :disabled="displayCurrentProvider !== provider.name"
+                                    :aria-label="`Open health dialog for ${provider.name}`"
+                                    :title="displayCurrentProvider === provider.name ? '健康聊天测试' : '请先切换到该提供商'"
+                                >
                                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                         <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                                         <path d="M8 9h8"/>


### PR DESCRIPTION
## Overview

This PR adds an optional OpenAI-compatible bridge mode for Codex providers.
When enabled, Codex traffic (Responses API) is routed through a local bridge,
which forwards to an OpenAI-compatible upstream (Chat Completions), while
keeping the existing default behavior unchanged.

It also includes several robustness and UX improvements discovered during
real-world provider testing (DashScope/Qwen, etc.).

## Key changes

### Provider bridging (optional)

- Adds a "Use transform (OpenAI-compatible)" toggle when creating a Codex
  provider.
- When enabled, `config.toml` is rewritten to point to the builtin bridge:
  - `http://127.0.0.1:<port>/bridge/openai/<provider>/v1`
- The Codex provider token in `config.toml` is set to a fixed value:
  - `codexmate`
- The upstream URL and API key are stored in:
  - `~/.codex/codexmate-openai-bridge.json`

### OpenAI bridge compatibility improvements

- Supports per-provider custom upstream headers (stored in the bridge JSON).
  Security-sensitive headers (e.g. `Authorization`, `Host`, hop-by-hop
  headers) are ignored.
- Prefers calling upstream `POST /v1/responses` when supported and falls back
  to `POST /v1/chat/completions` when the upstream does not implement
  `/responses` (404/405/501, or "not implemented" / `convert_request_failed`).
- Emits a more spec-aligned Responses SSE sequence so Codex reliably consumes
  streamed output:
  - `response.created`
  - `response.output_item.added`
  - `response.output_text.delta` / `response.output_text.done`
  - `response.output_item.done`
  - `response.completed`
  - `[DONE]`
- Maps Chat Completions `tool_calls` into Responses-style `function_call` items
  to keep tool chaining compatible.

### Web UI UX fixes

- Provider switching no longer auto-reverts when model list loading fails.
- Provider switching is now single-click even when `/models` is slow/unavailable
  (apply first, load models in the background).
- Config template editor now has a 2-step "Confirm → Apply" flow with a diff
  preview (mirrors the AGENTS.md editor workflow):
  - new backend action: `preview-config-template-diff`

## Testing

- `npm test` (all unit + e2e)
- Added unit coverage for:
  - upstream `/responses` preference + fallback behavior
  - 500 "not implemented" fallback behavior
  - SSE event structure expectations
  - provider switch regression behavior
  - config template diff confirmation flow
