### PR TITLE
fix: import skills cli edge cases

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -13163,6 +13163,37 @@ async function cmdMcp(args = []) {
     });
 }
 
+function printMainHelp() {
+    console.log('\nCodex Mate - Codex 提供商管理工具');
+    console.log('\n用法:');
+    console.log('  codexmate status           显示当前状态');
+    console.log('  codexmate doctor [--format json|md] [--lang zh|en] [--output <PATH>]  输出诊断报告');
+    console.log('  codexmate import-skills <URL> [--target-app codex|claude] [--name <NAME>] [--timeout-ms <MS>]  从 URL 导入 skills');
+    console.log('  codexmate setup            交互式配置向导');
+    console.log('  codexmate list             列出所有提供商');
+    console.log('  codexmate models           列出所有模型');
+    console.log('  codexmate switch <名称>    切换提供商');
+    console.log('  codexmate use <模型>       切换模型');
+    console.log('  codexmate add <名称> <URL> [密钥] [--bridge <openai>]');
+    console.log('  codexmate delete <名称>    删除提供商');
+    console.log('  codexmate claude <BaseURL> <API密钥> [模型]  写入 Claude Code 配置');
+    console.log('  codexmate auth <list|import|switch|delete|status>  认证管理');
+    console.log('  codexmate add-model <模型> 添加模型');
+    console.log('  codexmate delete-model <模型> 删除模型');
+    console.log('  codexmate workflow <list|get|validate|run|runs>  MCP 工作流中心');
+    console.log('  codexmate task <plan|run|runs|queue|retry|cancel|logs>  本地任务编排');
+    console.log('  codexmate run [--host <HOST>] [--no-browser]    启动 Web 界面');
+    console.log('  codexmate codex [参数...] [--follow-up <文本>|--queued-follow-up <文本> 可重复]  等同于 codex --yolo');
+    console.log('    注: follow-up 自动排队仅支持 linux/android/netbsd/openbsd/darwin/freebsd 且 stdin 必须是 TTY，其他平台会报错');
+    console.log('  codexmate qwen [参数...]   等同于 qwen --yolo');
+    console.log('  codexmate mcp [serve] [--transport stdio] [--allow-write|--read-only]');
+    console.log('  codexmate export-session --source <codex|claude> (--session-id <ID>|--file <PATH>) [--output <PATH>] [--max-messages <N|all|Infinity>]');
+    console.log('  codexmate zip <路径> [--max:级别]  压缩（系统 zip 优先，其次 zip-lib）');
+    console.log('  codexmate unzip <zip文件> [输出目录]  解压（zip-lib）');
+    console.log('  codexmate unzip-ext <zip目录> [输出目录] [--ext:后缀[,后缀...]] [--no-recursive]  批量提取 ZIP 指定后缀文件（默认递归）');
+    console.log('');
+}
+
 // ============================================================================
 // 主程序
 // ============================================================================
@@ -13178,35 +13209,8 @@ async function main() {
         }
     }
 
