### PR TITLE
feat(claude): add CLAUDE.md editor

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -24,6 +24,7 @@ Codex Mate is a local-first CLI + Web UI for unified management of:
 
 - Codex provider/model switching and config writes
 - Claude Code profiles (writes to `~/.claude/settings.json`)
+- Claude Code `CLAUDE.md` editing (writes to `~/.claude/CLAUDE.md`)
 - OpenClaw JSON5 profiles and workspace `AGENTS.md`
 - Local skills market for Codex / Claude Code (target switching, local skills management, cross-app import, ZIP distribution)
 - Local Codex/Claude sessions (list/filter/export/delete) with Usage analytics overview
@@ -48,6 +49,7 @@ It works on local files directly and does not require cloud hosting. The skills 
 - Provider/model switching (`switch`, `use`)
 - Codex `config.toml` template confirmation before write
 - Claude Code profile management and apply
+- Claude Code `CLAUDE.md` editing (writes to `~/.claude/CLAUDE.md`)
 - OpenClaw JSON5 profile management
 
 **Session Management**
@@ -91,7 +93,7 @@ flowchart LR
 
     subgraph Files["Local files only (auditable & reversible)"]
       CODEX["~/.codex/*"]
-      CLAUDE["~/.claude/settings.json"]
+      CLAUDE["~/.claude/settings.json + CLAUDE.md"]
       OPENCLAW["~/.openclaw/*.json5 + ~/.openclaw/openclaw.json + workspace/AGENTS.md"]
       SKILLS["~/.{codex,claude,agents}/skills"]
       STATE["sessions / usage / trash / runs"]
@@ -116,7 +118,7 @@ flowchart LR
 
 | Capability | Local target | What you get |
 | --- | --- | --- |
-| Config management (Codex / Claude / OpenClaw) | `~/.codex/*`, `~/.claude/settings.json`, `~/.openclaw/*` | Faster provider/model switching, multi-profile management, safer writes with backups |
+| Config management (Codex / Claude / OpenClaw) | `~/.codex/*`, `~/.claude/settings.json`, `~/.claude/CLAUDE.md`, `~/.openclaw/*` | Faster provider/model switching, multi-profile management, safer writes with backups |
 | Sessions & Usage | sessions / usage aggregates / trash | Quickly locate sessions, filter/export, batch cleanup, and view trends |
 | Skills market | `~/.{codex,claude,agents}/skills` | Local install/import/export (ZIP), cross-app reuse |
 | MCP (stdio) | local API + file operations | Integrate with external tools under controllable permissions (read-only by default) |
@@ -205,6 +207,7 @@ codexmate codex --model gpt-5.3-codex --follow-up "step1" --follow-up "step2"
 ### Claude Code Mode
 - Multi-profile management
 - Default write to `~/.claude/settings.json`
+- `~/.claude/CLAUDE.md` editing
 - Shareable import command copy
 
 ### OpenClaw Mode
@@ -247,6 +250,7 @@ codexmate mcp serve --allow-write
 - `~/.codex/models.json`
 - `~/.codex/provider-current-models.json`
 - `~/.claude/settings.json`
+- `~/.claude/CLAUDE.md`
 - `~/.openclaw/openclaw.json`
 - `~/.openclaw/workspace/AGENTS.md`
 
@@ -278,6 +282,7 @@ Apache-2.0
 ### Claude Code Mode
 - Multi-profile management
 - Default write to `~/.claude/settings.json`
+- `~/.claude/CLAUDE.md` editing
 - Shareable import command copy
 
 ### OpenClaw Mode
@@ -320,6 +325,7 @@ codexmate mcp serve --allow-write
 - `~/.codex/models.json`
 - `~/.codex/provider-current-models.json`
 - `~/.claude/settings.json`
+- `~/.claude/CLAUDE.md`
 - `~/.openclaw/openclaw.json`
 - `~/.openclaw/workspace/AGENTS.md`
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Codex Mate 提供一套本地优先的 CLI + Web UI，用于统一管理：
 
 - Codex 的 provider / model 切换与配置写入
 - Claude Code 配置方案（写入 `~/.claude/settings.json`）
