### PR TITLE
feat(web-ui): add daily token chart

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9203,7 +9203,7 @@ async function restartWebUiServerAfterFrontendChange({
 // #endregion restartWebUiServerAfterFrontendChange
 
 // 打开 Web UI
-function cmdStart(options = {}) {
+async function cmdStart(options = {}) {
     const webDir = path.join(__dirname, 'web-ui');
     const newHtmlPath = path.join(webDir, 'index.html');
     const legacyHtmlPath = path.join(__dirname, 'web-ui.html');
@@ -9216,6 +9216,78 @@ function cmdStart(options = {}) {
 
     const port = resolveWebPort();
     const host = resolveWebHost(options);
+    const openHost = host === '::'
+        ? '::1'
+        : (host === '0.0.0.0' ? DEFAULT_WEB_OPEN_HOST : host);
+    const openUrl = `http://${formatHostForUrl(openHost)}:${port}`;
+
+    const probeExistingWebUi = async () => {
+        const payload = JSON.stringify({ action: 'health-check', params: {} });
+        const postReady = await new Promise((resolve) => {
+            const requestOptions = {
+                hostname: openHost,
+                port,
+                path: '/api',
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json; charset=utf-8',
+                    'Content-Length': Buffer.byteLength(payload, 'utf-8')
+                }
+            };
+            let settled = false;
+            const finish = (ready) => {
+                if (settled) return;
+                settled = true;
+                resolve(ready);
+            };
+            const req = http.request(requestOptions, (probeRes) => {
+                if (typeof probeRes.resume === 'function') {
+                    probeRes.resume();
+                }
+                probeRes.on('end', () => finish(probeRes.statusCode === 200));
+            });
+            req.on('error', () => finish(false));
+            req.setTimeout(800, () => {
+                try { req.destroy(); } catch (_) {}
+                finish(false);
+            });
+            req.end(payload, 'utf-8');
+        });
+        if (!postReady) return false;
+
+        return await new Promise((resolve) => {
+            const requestOptions = {
+                hostname: openHost,
+                port,
+                path: '/web-ui/app.js',
+                method: 'GET'
+            };
+            let settled = false;
+            const finish = (ready) => {
+                if (settled) return;
+                settled = true;
+                resolve(ready);
+            };
+            const req = http.request(requestOptions, (probeRes) => {
+                if (typeof probeRes.resume === 'function') {
+                    probeRes.resume();
+                }
+                probeRes.on('end', () => finish(probeRes.statusCode === 200));
+            });
+            req.on('error', () => finish(false));
+            req.setTimeout(800, () => {
+                try { req.destroy(); } catch (_) {}
+                finish(false);
+            });
+            req.end();
+        });
+    };
+
+    if (await probeExistingWebUi()) {
+        console.log(`\n✓ Web UI 已在运行: ${openUrl}\n`);
+        return;
+    }
+
     releaseRunPortIfNeeded(port, host);
 
     const isDev = process.env.NODE_ENV === 'development'
@@ -13379,7 +13451,7 @@ async function main() {
         case 'proxy': await cmdProxy(args.slice(1)); break;
         case 'workflow': await cmdWorkflow(args.slice(1)); break;
         case 'task': await cmdTask(args.slice(1)); break;
-        case 'run': cmdStart(parseStartOptions(args.slice(1))); break;
+        case 'run': await cmdStart(parseStartOptions(args.slice(1))); break;
         case 'start':
             console.error('错误: 命令已更名为 "run"，请使用: codexmate run');
             process.exit(1);

--- a/tests/unit/session-usage.test.mjs
+++ b/tests/unit/session-usage.test.mjs
@@ -40,6 +40,7 @@ test('buildUsageChartGroups aggregates codex and claude sessions into day bucket
     const lastBucket = result.buckets[result.buckets.length - 1];
     assert.strictEqual(lastBucket.codex, 1);
     assert.strictEqual(lastBucket.claude, 1);
+    assert.strictEqual(lastBucket.totalTokens, 350);
     assert.strictEqual(lastBucket.totalMessages, 12);
 });
 
@@ -57,6 +58,7 @@ test('buildUsageChartGroups ignores invalid sessions and keeps empty buckets sta
     assert.strictEqual(result.summary.totalContextWindow, 0);
     assert.strictEqual(result.buckets.length, 7);
     assert.ok(result.buckets.every((item) => item.totalSessions === 0));
+    assert.ok(result.buckets.every((item) => item.totalTokens === 0));
     assert.ok(result.hourActivity.every((item) => item.count === 0));
     assert.ok(result.weekdayActivity.every((item) => item.count === 0));
     assert.deepStrictEqual(result.recentSessions, []);

--- a/web-ui/logic.sessions.mjs
+++ b/web-ui/logic.sessions.mjs
@@ -190,6 +190,7 @@ function buildUsageBuckets(normalizedSessions, options = {}) {
                 label: key.slice(5),
                 codex: 0,
                 claude: 0,
+                totalTokens: 0,
                 totalMessages: 0,
                 totalSessions: 0
             });
@@ -206,6 +207,7 @@ function buildUsageBuckets(normalizedSessions, options = {}) {
             label: key.slice(5),
             codex: 0,
             claude: 0,
+            totalTokens: 0,
             totalMessages: 0,
             totalSessions: 0
         });
@@ -287,6 +289,7 @@ export function buildUsageChartGroups(sessions = [], options = {}) {
             ? Math.max(0, Math.floor(Number(session.contextWindow)))
             : 0;
         bucket.totalSessions += 1;
+        bucket.totalTokens += sessionTotalTokens;
         bucket.totalMessages += messageCount;
         if (source === 'codex') {
             bucket.codex += 1;
@@ -428,6 +431,7 @@ export function buildUsageChartGroups(sessions = [], options = {}) {
 
     const maxSessionBucket = buckets.reduce((max, item) => Math.max(max, item.totalSessions), 0);
     const maxMessageBucket = buckets.reduce((max, item) => Math.max(max, item.totalMessages), 0);
+    const maxTokenBucket = buckets.reduce((max, item) => Math.max(max, item.totalTokens || 0), 0);
     const maxHourCount = hourCounts.reduce((max, item) => Math.max(max, item.count), 0);
     const maxWeekdayCount = weekdayCounts.reduce((max, item) => Math.max(max, item.count), 0);
     const busiestDay = [...buckets]
@@ -489,6 +493,7 @@ export function buildUsageChartGroups(sessions = [], options = {}) {
         })),
         maxSessionBucket,
         maxMessageBucket,
+        maxTokenBucket,
         maxHourCount,
         maxWeekdayCount
     };

--- a/web-ui/partials/index/panel-usage.html
+++ b/web-ui/partials/index/panel-usage.html
@@ -60,6 +60,18 @@
                             </section>
 
                             <section class="usage-card">
+                                <div class="usage-card-title">Token 趋势</div>
+                                <div class="usage-bars">
+                                    <div v-for="bucket in sessionUsageCharts.buckets" :key="bucket.key + '-tokens'" class="usage-bar-group">
+                                        <div class="usage-bar-stack">
+                                            <div class="usage-bar tokens" style="width:100%" :style="{ height: ((bucket.totalTokens / Math.max(sessionUsageCharts.maxTokenBucket, 1)) * 100) + '%' }" :title="`${bucket.totalTokens.toLocaleString('en-US')} token`"></div>
+                                        </div>
+                                        <div class="usage-bar-label">{{ bucket.label }}</div>
+                                    </div>
+                                </div>
+                            </section>
+
+                            <section class="usage-card">
                                 <div class="usage-card-title">活跃时段</div>
                                 <div class="usage-mini-bars">
                                     <div v-for="item in sessionUsageCharts.hourActivity" :key="item.key" class="usage-mini-bar-group">

--- a/web-ui/styles/sessions-usage.css
+++ b/web-ui/styles/sessions-usage.css
@@ -243,6 +243,10 @@
     background: #8b6bd6;
 }
 
+.usage-bar.tokens {
+    background: linear-gradient(180deg, rgba(199, 116, 98, 0.84) 0%, rgba(180, 94, 78, 1) 100%);
+}
+
 .usage-bar-label {
     font-size: 11px;
     color: var(--color-text-secondary);


### PR DESCRIPTION
- Add token totals to usage day buckets and render Token 趋势 chart
- When Web UI is already running, cmdStart prints the URL and skips auto-opening a browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added startup check to detect when the Web UI is already running; the server will reuse the existing instance instead of starting a new one.
  * Introduced a new "Token Trend" usage card to the dashboard, visualizing token consumption patterns over time with styled visual bars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->