-    if (args.length === 0) {
-        console.log('\nCodex Mate - Codex 提供商管理工具');
-        console.log('\n用法:');
-        console.log('  codexmate status           显示当前状态');
-        console.log('  codexmate doctor [--format json|md] [--lang zh|en] [--output <PATH>]  输出诊断报告');
-        console.log('  codexmate import-skills <URL> [--target-app codex|claude] [--name <NAME>] [--timeout-ms <MS>]  从 URL 导入 skills');
-        console.log('  codexmate setup            交互式配置向导');
-        console.log('  codexmate list             列出所有提供商');
-        console.log('  codexmate models           列出所有模型');
-        console.log('  codexmate switch <名称>    切换提供商');
-        console.log('  codexmate use <模型>       切换模型');
-        console.log('  codexmate add <名称> <URL> [密钥] [--bridge <openai>]');
-        console.log('  codexmate delete <名称>    删除提供商');
-        console.log('  codexmate claude <BaseURL> <API密钥> [模型]  写入 Claude Code 配置');
-        console.log('  codexmate auth <list|import|switch|delete|status>  认证管理');
-        console.log('  codexmate add-model <模型> 添加模型');
-        console.log('  codexmate delete-model <模型> 删除模型');
-        console.log('  codexmate workflow <list|get|validate|run|runs>  MCP 工作流中心');
-        console.log('  codexmate task <plan|run|runs|queue|retry|cancel|logs>  本地任务编排');
-        console.log('  codexmate run [--host <HOST>] [--no-browser]    启动 Web 界面');
-        console.log('  codexmate codex [参数...] [--follow-up <文本>|--queued-follow-up <文本> 可重复]  等同于 codex --yolo');
-        console.log('    注: follow-up 自动排队仅支持 linux/android/netbsd/openbsd/darwin/freebsd 且 stdin 必须是 TTY，其他平台会报错');
-        console.log('  codexmate qwen [参数...]   等同于 qwen --yolo');
-        console.log('  codexmate mcp [serve] [--transport stdio] [--allow-write|--read-only]');
-        console.log('  codexmate export-session --source <codex|claude> (--session-id <ID>|--file <PATH>) [--output <PATH>] [--max-messages <N|all|Infinity>]');
-        console.log('  codexmate zip <路径> [--max:级别]  压缩（系统 zip 优先，其次 zip-lib）');
-        console.log('  codexmate unzip <zip文件> [输出目录]  解压（zip-lib）');
-        console.log('  codexmate unzip-ext <zip目录> [输出目录] [--ext:后缀[,后缀...]] [--no-recursive]  批量提取 ZIP 指定后缀文件（默认递归）');
-        console.log('');
+    if (args.length === 0 || command === '--help' || command === '-h' || command === 'help') {
+        printMainHelp();
         process.exit(0);
     }
 

--- a/cli.js
+++ b/cli.js
@@ -6513,6 +6513,7 @@ async function cmdDoctor(argv = []) {
             ? renderDoctorMarkdown(report)
             : JSON.stringify(report, null, 2);
         if (options.output) {
+            ensureDir(path.dirname(options.output));
             fs.writeFileSync(options.output, text);
         } else {
             process.stdout.write(text + '\n');

--- a/cli/import-skills-url.js
+++ b/cli/import-skills-url.js
@@ -33,6 +33,40 @@ function resolveGithubArchiveZipUrl(inputUrl) {
     return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/archive/refs/heads/${encodeURIComponent(ref)}.zip`;
 }
 
+function buildGithubArchiveZipCandidates(inputUrl) {
+    const raw = typeof inputUrl === 'string' ? inputUrl.trim() : '';
+    if (!raw) return [];
+    let parsed;
+    try {
+        parsed = new URL(raw);
+    } catch (_) {
+        return [];
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return [];
+    }
+    if (parsed.hostname !== 'github.com') {
+        return [];
+    }
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length < 2) return [];
+    const owner = parts[0];
+    const repo = (parts[1] || '').endsWith('.git') ? parts[1].slice(0, -4) : parts[1];
+    if (!owner || !repo) return [];
+    const base = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/archive/refs`;
+    if (parts[2] === 'tree' && parts[3]) {
+        const ref = encodeURIComponent(parts[3]);
+        return [
+            `${base}/heads/${ref}.zip`,
+            `${base}/tags/${ref}.zip`
+        ];
+    }
+    return [
+        `${base}/heads/main.zip`,
+        `${base}/heads/master.zip`
+    ];
+}
+
 function redactUrlForLog(inputUrl) {
     const raw = typeof inputUrl === 'string' ? inputUrl.trim() : '';
     if (!raw) return '';
@@ -147,19 +181,44 @@ function downloadUrlToFile(targetUrl, filePath, options = {}) {
     });
 }
 
+function extractHttpStatusFromError(err) {
+    const message = err && err.message ? String(err.message) : '';
+    const matched = message.match(/\bHTTP\s+(\d{3})\b/);
+    if (!matched) return 0;
+    const value = Number(matched[1]);
+    return Number.isFinite(value) ? value : 0;
+}
+
+function printImportSkillsUsage() {
+    process.stdout.write('\n用法:\n');
+    process.stdout.write('  codexmate import-skills <URL> [--target-app codex|claude] [--name <NAME>] [--timeout-ms <MS>]\n');
+    process.stdout.write('\n示例:\n');
+    process.stdout.write('  codexmate import-skills https://github.com/<owner>/<repo>\n');
+    process.stdout.write('  codexmate import-skills https://github.com/<owner>/<repo>/tree/dev\n');
+    process.stdout.write('  codexmate import-skills https://github.com/<owner>/<repo>/archive/refs/heads/main.zip\n');
+}
+
 function parseImportSkillsCommandArgs(argv = []) {
     const options = {
         url: '',
         targetApp: 'codex',
         name: '',
-        timeoutMs: 30000
+        timeoutMs: 30000,
+        help: false
     };
-    if (argv[0] && !String(argv[0]).startsWith('--')) {
-        options.url = String(argv[0]).trim();
-    }
-    let cursor = 1;
+    let cursor = 0;
     while (cursor < argv.length) {
         const token = String(argv[cursor] || '');
+        if (token && !token.startsWith('--') && !options.url) {
+            options.url = token.trim();
+            cursor += 1;
+            continue;
+        }
+        if (token === '--help' || token === '-h') {
+            options.help = true;
+            cursor += 1;
+            continue;
+        }
         if (token === '--target-app') {
             const value = String(argv[cursor + 1] || '').trim().toLowerCase();
             if (!value || value.startsWith('--')) {
@@ -189,40 +248,77 @@ function parseImportSkillsCommandArgs(argv = []) {
         }
         cursor += 1;
     }
-    if (!options.url) {
-        throw new Error('错误: 缺少 URL（例如: https://github.com/<owner>/<repo>/archive/refs/heads/main.zip）');
-    }
     return options;
 }
 
 async function cmdImportSkills(argv = []) {
     const options = parseImportSkillsCommandArgs(argv);
-    const resolvedGithubUrl = resolveGithubArchiveZipUrl(options.url);
-    const zipUrl = resolvedGithubUrl || options.url;
-    if (!isValidHttpUrl(zipUrl)) {
+    if (options.help) {
+        printImportSkillsUsage();
+        return;
+    }
+    if (!options.url || options.url.trim().startsWith('--')) {
+        printImportSkillsUsage();
+        throw new Error('错误: 缺少 URL（例如: https://github.com/<owner>/<repo>/archive/refs/heads/main.zip）');
+    }
+
+    const candidates = [];
+    const githubCandidates = buildGithubArchiveZipCandidates(options.url);
+    if (githubCandidates.length) {
+        candidates.push(...githubCandidates);
+    } else {
+        const resolvedGithubUrl = resolveGithubArchiveZipUrl(options.url);
+        candidates.push(resolvedGithubUrl || options.url);
+    }
+    const uniqueCandidates = Array.from(new Set(candidates.filter(Boolean)));
+    if (!uniqueCandidates.length || !uniqueCandidates.every(isValidHttpUrl)) {
         throw new Error('错误: URL 非法（仅支持 http/https）');
     }
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codexmate-skills-url-'));
     const zipPath = path.join(tempDir, 'skills.zip');
-    const fallbackName = options.name || path.basename(new URL(zipUrl).pathname) || 'skills.zip';
-
-    console.log(`\n[Skills] Download: ${redactUrlForLog(zipUrl)}`);
-    await downloadUrlToFile(zipUrl, zipPath, {
-        maxBytes: MAX_SKILLS_ZIP_UPLOAD_SIZE,
-        timeoutMs: options.timeoutMs,
-        maxRedirects: 5
-    });
-    const result = await importSkillsFromZipFile(zipPath, {
-        tempDir,
-        targetApp: options.targetApp,
-        fallbackName
-    });
-    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    let lastError = null;
+    let finalUrl = uniqueCandidates[0];
+    try {
+        for (const candidateUrl of uniqueCandidates) {
+            finalUrl = candidateUrl;
+            console.log(`\n[Skills] Download: ${redactUrlForLog(candidateUrl)}`);
+            try {
+                await downloadUrlToFile(candidateUrl, zipPath, {
+                    maxBytes: MAX_SKILLS_ZIP_UPLOAD_SIZE,
+                    timeoutMs: options.timeoutMs,
+                    maxRedirects: 5
+                });
+                lastError = null;
+                break;
+            } catch (e) {
+                lastError = e;
+                const status = extractHttpStatusFromError(e);
+                if (status === 404) {
+                    continue;
+                }
+                throw e;
+            }
+        }
+        if (lastError) {
+            throw lastError;
+        }
+        const fallbackName = options.name || path.basename(new URL(finalUrl).pathname) || 'skills.zip';
+        const result = await importSkillsFromZipFile(zipPath, {
+            tempDir,
+            targetApp: options.targetApp,
+            fallbackName
+        });
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    } finally {
+        try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        } catch (_) {}
+    }
 }
 
 module.exports = {
     resolveGithubArchiveZipUrl,
+    buildGithubArchiveZipCandidates,
     cmdImportSkills
 };
-

--- a/cli/import-skills-url.js
+++ b/cli/import-skills-url.js
@@ -78,6 +78,14 @@ function redactUrlForLog(inputUrl) {
     }
 }
 
+function extractHttpStatusFromError(err) {
+    const message = err && err.message ? String(err.message) : '';
+    const matched = message.match(/\bHTTP\s+(\d{3})\b/);
+    if (!matched) return 0;
+    const value = Number(matched[1]);
+    return Number.isFinite(value) ? value : 0;
+}
+
 function downloadUrlToFile(targetUrl, filePath, options = {}) {
     const maxBytes = Number.isFinite(options.maxBytes) && options.maxBytes > 0
         ? Math.floor(options.maxBytes)
@@ -181,14 +189,6 @@ function downloadUrlToFile(targetUrl, filePath, options = {}) {
     });
 }
 
-function extractHttpStatusFromError(err) {
-    const message = err && err.message ? String(err.message) : '';
-    const matched = message.match(/\bHTTP\s+(\d{3})\b/);
-    if (!matched) return 0;
-    const value = Number(matched[1]);
-    return Number.isFinite(value) ? value : 0;
-}
-
 function printImportSkillsUsage() {
     process.stdout.write('\n用法:\n');
     process.stdout.write('  codexmate import-skills <URL> [--target-app codex|claude] [--name <NAME>] [--timeout-ms <MS>]\n');
@@ -261,12 +261,8 @@ async function cmdImportSkills(argv = []) {
         printImportSkillsUsage();
         throw new Error('错误: 缺少 URL（例如: https://github.com/<owner>/<repo>/archive/refs/heads/main.zip）');
     }
-
-    const candidates = [];
-    const githubCandidates = buildGithubArchiveZipCandidates(options.url);
-    if (githubCandidates.length) {
-        candidates.push(...githubCandidates);
-    } else {
+    const candidates = buildGithubArchiveZipCandidates(options.url);
+    if (!candidates.length) {
         const resolvedGithubUrl = resolveGithubArchiveZipUrl(options.url);
         candidates.push(resolvedGithubUrl || options.url);
     }
@@ -277,9 +273,9 @@ async function cmdImportSkills(argv = []) {
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codexmate-skills-url-'));
     const zipPath = path.join(tempDir, 'skills.zip');
-    let lastError = null;
     let finalUrl = uniqueCandidates[0];
     try {
+        let lastError = null;
         for (const candidateUrl of uniqueCandidates) {
             finalUrl = candidateUrl;
             console.log(`\n[Skills] Download: ${redactUrlForLog(candidateUrl)}`);
@@ -293,8 +289,7 @@ async function cmdImportSkills(argv = []) {
                 break;
             } catch (e) {
                 lastError = e;
-                const status = extractHttpStatusFromError(e);
-                if (status === 404) {
+                if (extractHttpStatusFromError(e) === 404) {
                     continue;
                 }
                 throw e;

--- a/cli/import-skills-url.js
+++ b/cli/import-skills-url.js
@@ -6,6 +6,14 @@ const https = require('https');
 const { isValidHttpUrl } = require('../lib/cli-utils');
 const { MAX_SKILLS_ZIP_UPLOAD_SIZE, importSkillsFromZipFile } = require('./skills');
 
+function decodeUrlPathPart(part) {
+    try {
+        return decodeURIComponent(part);
+    } catch (_) {
+        return part;
+    }
+}
+
 function parseGithubRepoFromUrl(inputUrl) {
     const raw = typeof inputUrl === 'string' ? inputUrl.trim() : '';
     if (!raw) return null;
@@ -21,7 +29,7 @@ function parseGithubRepoFromUrl(inputUrl) {
     if (parsed.hostname !== 'github.com') {
         return null;
     }
-    const parts = parsed.pathname.split('/').filter(Boolean);
+    const parts = parsed.pathname.split('/').filter(Boolean).map(decodeUrlPathPart);
     if (parts.length < 2) return null;
     const owner = parts[0];
     const repoPart = parts[1] || '';
@@ -38,12 +46,19 @@ function buildGithubArchiveZipBase(repoInfo) {
     return `https://github.com/${encodeURIComponent(repoInfo.owner)}/${encodeURIComponent(repoInfo.repo)}/archive/refs`;
 }
 
+function encodeGithubRefPath(ref) {
+    return String(ref || '')
+        .split('/')
+        .map(part => encodeURIComponent(part))
+        .join('/');
+}
+
 function resolveGithubArchiveZipUrl(inputUrl) {
     const repoInfo = parseGithubRepoFromUrl(inputUrl);
     if (!repoInfo) return '';
     const base = buildGithubArchiveZipBase(repoInfo);
     const ref = repoInfo.ref || 'main';
-    return `${base}/heads/${encodeURIComponent(ref)}.zip`;
+    return `${base}/heads/${encodeGithubRefPath(ref)}.zip`;
 }
 
 function buildGithubArchiveZipCandidates(inputUrl) {
@@ -51,7 +66,7 @@ function buildGithubArchiveZipCandidates(inputUrl) {
     if (!repoInfo) return [];
     const base = buildGithubArchiveZipBase(repoInfo);
     if (repoInfo.ref) {
-        const ref = encodeURIComponent(repoInfo.ref);
+        const ref = encodeGithubRefPath(repoInfo.ref);
         return [
             `${base}/heads/${ref}.zip`,
             `${base}/tags/${ref}.zip`
@@ -256,7 +271,7 @@ async function cmdImportSkills(argv = []) {
         printImportSkillsUsage();
         return;
     }
-    if (!options.url || options.url.trim().startsWith('--')) {
+    if (!options.url) {
         printImportSkillsUsage();
         throw new Error('错误: 缺少 URL（例如: https://github.com/<owner>/<repo>/archive/refs/heads/main.zip）');
     }

--- a/cli/import-skills-url.js
+++ b/cli/import-skills-url.js
@@ -6,56 +6,52 @@ const https = require('https');
 const { isValidHttpUrl } = require('../lib/cli-utils');
 const { MAX_SKILLS_ZIP_UPLOAD_SIZE, importSkillsFromZipFile } = require('./skills');
 
-function resolveGithubArchiveZipUrl(inputUrl) {
+function parseGithubRepoFromUrl(inputUrl) {
     const raw = typeof inputUrl === 'string' ? inputUrl.trim() : '';
-    if (!raw) return '';
+    if (!raw) return null;
     let parsed;
     try {
         parsed = new URL(raw);
     } catch (_) {
-        return '';
+        return null;
     }
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return '';
+        return null;
     }
     if (parsed.hostname !== 'github.com') {
-        return '';
+        return null;
     }
     const parts = parsed.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) return '';
+    if (parts.length < 2) return null;
     const owner = parts[0];
-    const repo = (parts[1] || '').endsWith('.git') ? parts[1].slice(0, -4) : parts[1];
-    if (!owner || !repo) return '';
-    let ref = 'main';
-    if (parts[2] === 'tree' && parts[3]) {
-        ref = parts[3];
-    }
-    return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/archive/refs/heads/${encodeURIComponent(ref)}.zip`;
+    const repoPart = parts[1] || '';
+    const repo = repoPart.endsWith('.git') ? repoPart.slice(0, -4) : repoPart;
+    if (!owner || !repo) return null;
+    const ref = parts[2] === 'tree' && parts[3]
+        ? parts.slice(3).join('/')
+        : '';
+    return { owner, repo, ref };
+}
+
+function buildGithubArchiveZipBase(repoInfo) {
+    if (!repoInfo || !repoInfo.owner || !repoInfo.repo) return '';
+    return `https://github.com/${encodeURIComponent(repoInfo.owner)}/${encodeURIComponent(repoInfo.repo)}/archive/refs`;
+}
+
+function resolveGithubArchiveZipUrl(inputUrl) {
+    const repoInfo = parseGithubRepoFromUrl(inputUrl);
+    if (!repoInfo) return '';
+    const base = buildGithubArchiveZipBase(repoInfo);
+    const ref = repoInfo.ref || 'main';
+    return `${base}/heads/${encodeURIComponent(ref)}.zip`;
 }
 
 function buildGithubArchiveZipCandidates(inputUrl) {
-    const raw = typeof inputUrl === 'string' ? inputUrl.trim() : '';
-    if (!raw) return [];
-    let parsed;
-    try {
-        parsed = new URL(raw);
-    } catch (_) {
-        return [];
-    }
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-        return [];
-    }
-    if (parsed.hostname !== 'github.com') {
-        return [];
-    }
-    const parts = parsed.pathname.split('/').filter(Boolean);
-    if (parts.length < 2) return [];
-    const owner = parts[0];
-    const repo = (parts[1] || '').endsWith('.git') ? parts[1].slice(0, -4) : parts[1];
-    if (!owner || !repo) return [];
-    const base = `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/archive/refs`;
-    if (parts[2] === 'tree' && parts[3]) {
-        const ref = encodeURIComponent(parts[3]);
+    const repoInfo = parseGithubRepoFromUrl(inputUrl);
+    if (!repoInfo) return [];
+    const base = buildGithubArchiveZipBase(repoInfo);
+    if (repoInfo.ref) {
+        const ref = encodeURIComponent(repoInfo.ref);
         return [
             `${base}/heads/${ref}.zip`,
             `${base}/tags/${ref}.zip`
@@ -209,19 +205,19 @@ function parseImportSkillsCommandArgs(argv = []) {
     let cursor = 0;
     while (cursor < argv.length) {
         const token = String(argv[cursor] || '');
-        if (token && !token.startsWith('--') && !options.url) {
-            options.url = token.trim();
-            cursor += 1;
-            continue;
-        }
         if (token === '--help' || token === '-h') {
             options.help = true;
             cursor += 1;
             continue;
         }
+        if (token && !token.startsWith('-') && !options.url) {
+            options.url = token.trim();
+            cursor += 1;
+            continue;
+        }
         if (token === '--target-app') {
             const value = String(argv[cursor + 1] || '').trim().toLowerCase();
-            if (!value || value.startsWith('--')) {
+            if (!value || value.startsWith('-')) {
                 throw new Error('错误: --target-app 需要一个值（codex/claude）');
             }
             options.targetApp = value === 'claude' ? 'claude' : 'codex';
@@ -230,7 +226,7 @@ function parseImportSkillsCommandArgs(argv = []) {
         }
         if (token === '--name') {
             const value = String(argv[cursor + 1] || '').trim();
-            if (!value || value.startsWith('--')) {
+            if (!value || value.startsWith('-')) {
                 throw new Error('错误: --name 需要一个值');
             }
             options.name = value;
@@ -246,7 +242,10 @@ function parseImportSkillsCommandArgs(argv = []) {
             cursor += 2;
             continue;
         }
-        cursor += 1;
+        if (token.startsWith('-')) {
+            throw new Error(`错误: 未知参数: ${token}`);
+        }
+        throw new Error(`错误: 多余参数: ${token}`);
     }
     return options;
 }
@@ -313,6 +312,7 @@ async function cmdImportSkills(argv = []) {
 }
 
 module.exports = {
+    parseGithubRepoFromUrl,
     resolveGithubArchiveZipUrl,
     buildGithubArchiveZipCandidates,
     cmdImportSkills

--- a/tests/unit/cli-help.test.mjs
+++ b/tests/unit/cli-help.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'assert';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const cliPath = path.join(__dirname, '..', '..', 'cli.js');
+
+function runCli(args = []) {
+    return spawnSync(process.execPath, [cliPath, ...args], {
+        cwd: path.join(__dirname, '..', '..'),
+        encoding: 'utf-8'
+    });
+}
+
+test('top-level help flags print usage and exit successfully', () => {
+    for (const args of [[], ['--help'], ['-h'], ['help']]) {
+        const result = runCli(args);
+        assert.strictEqual(result.status, 0, `args ${args.join(' ')} stderr: ${result.stderr}`);
+        assert.match(result.stdout, /Codex Mate/);
+        assert.match(result.stdout, /codexmate import-skills/);
+        assert.equal(result.stderr, '');
+    }
+});

--- a/tests/unit/cli-help.test.mjs
+++ b/tests/unit/cli-help.test.mjs
@@ -20,6 +20,6 @@ test('top-level help flags print usage and exit successfully', () => {
         assert.strictEqual(result.status, 0, `args ${args.join(' ')} stderr: ${result.stderr}`);
         assert.match(result.stdout, /Codex Mate/);
         assert.match(result.stdout, /codexmate import-skills/);
-        assert.equal(result.stderr, '');
+        assert.doesNotMatch(result.stderr, /error|exception/i);
     }
 });

--- a/tests/unit/import-skills-url.test.mjs
+++ b/tests/unit/import-skills-url.test.mjs
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { resolveGithubArchiveZipUrl, buildGithubArchiveZipCandidates } = require('../../cli/import-skills-url');
+const { resolveGithubArchiveZipUrl, buildGithubArchiveZipCandidates, cmdImportSkills } = require('../../cli/import-skills-url');
 
 assert.equal(
     resolveGithubArchiveZipUrl('https://github.com/foo/bar'),
@@ -32,3 +32,13 @@ assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tre
     'https://github.com/foo/bar/archive/refs/tags/dev.zip'
 ]);
 assert.deepEqual(buildGithubArchiveZipCandidates('https://example.com/foo/bar'), []);
+
+let captured = '';
+const originalWrite = process.stdout.write;
+process.stdout.write = (chunk) => {
+    captured += String(chunk || '');
+    return true;
+};
+await cmdImportSkills(['--help']);
+process.stdout.write = originalWrite;
+assert.ok(captured.includes('codexmate import-skills'));

--- a/tests/unit/import-skills-url.test.mjs
+++ b/tests/unit/import-skills-url.test.mjs
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { resolveGithubArchiveZipUrl } = require('../../cli/import-skills-url');
+const { resolveGithubArchiveZipUrl, buildGithubArchiveZipCandidates } = require('../../cli/import-skills-url');
 
 assert.equal(
     resolveGithubArchiveZipUrl('https://github.com/foo/bar'),
@@ -23,3 +23,12 @@ assert.equal(
 assert.equal(resolveGithubArchiveZipUrl('https://example.com/foo/bar.zip'), '');
 assert.equal(resolveGithubArchiveZipUrl('not a url'), '');
 
+assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar'), [
+    'https://github.com/foo/bar/archive/refs/heads/main.zip',
+    'https://github.com/foo/bar/archive/refs/heads/master.zip'
+]);
+assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tree/dev'), [
+    'https://github.com/foo/bar/archive/refs/heads/dev.zip',
+    'https://github.com/foo/bar/archive/refs/tags/dev.zip'
+]);
+assert.deepEqual(buildGithubArchiveZipCandidates('https://example.com/foo/bar'), []);

--- a/tests/unit/import-skills-url.test.mjs
+++ b/tests/unit/import-skills-url.test.mjs
@@ -39,7 +39,11 @@ assert.equal(
 );
 assert.equal(
     resolveGithubArchiveZipUrl('https://github.com/foo/bar/tree/feature/x'),
-    'https://github.com/foo/bar/archive/refs/heads/feature%2Fx.zip'
+    'https://github.com/foo/bar/archive/refs/heads/feature/x.zip'
+);
+assert.equal(
+    resolveGithubArchiveZipUrl('https://github.com/foo/bar/tree/release candidate/x'),
+    'https://github.com/foo/bar/archive/refs/heads/release%20candidate/x.zip'
 );
 assert.equal(resolveGithubArchiveZipUrl('https://example.com/foo/bar.zip'), '');
 assert.equal(resolveGithubArchiveZipUrl('not a url'), '');
@@ -53,8 +57,12 @@ assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tre
     'https://github.com/foo/bar/archive/refs/tags/dev.zip'
 ]);
 assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tree/feature/x'), [
-    'https://github.com/foo/bar/archive/refs/heads/feature%2Fx.zip',
-    'https://github.com/foo/bar/archive/refs/tags/feature%2Fx.zip'
+    'https://github.com/foo/bar/archive/refs/heads/feature/x.zip',
+    'https://github.com/foo/bar/archive/refs/tags/feature/x.zip'
+]);
+assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tree/release candidate/x'), [
+    'https://github.com/foo/bar/archive/refs/heads/release%20candidate/x.zip',
+    'https://github.com/foo/bar/archive/refs/tags/release%20candidate/x.zip'
 ]);
 assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar.git'), [
     'https://github.com/foo/bar/archive/refs/heads/main.zip',

--- a/tests/unit/import-skills-url.test.mjs
+++ b/tests/unit/import-skills-url.test.mjs
@@ -2,7 +2,24 @@ import assert from 'assert';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
-const { resolveGithubArchiveZipUrl, buildGithubArchiveZipCandidates, cmdImportSkills } = require('../../cli/import-skills-url');
+const {
+    parseGithubRepoFromUrl,
+    resolveGithubArchiveZipUrl,
+    buildGithubArchiveZipCandidates,
+    cmdImportSkills
+} = require('../../cli/import-skills-url');
+
+assert.deepEqual(parseGithubRepoFromUrl('https://github.com/foo/bar/tree/feature/x'), {
+    owner: 'foo',
+    repo: 'bar',
+    ref: 'feature/x'
+});
+assert.deepEqual(parseGithubRepoFromUrl('https://github.com/foo/bar.git'), {
+    owner: 'foo',
+    repo: 'bar',
+    ref: ''
+});
+assert.equal(parseGithubRepoFromUrl('not a url'), null);
 
 assert.equal(
     resolveGithubArchiveZipUrl('https://github.com/foo/bar'),
@@ -20,6 +37,10 @@ assert.equal(
     resolveGithubArchiveZipUrl('https://github.com/foo/bar/tree/dev'),
     'https://github.com/foo/bar/archive/refs/heads/dev.zip'
 );
+assert.equal(
+    resolveGithubArchiveZipUrl('https://github.com/foo/bar/tree/feature/x'),
+    'https://github.com/foo/bar/archive/refs/heads/feature%2Fx.zip'
+);
 assert.equal(resolveGithubArchiveZipUrl('https://example.com/foo/bar.zip'), '');
 assert.equal(resolveGithubArchiveZipUrl('not a url'), '');
 
@@ -31,7 +52,20 @@ assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tre
     'https://github.com/foo/bar/archive/refs/heads/dev.zip',
     'https://github.com/foo/bar/archive/refs/tags/dev.zip'
 ]);
+assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/tree/feature/x'), [
+    'https://github.com/foo/bar/archive/refs/heads/feature%2Fx.zip',
+    'https://github.com/foo/bar/archive/refs/tags/feature%2Fx.zip'
+]);
+assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar.git'), [
+    'https://github.com/foo/bar/archive/refs/heads/main.zip',
+    'https://github.com/foo/bar/archive/refs/heads/master.zip'
+]);
+assert.deepEqual(buildGithubArchiveZipCandidates('https://github.com/foo/bar/'), [
+    'https://github.com/foo/bar/archive/refs/heads/main.zip',
+    'https://github.com/foo/bar/archive/refs/heads/master.zip'
+]);
 assert.deepEqual(buildGithubArchiveZipCandidates('https://example.com/foo/bar'), []);
+assert.deepEqual(buildGithubArchiveZipCandidates('not a url'), []);
 
 let captured = '';
 const originalWrite = process.stdout.write;
@@ -42,3 +76,32 @@ process.stdout.write = (chunk) => {
 await cmdImportSkills(['--help']);
 process.stdout.write = originalWrite;
 assert.ok(captured.includes('codexmate import-skills'));
+
+captured = '';
+process.stdout.write = (chunk) => {
+    captured += String(chunk || '');
+    return true;
+};
+await cmdImportSkills(['-h']);
+process.stdout.write = originalWrite;
+assert.ok(captured.includes('codexmate import-skills'));
+
+await assert.rejects(
+    () => cmdImportSkills(['--bogus']),
+    /未知参数: --bogus/
+);
+
+await assert.rejects(
+    () => cmdImportSkills(['-x']),
+    /未知参数: -x/
+);
+
+await assert.rejects(
+    () => cmdImportSkills(['--target-app', '-h', 'https://github.com/foo/bar']),
+    /--target-app 需要一个值/
+);
+
+await assert.rejects(
+    () => cmdImportSkills(['https://github.com/foo/bar', 'https://github.com/foo/baz']),
+    /多余参数: https:\/\/github\.com\/foo\/baz/
+);

--- a/tests/unit/run.mjs
+++ b/tests/unit/run.mjs
@@ -25,6 +25,7 @@ await import(pathToFileURL(path.join(__dirname, 'compact-layout-ui.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'web-ui-source-bundle.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'startup-claude-star-prompt.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'install-methods.test.mjs')));
+await import(pathToFileURL(path.join(__dirname, 'cli-help.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'cli-network-utils.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'config-health-module.test.mjs')));
 await import(pathToFileURL(path.join(__dirname, 'openclaw-core.test.mjs')));


### PR DESCRIPTION
## Summary
- Fix import-skills help handling and cleanup on download failures
- Add GitHub archive fallback candidates (main/master, heads/tags)
- Ensure doctor --output creates parent directories

## Tests
- npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import command: added help flag handling and improved GitHub archive resolution with multiple candidate attempts and guaranteed temp-file cleanup on failure

* **Bug Fixes**
  * Doctor command now creates missing output directories before writing files to prevent write failures

* **Tests**
  * Added and expanded unit tests to cover CLI help behavior, GitHub URL parsing/candidates, and import command error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->