+- Claude Code `CLAUDE.md` 编辑（写入 `~/.claude/CLAUDE.md`）
 - OpenClaw JSON5 配置与 Workspace `AGENTS.md`
 - Codex / Claude Code Skills 市场（安装目标切换、本地 skills 管理、跨应用导入、ZIP 分发）
 - Codex / Claude 本地会话浏览、筛选、导出、删除与 Usage 统计概览
@@ -49,6 +50,7 @@ Codex Mate 提供一套本地优先的 CLI + Web UI，用于统一管理：
 - provider / model 切换（`switch` / `use`）
 - Codex `config.toml` 模板确认后写入
 - Claude Code 多配置方案管理与一键应用
+- Claude Code `CLAUDE.md` 编辑（写入 `~/.claude/CLAUDE.md`）
 - 分享命令前缀切换（`npm start` / `codexmate`），用于复制 provider / Claude 导入命令，选择持久化到浏览器本地缓存
 - OpenClaw JSON5 配置方案管理
 
@@ -94,7 +96,7 @@ flowchart LR
 
     subgraph Files["只操作你的本地文件（可审计/可回滚）"]
       CODEX["~/.codex/*"]
-      CLAUDE["~/.claude/settings.json"]
+      CLAUDE["~/.claude/settings.json + CLAUDE.md"]
       OPENCLAW["~/.openclaw/*.json5 + ~/.openclaw/openclaw.json + workspace/AGENTS.md"]
       SKILLS["~/.{codex,claude,agents}/skills"]
       SESSFILES["sessions / usage / trash / runs"]
@@ -119,7 +121,7 @@ flowchart LR
 
 | 能力 | 作用对象（本地） | 你能直接得到什么 |
 | --- | --- | --- |
-| 配置管理（Codex / Claude / OpenClaw） | `~/.codex/*`、`~/.claude/settings.json`、`~/.openclaw/*` | 一键切换 provider/model、管理多套配置、写入前后可控与可回滚 |
+| 配置管理（Codex / Claude / OpenClaw） | `~/.codex/*`、`~/.claude/settings.json`、`~/.claude/CLAUDE.md`、`~/.openclaw/*` | 一键切换 provider/model、管理多套配置、写入前后可控与可回滚 |
 | 会话与 Usage | sessions / usage 聚合 / trash | 更快定位会话、筛选导出、批量清理、查看趋势与占比 |
 | Skills 市场 | `~/.{codex,claude,agents}/skills` | 本地安装/导入/导出/分发（ZIP），跨应用复用更省事 |
 | MCP（stdio） | 本地 API / 文件能力 | 让外部工具以“可控权限”调用本地能力（默认只读） |
@@ -206,6 +208,7 @@ codexmate codex --model gpt-5.3-codex --follow-up "步骤1" --follow-up "步骤2
 ### Claude Code 配置模式
 - 多配置方案管理
 - 默认写入 `~/.claude/settings.json`
+- `~/.claude/CLAUDE.md` 编辑
 - 支持复制分享导入命令
 
 ### OpenClaw 配置模式
@@ -255,6 +258,7 @@ codexmate mcp serve --allow-write
 - `~/.codex/models.json`
 - `~/.codex/provider-current-models.json`
 - `~/.claude/settings.json`
+- `~/.claude/CLAUDE.md`
 - `~/.openclaw/openclaw.json`
 - `~/.openclaw/workspace/AGENTS.md`
 

--- a/cli.js
+++ b/cli.js
@@ -179,6 +179,7 @@ const OPENCLAW_AUTH_PROFILES_FILE_NAME = 'auth-profiles.json';
 const OPENCLAW_AUTH_STATE_FILE_NAME = 'auth-state.json';
 const CLAUDE_DIR = path.join(os.homedir(), '.claude');
 const CLAUDE_SETTINGS_FILE = path.join(CLAUDE_DIR, 'settings.json');
+const CLAUDE_MD_FILE_NAME = 'CLAUDE.md';
 const CLAUDE_PROJECTS_DIR = path.join(os.homedir(), '.claude', 'projects');
 const RECENT_CONFIGS_FILE = path.join(CONFIG_DIR, 'recent-configs.json');
 const WORKFLOW_DEFINITIONS_FILE = path.join(CONFIG_DIR, 'codexmate-workflows.json');
@@ -1425,6 +1426,9 @@ async function fetchProviderModels(providerName, overrides = {}) {
 const {
     resolveAgentsFilePath,
     validateAgentsBaseDir,
+    resolveClaudeMdFilePath,
+    readClaudeMdFile,
+    applyClaudeMdFile,
     readAgentsFile,
     applyAgentsFile,
     normalizeDiffText,
@@ -1433,6 +1437,7 @@ const {
     fs,
     path,
     os,
+    ensureDir,
     stripUtf8Bom,
     detectLineEnding,
     normalizeLineEnding,
@@ -1440,6 +1445,8 @@ const {
     buildLineDiff,
     CONFIG_DIR,
     AGENTS_FILE_NAME,
+    CLAUDE_DIR,
+    CLAUDE_MD_FILE_NAME,
     readOpenclawAgentsFile() {
         return readOpenclawAgentsFile(...arguments);
     },
@@ -8537,6 +8544,12 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                             break;
                         case 'apply-agents-file':
                             result = applyAgentsFile(params || {});
+                            break;
+                        case 'get-claude-md-file':
+                            result = readClaudeMdFile(params || {});
+                            break;
+                        case 'apply-claude-md-file':
+                            result = applyClaudeMdFile(params || {});
                             break;
                         case 'preview-agents-diff':
                             result = buildAgentsDiff(params || {});

--- a/cli/agents-files.js
+++ b/cli/agents-files.js
@@ -3,6 +3,7 @@ function createAgentsFileController(deps = {}) {
         fs,
         path,
         os,
+        ensureDir,
         stripUtf8Bom,
         detectLineEnding,
         normalizeLineEnding,
@@ -10,6 +11,8 @@ function createAgentsFileController(deps = {}) {
         buildLineDiff,
         CONFIG_DIR,
         AGENTS_FILE_NAME,
+        CLAUDE_DIR,
+        CLAUDE_MD_FILE_NAME,
         readOpenclawAgentsFile,
         readOpenclawWorkspaceFile
     } = deps;
@@ -17,6 +20,7 @@ function createAgentsFileController(deps = {}) {
     if (!fs) throw new Error('createAgentsFileController 缺少 fs');
     if (!path) throw new Error('createAgentsFileController 缺少 path');
     if (!os) throw new Error('createAgentsFileController 缺少 os');
+    if (typeof ensureDir !== 'function') throw new Error('createAgentsFileController 缺少 ensureDir');
     if (typeof stripUtf8Bom !== 'function') throw new Error('createAgentsFileController 缺少 stripUtf8Bom');
     if (typeof detectLineEnding !== 'function') throw new Error('createAgentsFileController 缺少 detectLineEnding');
     if (typeof normalizeLineEnding !== 'function') throw new Error('createAgentsFileController 缺少 normalizeLineEnding');
@@ -24,6 +28,8 @@ function createAgentsFileController(deps = {}) {
     if (typeof buildLineDiff !== 'function') throw new Error('createAgentsFileController 缺少 buildLineDiff');
     if (typeof CONFIG_DIR !== 'string' || !CONFIG_DIR) throw new Error('createAgentsFileController 缺少 CONFIG_DIR');
     if (typeof AGENTS_FILE_NAME !== 'string' || !AGENTS_FILE_NAME) throw new Error('createAgentsFileController 缺少 AGENTS_FILE_NAME');
+    if (typeof CLAUDE_DIR !== 'string' || !CLAUDE_DIR) throw new Error('createAgentsFileController 缺少 CLAUDE_DIR');
+    if (typeof CLAUDE_MD_FILE_NAME !== 'string' || !CLAUDE_MD_FILE_NAME) throw new Error('createAgentsFileController 缺少 CLAUDE_MD_FILE_NAME');
     if (typeof readOpenclawAgentsFile !== 'function') throw new Error('createAgentsFileController 缺少 readOpenclawAgentsFile');
     if (typeof readOpenclawWorkspaceFile !== 'function') throw new Error('createAgentsFileController 缺少 readOpenclawWorkspaceFile');
 
@@ -45,6 +51,57 @@ function createAgentsFileController(deps = {}) {
             return { error: `目标目录不存在: ${dirPath}` };
         }
         return { ok: true, dirPath };
+    }
+
+    function resolveClaudeMdFilePath() {
+        return path.join(CLAUDE_DIR, CLAUDE_MD_FILE_NAME);
+    }
+
+    function readClaudeMdFile(params = {}) {
+        const filePath = resolveClaudeMdFilePath();
+        const lineEndingFallback = os.EOL === '\r\n' ? '\r\n' : '\n';
+        if (!fs.existsSync(filePath)) {
+            return {
+                exists: false,
+                path: filePath,
+                content: '',
+                lineEnding: lineEndingFallback
+            };
+        }
+        if (params.metaOnly) {
+            return {
+                exists: true,
+                path: filePath,
+                content: '',
+                lineEnding: lineEndingFallback
+            };
+        }
+        try {
+            const raw = fs.readFileSync(filePath, 'utf-8');
+            return {
+                exists: true,
+                path: filePath,
+                content: stripUtf8Bom(raw),
+                lineEnding: detectLineEnding(raw)
+            };
+        } catch (e) {
+            return { error: `读取 CLAUDE.md 失败: ${e.message}` };
+        }
+    }
+
+    function applyClaudeMdFile(params = {}) {
+        const filePath = resolveClaudeMdFilePath();
+        const content = typeof params.content === 'string' ? params.content : '';
+        const lineEnding = params.lineEnding === '\r\n' ? '\r\n' : '\n';
+        const normalized = normalizeLineEnding(content, lineEnding);
+        const finalContent = ensureUtf8Bom(normalized);
+        try {
+            ensureDir(CLAUDE_DIR);
+            fs.writeFileSync(filePath, finalContent, 'utf-8');
+            return { success: true, path: filePath };
+        } catch (e) {
+            return { error: `写入 CLAUDE.md 失败: ${e.message}` };
+        }
     }
 
     function readAgentsFile(params = {}) {
@@ -116,7 +173,9 @@ function createAgentsFileController(deps = {}) {
         const context = contextRaw || 'codex';
         const metaOnly = hasBaseContent;
         let readResult;
-        if (context === 'openclaw') {
+        if (context === 'claude-md') {
+            readResult = readClaudeMdFile({ metaOnly });
+        } else if (context === 'openclaw') {
             readResult = readOpenclawAgentsFile({ metaOnly });
         } else if (context === 'openclaw-workspace') {
             readResult = readOpenclawWorkspaceFile({ ...params, metaOnly });
@@ -150,6 +209,9 @@ function createAgentsFileController(deps = {}) {
     return {
         resolveAgentsFilePath,
         validateAgentsBaseDir,
+        resolveClaudeMdFilePath,
+        readClaudeMdFile,
+        applyClaudeMdFile,
         readAgentsFile,
         applyAgentsFile,
         normalizeDiffText,

--- a/tests/unit/web-ui-behavior-parity.test.mjs
+++ b/tests/unit/web-ui-behavior-parity.test.mjs
@@ -441,7 +441,8 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'stopTaskOrchestrationPolling',
         'syncTaskOrchestrationPolling',
         'resetTaskOrchestrationDraft',
-        'appendTaskWorkflowId'
+        'appendTaskWorkflowId',
+        'openClaudeMdEditor'
     ];
     allowedExtraCurrentMethodKeys.push(
         'resetConfigTemplateDiffState',

--- a/web-ui/modules/app.methods.agents.mjs
+++ b/web-ui/modules/app.methods.agents.mjs
@@ -36,6 +36,38 @@ export function createAgentsMethods(options = {}) {
     } = options;
 
     return {
+        async openClaudeMdEditor() {
+            this.setAgentsModalContext('claude-md');
+            const requestToken = issueLatestRequestToken(this, '_agentsOpenRequestToken');
+            this.agentsLoading = true;
+            try {
+                const res = await api('get-claude-md-file');
+                if (!isLatestRequestToken(this, '_agentsOpenRequestToken', requestToken)) {
+                    return;
+                }
+                if (res.error) {
+                    this.showMessage(res.error, 'error');
+                    return;
+                }
+                this.agentsContent = res.content || '';
+                this.agentsOriginalContent = this.agentsContent;
+                this.agentsPath = res.path || '';
+                this.agentsExists = !!res.exists;
+                this.agentsLineEnding = res.lineEnding === '\r\n' ? '\r\n' : '\n';
+                this.resetAgentsDiffState();
+                this.showAgentsModal = true;
+            } catch (e) {
+                if (!isLatestRequestToken(this, '_agentsOpenRequestToken', requestToken)) {
+                    return;
+                }
+                this.showMessage('加载文件失败', 'error');
+            } finally {
+                if (isLatestRequestToken(this, '_agentsOpenRequestToken', requestToken)) {
+                    this.agentsLoading = false;
+                }
+            }
+        },
+
         async openAgentsEditor() {
             this.setAgentsModalContext('codex');
             const requestToken = issueLatestRequestToken(this, '_agentsOpenRequestToken');
@@ -148,6 +180,13 @@ export function createAgentsMethods(options = {}) {
         },
 
         setAgentsModalContext(context, options = {}) {
+            if (context === 'claude-md') {
+                this.agentsContext = 'claude-md';
+                this.agentsWorkspaceFileName = '';
+                this.agentsModalTitle = 'CLAUDE.md 编辑器';
+                this.agentsModalHint = '保存后会写入 ~/.claude/CLAUDE.md。';
+                return;
+            }
             if (context === 'openclaw-workspace') {
                 const fileName = (options.fileName || this.openclawWorkspaceFileName || 'AGENTS.md').trim();
                 this.agentsContext = 'openclaw-workspace';
@@ -467,7 +506,9 @@ export function createAgentsMethods(options = {}) {
                     content: this.agentsContent,
                     lineEnding: this.agentsLineEnding
                 };
-                if (this.agentsContext === 'openclaw') {
+                if (this.agentsContext === 'claude-md') {
+                    action = 'apply-claude-md-file';
+                } else if (this.agentsContext === 'openclaw') {
                     action = 'apply-openclaw-agents-file';
                 } else if (this.agentsContext === 'openclaw-workspace') {
                     action = 'apply-openclaw-workspace-file';
@@ -480,7 +521,9 @@ export function createAgentsMethods(options = {}) {
                 }
                 const successLabel = this.agentsContext === 'openclaw-workspace'
                     ? `工作区文件已保存${this.agentsWorkspaceFileName ? `: ${this.agentsWorkspaceFileName}` : ''}`
-                    : (this.agentsContext === 'openclaw' ? 'OpenClaw AGENTS.md 已保存' : 'AGENTS.md 已保存');
+                    : (this.agentsContext === 'claude-md'
+                        ? 'CLAUDE.md 已保存'
+                        : (this.agentsContext === 'openclaw' ? 'OpenClaw AGENTS.md 已保存' : 'AGENTS.md 已保存'));
                 this.showMessage(successLabel, 'success');
                 this.closeAgentsModal({ force: true });
             } catch (e) {

--- a/web-ui/partials/index/panel-config-claude.html
+++ b/web-ui/partials/index/panel-config-claude.html
@@ -76,6 +76,18 @@
                     </button>
                 </div>
 
+                <div class="selector-section">
+                    <div class="selector-header">
+                        <span class="selector-title">CLAUDE.md</span>
+                    </div>
+                    <button class="btn-tool" @click="openClaudeMdEditor" :disabled="loading || !!initError || agentsLoading">
+                        {{ agentsLoading ? '加载中...' : '打开 CLAUDE.md' }}
+                    </button>
+                    <div class="config-template-hint">
+                        读写 <code>~/.claude/CLAUDE.md</code>。
+                    </div>
+                </div>
+
                 <div class="card-list">
                     <div v-for="(config, name) in claudeConfigs" :key="name"
                          :class="['card', { active: currentClaudeConfig === name }]"


### PR DESCRIPTION
## What
- In **Claude** config tab, add an entry to open/edit `~/.claude/CLAUDE.md` (UI style aligned with the existing AGENTS.md editor).
- Backend supports read/write for `~/.claude/CLAUDE.md` and reuses the existing diff preview pipeline.

## Notes
- README (CN/EN) updated to document this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to open and edit a new local configuration file directly within Claude Code's Web UI, providing an additional configuration management option.

* **Documentation**
  * Updated documentation to reflect the new editable configuration file and its default storage location, and updated feature diagrams accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->