### PR TITLE
fix: harden remote endpoints, SSRF, and DoS limits

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -10,6 +10,7 @@ const yauzl = require('yauzl');
 const { exec, execSync, spawn, spawnSync } = require('child_process');
 const http = require('http');
 const https = require('https');
+const net = require('net');
 const readline = require('readline');
 const {
     expandHomePath,
@@ -7315,18 +7316,55 @@ function cmdClaude(baseUrl, apiKey, model, silent = false) {
 function commandExists(command, args = '') {
     const cmd = typeof command === 'string' ? command.trim() : '';
     const argText = typeof args === 'string' ? args.trim() : '';
-    if (!cmd || !/^[A-Za-z0-9._-]+$/.test(cmd)) {
+    if (!cmd || cmd.includes('\0') || /[\r\n]/.test(cmd)) {
         return false;
     }
-    if (argText && /[\r\n;&|<>`$]/.test(argText)) {
-        return false;
+    const argv = argText ? argText.split(/\s+/g).filter(Boolean) : [];
+    const hasSeparators = cmd.includes('/') || cmd.includes('\\');
+    const useShell = process.platform === 'win32' && !hasSeparators;
+    if (useShell) {
+        if (!/^[A-Za-z0-9._-]+$/.test(cmd)) return false;
+        if (argText && /[\r\n;&|<>`$]/.test(argText)) return false;
     }
     try {
-        execSync(`${cmd}${argText ? ` ${argText}` : ''}`, { stdio: 'ignore', shell: process.platform === 'win32' });
-        return true;
-    } catch (e) {
+        const probe = spawnSync(cmd, argv, {
+            stdio: 'ignore',
+            windowsHide: true,
+            timeout: 5000,
+            shell: useShell
+        });
+        return probe.status === 0;
+    } catch (_) {
         return false;
     }
+}
+
+function isPrivateNetworkHost(hostname) {
+    const host = typeof hostname === 'string' ? hostname.trim().toLowerCase() : '';
+    if (!host) return true;
+    if (host === 'localhost') return true;
+    const ipVer = net.isIP(host);
+    if (!ipVer) {
+        return false;
+    }
+    if (ipVer === 4) {
+        const parts = host.split('.').map((x) => parseInt(x, 10));
+        if (parts.length !== 4 || parts.some((x) => !Number.isFinite(x))) return true;
+        const [a, b] = parts;
+        if (a === 10) return true;
+        if (a === 127) return true;
+        if (a === 169 && b === 254) return true;
+        if (a === 192 && b === 168) return true;
+        if (a === 172 && b >= 16 && b <= 31) return true;
+        return false;
+    }
+    if (ipVer === 6) {
+        if (host === '::1') return true;
+        if (host.startsWith('fe80:')) return true;
+        if (host.startsWith('fc') || host.startsWith('fd')) return true;
+        return false;
+    }
+    return false;
 }
 
 function detectPreferredPackageManager() {
@@ -8643,6 +8681,20 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                                 if (!baseUrl) {
                                     result = { error: 'Base URL is required' };
                                 } else {
+                                    const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+                                    const requesterIsLoopback = !remoteAddr
+                                        || remoteAddr === '127.0.0.1'
+                                        || remoteAddr === '::1'
+                                        || remoteAddr === '::ffff:127.0.0.1';
+                                    if (!requesterIsLoopback) {
+                                        try {
+                                            const parsedUrl = new URL(baseUrl);
+                                            if (isPrivateNetworkHost(parsedUrl.hostname || '')) {
+                                                result = { error: 'Refusing to access private network baseUrl from non-loopback request' };
+                                                break;
+                                            }
+                                        } catch (_) {}
+                                    }
                                     const res = await fetchModelsFromBaseUrl(baseUrl, apiKey);
                                     if (res.error) {
                                         result = { error: res.error, models: [], source: 'remote' };
@@ -9230,7 +9282,14 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                 });
                 return;
             }
-
+            const allowLegacy = process.env.CODEXMATE_ALLOW_LEGACY_DOWNLOAD === '1';
+            const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+            const isLoopback = !remoteAddr || remoteAddr === '127.0.0.1' || remoteAddr === '::1' || remoteAddr === '::ffff:127.0.0.1';
+            if (!allowLegacy || !isLoopback) {
+                res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+                res.end('Not Found');
+                return;
+            }
             const tempDir = os.tmpdir();
             const legacyFilePath = path.join(tempDir, decodedFileName);
             if (!isPathInside(legacyFilePath, tempDir)) {
@@ -9304,8 +9363,12 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
         }
         console.log('  退出: Ctrl+C\n');
         if (isAnyAddressHost(host)) {
-            console.warn('! 安全提示: 当前监听所有网卡（无鉴权）。');
-            console.warn('  建议仅在可信网络使用，或改用 --host 127.0.0.1。');
+            const tokenEnabled = typeof process.env.CODEXMATE_HTTP_TOKEN === 'string' && process.env.CODEXMATE_HTTP_TOKEN.trim().length > 0;
+            console.warn(`! 安全提示: 当前监听所有网卡（${tokenEnabled ? '已启用鉴权' : '无鉴权'}）。`);
+            if (!tokenEnabled) {
+                console.warn('  建议仅在可信网络使用，或改用 --host 127.0.0.1。');
+                console.warn('  如需远程访问，请设置 CODEXMATE_HTTP_TOKEN。');
+            }
         }
 
         if (willOpenBrowser) {

--- a/cli.js
+++ b/cli.js
@@ -285,7 +285,7 @@ const HTTPS_KEEP_ALIVE_AGENT = new https.Agent({ keepAlive: true });
 
 const openaiBridgeHandler = createOpenaiBridgeHttpHandler({
     settingsFile: OPENAI_BRIDGE_SETTINGS_FILE,
-    expectedToken: 'codexmate',
+    expectedToken: typeof process.env.CODEXMATE_HTTP_TOKEN === 'string' ? process.env.CODEXMATE_HTTP_TOKEN.trim() : '',
     maxBodySize: MAX_API_BODY_SIZE,
     httpAgent: HTTP_KEEP_ALIVE_AGENT,
     httpsAgent: HTTPS_KEEP_ALIVE_AGENT
@@ -7964,7 +7964,7 @@ function writeJsonResponse(res, statusCode, payload) {
 function readJsonRequestBody(req, res, options = {}) {
     const maxBytes = Number.isFinite(options.maxBytes) ? Math.max(1024, Math.floor(options.maxBytes)) : MAX_API_BODY_SIZE;
     return new Promise((resolve) => {
-        let body = '';
+        const chunks = [];
         let bodySize = 0;
         let bodyTooLarge = false;
         req.on('data', (chunk) => {
@@ -7979,12 +7979,14 @@ function readJsonRequestBody(req, res, options = {}) {
                 resolve({ ok: false, error: 'payload-too-large' });
                 return;
             }
-            body += chunk;
+            chunks.push(chunk);
         });
         req.on('end', () => {
             if (bodyTooLarge) return;
+            const rawBuffer = chunks.length ? Buffer.concat(chunks) : Buffer.alloc(0);
+            const rawText = rawBuffer.length ? rawBuffer.toString('utf-8') : '';
             try {
-                resolve({ ok: true, body: JSON.parse(body || '{}') });
+                resolve({ ok: true, body: JSON.parse(rawText || '{}'), rawText, rawBuffer });
             } catch (error) {
                 resolve({ ok: false, error: error && error.message ? error.message : 'invalid json' });
             }
@@ -8064,6 +8066,25 @@ function rememberWebhookDeliveryId(value, ttlMs = 10 * 60 * 1000) {
     return { ok: true, seen: false };
 }
 
+function safeTimingEqual(a, b) {
+    try {
+        const ba = Buffer.isBuffer(a) ? a : Buffer.from(String(a || ''), 'utf-8');
+        const bb = Buffer.isBuffer(b) ? b : Buffer.from(String(b || ''), 'utf-8');
+        if (ba.length !== bb.length) return false;
+        return crypto.timingSafeEqual(ba, bb);
+    } catch (_) {
+        return false;
+    }
+}
+
+function verifyGithubWebhookSignature(secret, signatureHeader, rawBuffer) {
+    const key = typeof secret === 'string' ? secret : '';
+    const signature = typeof signatureHeader === 'string' ? signatureHeader.trim() : '';
+    if (!key || !signature || !signature.startsWith('sha256=')) return false;
+    const expected = 'sha256=' + crypto.createHmac('sha256', key).update(rawBuffer || Buffer.alloc(0)).digest('hex');
+    return safeTimingEqual(signature, expected);
+}
+
 async function handleAutomationHook(req, res, source) {
     const method = (req.method || 'GET').toUpperCase();
     if (method !== 'POST') {
@@ -8084,6 +8105,42 @@ async function handleAutomationHook(req, res, source) {
             writeJsonResponse(res, 400, { error: parsedBody.error || 'invalid request body' });
         }
         return;
+    }
+    const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+    const isLoopback = !remoteAddr || isLoopbackRemoteAddress(remoteAddr);
+    const normalizedSource = typeof source === 'string' ? source.trim().toLowerCase() : '';
+    if (normalizedSource === 'github') {
+        const secret = typeof process.env.CODEXMATE_GITHUB_WEBHOOK_SECRET === 'string'
+            ? process.env.CODEXMATE_GITHUB_WEBHOOK_SECRET
+            : '';
+        if (!secret && !isLoopback) {
+            writeJsonResponse(res, 403, { error: 'Remote GitHub webhook is disabled (set CODEXMATE_GITHUB_WEBHOOK_SECRET)' });
+            return;
+        }
+        if (secret) {
+            const signature = (req.headers || {})['x-hub-signature-256'];
+            if (!verifyGithubWebhookSignature(secret, signature, parsedBody.rawBuffer)) {
+                writeJsonResponse(res, 401, { error: 'Invalid webhook signature' });
+                return;
+            }
+        }
+    } else if (normalizedSource === 'gitlab') {
+        const secret = typeof process.env.CODEXMATE_GITLAB_WEBHOOK_SECRET === 'string'
+            ? process.env.CODEXMATE_GITLAB_WEBHOOK_SECRET.trim()
+            : '';
+        if (!secret && !isLoopback) {
+            writeJsonResponse(res, 403, { error: 'Remote GitLab webhook is disabled (set CODEXMATE_GITLAB_WEBHOOK_SECRET)' });
+            return;
+        }
+        if (secret) {
+            const tokenHeader = typeof (req.headers || {})['x-gitlab-token'] === 'string'
+                ? String(req.headers['x-gitlab-token']).trim()
+                : '';
+            if (!tokenHeader || tokenHeader !== secret) {
+                writeJsonResponse(res, 401, { error: 'Invalid webhook token' });
+                return;
+            }
+        }
     }
     const payload = parsedBody.body && typeof parsedBody.body === 'object' ? parsedBody.body : {};
     const eventKey = buildAutomationEventKey(source, req.headers || {}, payload);

--- a/cli.js
+++ b/cli.js
@@ -7313,8 +7313,16 @@ function cmdClaude(baseUrl, apiKey, model, silent = false) {
 }
 
 function commandExists(command, args = '') {
+    const cmd = typeof command === 'string' ? command.trim() : '';
+    const argText = typeof args === 'string' ? args.trim() : '';
+    if (!cmd || !/^[A-Za-z0-9._-]+$/.test(cmd)) {
+        return false;
+    }
+    if (argText && /[\r\n;&|<>`$]/.test(argText)) {
+        return false;
+    }
     try {
-        execSync(`${command} ${args}`, { stdio: 'ignore', shell: process.platform === 'win32' });
+        execSync(`${cmd}${argText ? ` ${argText}` : ''}`, { stdio: 'ignore', shell: process.platform === 'win32' });
         return true;
     } catch (e) {
         return false;
@@ -7984,10 +7992,90 @@ function readJsonRequestBody(req, res, options = {}) {
     });
 }
 
+function isLoopbackRemoteAddress(value) {
+    const addr = typeof value === 'string' ? value.trim() : '';
+    if (!addr) return false;
+    if (addr === '127.0.0.1' || addr === '::1') return true;
+    if (addr === '::ffff:127.0.0.1') return true;
+    return false;
+}
+
+function extractRequestToken(req) {
+    const headers = req && req.headers && typeof req.headers === 'object' ? req.headers : {};
+    const rawAuth = typeof headers.authorization === 'string' ? headers.authorization.trim() : '';
+    if (rawAuth) {
+        const match = rawAuth.match(/^bearer\s+(.+)$/i);
+        if (match && match[1]) return match[1].trim();
+        return rawAuth;
+    }
+    const raw = typeof headers['x-codexmate-token'] === 'string' ? headers['x-codexmate-token'].trim() : '';
+    return raw;
+}
+
+function readServerToken() {
+    const raw = typeof process.env.CODEXMATE_HTTP_TOKEN === 'string' ? process.env.CODEXMATE_HTTP_TOKEN.trim() : '';
+    return raw;
+}
+
+function assertRequestAuthorized(req, res) {
+    const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+    if (isLoopbackRemoteAddress(remoteAddr)) {
+        return { ok: true, mode: 'loopback' };
+    }
+    const expected = readServerToken();
+    if (!expected) {
+        writeJsonResponse(res, 403, {
+            error: 'Remote access is disabled (set CODEXMATE_HTTP_TOKEN or use --host 127.0.0.1)'
+        });
+        return { ok: false, mode: 'missing-token' };
+    }
+    const actual = extractRequestToken(req);
+    if (!actual || actual !== expected) {
+        writeJsonResponse(res, 401, { error: 'Unauthorized' });
+        return { ok: false, mode: 'unauthorized' };
+    }
+    return { ok: true, mode: 'token' };
+}
+
+const g_webhookDeliveryCache = new Map();
+
+function pruneWebhookDeliveryCache() {
+    const now = Date.now();
+    for (const [key, expiresAt] of g_webhookDeliveryCache.entries()) {
+        if (now >= expiresAt) {
+            g_webhookDeliveryCache.delete(key);
+        }
+    }
+}
+
+function rememberWebhookDeliveryId(value, ttlMs = 10 * 60 * 1000) {
+    const id = typeof value === 'string' ? value.trim() : '';
+    if (!id) return { ok: true, seen: false };
+    pruneWebhookDeliveryCache();
+    if (g_webhookDeliveryCache.has(id)) {
+        return { ok: true, seen: true };
+    }
+    g_webhookDeliveryCache.set(id, Date.now() + ttlMs);
+    while (g_webhookDeliveryCache.size > 2000) {
+        const firstKey = g_webhookDeliveryCache.keys().next().value;
+        if (!firstKey) break;
+        g_webhookDeliveryCache.delete(firstKey);
+    }
+    return { ok: true, seen: false };
+}
+
 async function handleAutomationHook(req, res, source) {
     const method = (req.method || 'GET').toUpperCase();
     if (method !== 'POST') {
         writeJsonResponse(res, 405, { error: 'Method Not Allowed' });
+        return;
+    }
+    const deliveryId = typeof (req.headers || {})['x-github-delivery'] === 'string'
+        ? String(req.headers['x-github-delivery'] || '')
+        : (typeof (req.headers || {})['x-gitlab-event-uuid'] === 'string' ? String(req.headers['x-gitlab-event-uuid'] || '') : '');
+    const remember = rememberWebhookDeliveryId(deliveryId);
+    if (remember.seen) {
+        writeJsonResponse(res, 200, { ok: true, deduped: true });
         return;
     }
     const parsedBody = await readJsonRequestBody(req, res);
@@ -8346,8 +8434,49 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
 
     const server = http.createServer((req, res) => {
         const requestPath = (req.url || '/').split('?')[0];
+        const sendJson = (statusCode, payload) => {
+            const body = JSON.stringify(payload || {}, null, 2);
+            res.writeHead(statusCode, {
+                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Length': Buffer.byteLength(body, 'utf-8')
+            });
+            res.end(body, 'utf-8');
+        };
         if (typeof openaiBridgeHandler === 'function' && openaiBridgeHandler(req, res)) {
             return;
+        }
+        if (
+            requestPath === '/api'
+            || requestPath.startsWith('/api/import-')
+            || requestPath.startsWith('/hooks/')
+            || requestPath.startsWith('/download/')
+        ) {
+            const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+            const isLoopback = !remoteAddr
+                || remoteAddr === '127.0.0.1'
+                || remoteAddr === '::1'
+                || remoteAddr === '::ffff:127.0.0.1';
+            if (!isLoopback) {
+                const expected = typeof process.env.CODEXMATE_HTTP_TOKEN === 'string'
+                    ? process.env.CODEXMATE_HTTP_TOKEN.trim()
+                    : '';
+                if (!expected) {
+                    sendJson(403, {
+                        error: 'Remote access is disabled (set CODEXMATE_HTTP_TOKEN or use --host 127.0.0.1)'
+                    });
+                    return;
+                }
+                const headers = req && req.headers && typeof req.headers === 'object' ? req.headers : {};
+                const rawAuth = typeof headers.authorization === 'string' ? headers.authorization.trim() : '';
+                const match = rawAuth ? rawAuth.match(/^bearer\s+(.+)$/i) : null;
+                const actual = match && match[1]
+                    ? match[1].trim()
+                    : (rawAuth ? rawAuth : (typeof headers['x-codexmate-token'] === 'string' ? String(headers['x-codexmate-token']).trim() : ''));
+                if (!actual || actual !== expected) {
+                    sendJson(401, { error: 'Unauthorized' });
+                    return;
+                }
+            }
         }
         if (requestPath === '/api/import-skills-zip') {
             void handleImportSkillsZipUpload(req, res);
@@ -8364,6 +8493,11 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
             return;
         }
         if (requestPath === '/api') {
+            const method = (req.method ? String(req.method) : 'POST').toUpperCase();
+            if (method !== 'POST') {
+                sendJson(405, { error: 'Method Not Allowed' });
+                return;
+            }
             let body = '';
             let bodySize = 0;
             let bodyTooLarge = false;
@@ -8372,7 +8506,7 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                 bodySize += chunk.length;
                 if (bodySize > MAX_API_BODY_SIZE) {
                     bodyTooLarge = true;
-                    writeJsonResponse(res, 413, {
+                    sendJson(413, {
                         error: `请求体过大（>${Math.floor(MAX_API_BODY_SIZE / 1024 / 1024)}MB）`
                     });
                     req.destroy();
@@ -8383,7 +8517,7 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
             req.on('end', async () => {
                 if (bodyTooLarge) return;
                 try {
-                    const { action, params } = JSON.parse(body);
+                    const { action, params } = JSON.parse(body || '{}');
                     let result;
 
                     switch (action) {
@@ -11473,14 +11607,21 @@ function normalizeTaskQueueItem(raw = {}) {
 
 function readTaskQueueState() {
     const parsed = readJsonObjectFromFile(TASK_QUEUE_FILE, {});
+    if (!parsed.ok && parsed.exists) {
+        return {
+            tasks: [],
+            error: parsed.error || 'failed to read task queue'
+        };
+    }
     if (!parsed.ok || !parsed.exists) {
         return {
-            tasks: []
+            tasks: [],
+            error: ''
         };
     }
     const source = parsed.data && typeof parsed.data === 'object' ? parsed.data : {};
     const tasks = Array.isArray(source.tasks) ? source.tasks.map((item) => normalizeTaskQueueItem(item)) : [];
-    return { tasks };
+    return { tasks, error: '' };
 }
 
 function writeTaskQueueState(state = {}) {
@@ -11490,17 +11631,58 @@ function writeTaskQueueState(state = {}) {
     });
 }
 
-function upsertTaskQueueItem(item) {
-    const state = readTaskQueueState();
-    const next = normalizeTaskQueueItem(item || {});
-    const index = state.tasks.findIndex((entry) => entry.taskId === next.taskId);
-    if (index >= 0) {
-        state.tasks[index] = next;
-    } else {
-        state.tasks.push(next);
+function withTaskQueueLock(fn) {
+    const lockPath = `${TASK_QUEUE_FILE}.lock`;
+    ensureDir(path.dirname(lockPath));
+    let lockFd = null;
+    try {
+        lockFd = fs.openSync(lockPath, 'wx', 0o600);
+    } catch (error) {
+        const code = error && error.code ? error.code : '';
+        if (code === 'EEXIST') {
+            try {
+                const stat = fs.statSync(lockPath);
+                const ageMs = Date.now() - stat.mtimeMs;
+                if (ageMs > 5000) {
+                    try {
+                        fs.unlinkSync(lockPath);
+                    } catch (_) {}
+                    lockFd = fs.openSync(lockPath, 'wx', 0o600);
+                }
+            } catch (_) {}
+        }
     }
-    writeTaskQueueState(state);
-    return next;
+    if (!lockFd) {
+        return { error: 'task queue is busy' };
+    }
+    try {
+        return fn();
+    } finally {
+        try {
+            fs.closeSync(lockFd);
+        } catch (_) {}
+        try {
+            fs.unlinkSync(lockPath);
+        } catch (_) {}
+    }
+}
+
+function upsertTaskQueueItem(item) {
+    return withTaskQueueLock(() => {
+        const state = readTaskQueueState();
+        if (state.error) {
+            return { error: state.error };
+        }
+        const next = normalizeTaskQueueItem(item || {});
+        const index = state.tasks.findIndex((entry) => entry.taskId === next.taskId);
+        if (index >= 0) {
+            state.tasks[index] = next;
+        } else {
+            state.tasks.push(next);
+        }
+        writeTaskQueueState(state);
+        return next;
+    });
 }
 
 function getTaskQueueItem(taskId) {
@@ -11535,15 +11717,19 @@ function appendTaskRunRecord(record) {
     fs.appendFileSync(TASK_RUNS_FILE, `${JSON.stringify(record)}\n`, { encoding: 'utf-8', mode: 0o600 });
 }
 
+let g_taskRunRecordsLastParseErrors = 0;
+
 function listTaskRunRecords(limit = 20) {
     const max = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 20;
     if (!fs.existsSync(TASK_RUNS_FILE)) {
+        g_taskRunRecordsLastParseErrors = 0;
         return [];
     }
     let content = '';
     try {
         content = fs.readFileSync(TASK_RUNS_FILE, 'utf-8');
     } catch (_) {
+        g_taskRunRecordsLastParseErrors = 0;
         return [];
     }
     const rows = content
@@ -11551,14 +11737,18 @@ function listTaskRunRecords(limit = 20) {
         .map((line) => line.trim())
         .filter(Boolean);
     const parsed = [];
+    let parseErrors = 0;
     for (let i = rows.length - 1; i >= 0; i -= 1) {
         try {
             parsed.push(JSON.parse(rows[i]));
             if (parsed.length >= max) {
                 break;
             }
-        } catch (_) {}
+        } catch (_) {
+            parseErrors += 1;
+        }
     }
+    g_taskRunRecordsLastParseErrors = parseErrors;
     return parsed;
 }
 
@@ -11660,7 +11850,13 @@ async function notifyAutomationOnTaskRun(detail = {}) {
 
 function startAutomationScheduler() {
     const lastTicks = new Map();
+    let tickInFlight = false;
     let timer = setInterval(async () => {
+        if (tickInFlight) {
+            return;
+        }
+        tickInFlight = true;
+        try {
         const cfg = readAutomationConfig(AUTOMATION_CONFIG_FILE, { env: process.env });
         if (!cfg.ok || !cfg.config) {
             return;
@@ -11681,11 +11877,16 @@ function startAutomationScheduler() {
             const actionType = typeof action.type === 'string' ? action.type.trim().toLowerCase() : '';
             if (actionType !== 'task.queue.add') continue;
             const taskPayload = action.task && typeof action.task === 'object' ? action.task : {};
-            const enqueue = addTaskToQueue(taskPayload);
-            if (enqueue && enqueue.error) continue;
-            if (action.startQueue === true) {
-                await startTaskQueueProcessing({ taskId: '', detach: true });
-            }
+            try {
+                const enqueue = addTaskToQueue(taskPayload);
+                if (enqueue && enqueue.error) continue;
+                if (action.startQueue === true) {
+                    await startTaskQueueProcessing({ taskId: '', detach: true });
+                }
+            } catch (_) {}
+        }
+        } finally {
+            tickInFlight = false;
         }
     }, 30000);
     if (timer && typeof timer.unref === 'function') {
@@ -11702,14 +11903,24 @@ function buildTaskOverviewPayload(options = {}) {
     const queueLimit = Number.isFinite(options.queueLimit) ? Math.max(1, Math.floor(options.queueLimit)) : 20;
     const runLimit = Number.isFinite(options.runLimit) ? Math.max(1, Math.floor(options.runLimit)) : 20;
     const workflowCatalog = buildTaskWorkflowCatalog();
-    const queue = listTaskQueueItems({ limit: queueLimit });
+    const queueState = readTaskQueueState();
+    const queue = queueState.error ? [] : listTaskQueueItems({ limit: queueLimit });
     const runs = listTaskRunRecords(runLimit);
+    const warnings = Array.isArray(workflowCatalog.warnings) ? [...workflowCatalog.warnings] : [];
+    if (queueState.error) {
+        warnings.push(`task queue read error: ${queueState.error}`);
+    }
+    if (g_taskRunRecordsLastParseErrors > 0) {
+        warnings.push(`task run history parse errors: ${g_taskRunRecordsLastParseErrors}`);
+    }
     return {
         workflows: workflowCatalog.workflows,
-        warnings: workflowCatalog.warnings,
+        warnings,
         queue,
         runs,
-        activeRunIds: Array.from(g_taskRunControllers.keys())
+        activeRunIds: Array.from(g_taskRunControllers.keys()),
+        queueError: queueState.error || '',
+        runParseErrors: g_taskRunRecordsLastParseErrors
     };
 }
 
@@ -12007,7 +12218,7 @@ async function runTaskPlanInternal(plan, options = {}) {
         }
     });
     if (options.queueItem) {
-        upsertTaskQueueItem({
+        const queued = upsertTaskQueueItem({
             ...options.queueItem,
             taskId,
             status: 'running',
@@ -12017,6 +12228,7 @@ async function runTaskPlanInternal(plan, options = {}) {
             updatedAt: toIsoTime(Date.now()),
             plan
         });
+        if (queued && queued.error) {}
     }
     try {
         const run = await executeTaskPlan(plan, {
@@ -12040,7 +12252,7 @@ async function runTaskPlanInternal(plan, options = {}) {
                 };
                 writeTaskRunDetail(nextDetail);
                 if (options.queueItem) {
-                    upsertTaskQueueItem({
+                    const queued = upsertTaskQueueItem({
                         ...options.queueItem,
                         taskId,
                         status: snapshot.status === 'success'
@@ -12052,6 +12264,7 @@ async function runTaskPlanInternal(plan, options = {}) {
                         updatedAt: toIsoTime(Date.now()),
                         plan
                     });
+                    if (queued && queued.error) {}
                 }
             }
         });
@@ -12068,7 +12281,7 @@ async function runTaskPlanInternal(plan, options = {}) {
             await notifyAutomationOnTaskRun(detail);
         } catch (_) {}
         if (options.queueItem) {
-            upsertTaskQueueItem({
+            const queued = upsertTaskQueueItem({
                 ...options.queueItem,
                 taskId,
                 status: run.status === 'success'
@@ -12080,6 +12293,7 @@ async function runTaskPlanInternal(plan, options = {}) {
                 updatedAt: toIsoTime(Date.now()),
                 plan
             });
+            if (queued && queued.error) {}
         }
         return detail;
     } finally {
@@ -12115,6 +12329,9 @@ function addTaskToQueue(params = {}) {
         runStatus: '',
         plan
     });
+    if (item && item.error) {
+        return { error: item.error };
+    }
     return {
         ok: true,
         task: item,
@@ -12285,6 +12502,9 @@ function cancelTaskRunOrQueue(params = {}) {
                 updatedAt: toIsoTime(Date.now()),
                 lastSummary: queueItem.lastSummary || '已取消'
             });
+            if (next && next.error) {
+                return { error: next.error };
+            }
             return {
                 ok: true,
                 cancelled: true,
@@ -12423,13 +12643,37 @@ function isLiveProcessId(value) {
     }
 }
 
+function isTaskWorkerProcessId(value) {
+    const pid = Number.isFinite(Number(value)) ? Math.floor(Number(value)) : 0;
+    if (!isLiveProcessId(pid)) return false;
+    if (process.platform === 'linux') {
+        try {
+            const raw = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf-8');
+            return raw.includes('__task-worker');
+        } catch (_) {
+            return true;
+        }
+    }
+    if (process.platform === 'darwin') {
+        try {
+            const probe = spawnSync('ps', ['-p', String(pid), '-o', 'command='], { encoding: 'utf-8', timeout: 1500 });
+            if (probe.error || probe.status !== 0) return true;
+            const cmd = String(probe.stdout || '');
+            return cmd.includes('__task-worker');
+        } catch (_) {
+            return true;
+        }
+    }
+    return true;
+}
+
 function readTaskQueueWorkerState() {
     const parsed = readJsonObjectFromFile(TASK_QUEUE_WORKER_FILE, {});
     if (!parsed.ok || !parsed.exists || !parsed.data || typeof parsed.data !== 'object') {
         return null;
     }
     const state = parsed.data;
-    if (!isLiveProcessId(state.pid)) {
+    if (!isTaskWorkerProcessId(state.pid)) {
         try {
             fs.unlinkSync(TASK_QUEUE_WORKER_FILE);
         } catch (_) {}

--- a/cli/builtin-proxy.js
+++ b/cli/builtin-proxy.js
@@ -674,6 +674,41 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                 return;
             }
 
+            const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+            const isLoopback = !remoteAddr
+                || remoteAddr === '127.0.0.1'
+                || remoteAddr === '::1'
+                || remoteAddr === '::ffff:127.0.0.1';
+            if (!isLoopback) {
+                const expected = typeof process.env.CODEXMATE_HTTP_TOKEN === 'string'
+                    ? process.env.CODEXMATE_HTTP_TOKEN.trim()
+                    : '';
+                if (!expected) {
+                    const body = JSON.stringify({ error: 'Remote access is disabled (set CODEXMATE_HTTP_TOKEN)' });
+                    res.writeHead(403, {
+                        'Content-Type': 'application/json; charset=utf-8',
+                        'Content-Length': Buffer.byteLength(body, 'utf-8')
+                    });
+                    res.end(body, 'utf-8');
+                    return;
+                }
+                const headers = req && req.headers && typeof req.headers === 'object' ? req.headers : {};
+                const rawAuth = typeof headers.authorization === 'string' ? headers.authorization.trim() : '';
+                const match = rawAuth ? rawAuth.match(/^bearer\s+(.+)$/i) : null;
+                const actual = match && match[1]
+                    ? match[1].trim()
+                    : (rawAuth ? rawAuth : (typeof headers['x-codexmate-token'] === 'string' ? String(headers['x-codexmate-token']).trim() : ''));
+                if (!actual || actual !== expected) {
+                    const body = JSON.stringify({ error: 'Unauthorized' });
+                    res.writeHead(401, {
+                        'Content-Type': 'application/json; charset=utf-8',
+                        'Content-Length': Buffer.byteLength(body, 'utf-8')
+                    });
+                    res.end(body, 'utf-8');
+                    return;
+                }
+            }
+
             const incomingPath = parsedIncoming.pathname || '/';
             if (incomingPath === '/health' || incomingPath === '/status') {
                 const body = JSON.stringify({

--- a/cli/claude-proxy.js
+++ b/cli/claude-proxy.js
@@ -864,6 +864,30 @@ function createBuiltinClaudeProxyRuntimeController(deps = {}) {
     function createBuiltinClaudeProxyServer(settings, upstream) {
         const connections = new Set();
         const server = http.createServer((req, res) => {
+            const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
+            const isLoopback = !remoteAddr
+                || remoteAddr === '127.0.0.1'
+                || remoteAddr === '::1'
+                || remoteAddr === '::ffff:127.0.0.1';
+            if (!isLoopback) {
+                const expected = typeof process.env.CODEXMATE_HTTP_TOKEN === 'string'
+                    ? process.env.CODEXMATE_HTTP_TOKEN.trim()
+                    : '';
+                if (!expected) {
+                    writeAnthropicProxyError(res, 403, 'Remote access is disabled (set CODEXMATE_HTTP_TOKEN)', 'authentication_error');
+                    return;
+                }
+                const headers = req && req.headers && typeof req.headers === 'object' ? req.headers : {};
+                const rawAuth = typeof headers.authorization === 'string' ? headers.authorization.trim() : '';
+                const match = rawAuth ? rawAuth.match(/^bearer\s+(.+)$/i) : null;
+                const actual = match && match[1]
+                    ? match[1].trim()
+                    : (rawAuth ? rawAuth : (typeof headers['x-codexmate-token'] === 'string' ? String(headers['x-codexmate-token']).trim() : ''));
+                if (!actual || actual !== expected) {
+                    writeAnthropicProxyError(res, 401, 'Unauthorized', 'authentication_error');
+                    return;
+                }
+            }
             handleBuiltinClaudeProxyRequest(req, res, settings, upstream).catch((err) => {
                 if (res.headersSent) {
                     try { res.destroy(err); } catch (_) {}

--- a/cli/import-skills-url.js
+++ b/cli/import-skills-url.js
@@ -97,6 +97,17 @@ function extractHttpStatusFromError(err) {
     return Number.isFinite(value) ? value : 0;
 }
 
+function isAllowedSkillsRedirectHost(originHost, nextHost) {
+    const origin = typeof originHost === 'string' ? originHost.trim().toLowerCase() : '';
+    const next = typeof nextHost === 'string' ? nextHost.trim().toLowerCase() : '';
+    if (!origin || !next) return false;
+    if (origin === next) return true;
+    if (process.env.CODEXMATE_ALLOW_SKILLS_REDIRECT === '1') return true;
+    if (origin === 'github.com' && next === 'codeload.github.com') return true;
+    if (origin === 'github.com' && next.endsWith('.githubusercontent.com')) return true;
+    return false;
+}
+
 function downloadUrlToFile(targetUrl, filePath, options = {}) {
     const maxBytes = Number.isFinite(options.maxBytes) && options.maxBytes > 0
         ? Math.floor(options.maxBytes)
@@ -141,8 +152,19 @@ function downloadUrlToFile(targetUrl, filePath, options = {}) {
                 const nextUrl = redirectLocation.startsWith('http')
                     ? redirectLocation
                     : `${parsed.origin}${redirectLocation}`;
+                let originHost = typeof options.originHost === 'string' && options.originHost.trim()
+                    ? options.originHost.trim()
+                    : parsed.host;
+                try {
+                    const nextParsed = new URL(nextUrl);
+                    if (!isAllowedSkillsRedirectHost(originHost, nextParsed.host)) {
+                        res.resume();
+                        reject(new Error('Cross-origin redirect is not allowed'));
+                        return;
+                    }
+                } catch (_) {}
                 res.resume();
-                downloadUrlToFile(nextUrl, filePath, { maxBytes, timeoutMs, maxRedirects: maxRedirects - 1 })
+                downloadUrlToFile(nextUrl, filePath, { maxBytes, timeoutMs, maxRedirects: maxRedirects - 1, originHost })
                     .then(resolve)
                     .catch(reject);
                 return;

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -707,9 +707,10 @@ async function proxyRequestJson(targetUrl, options = {}) {
 
 function createOpenaiBridgeHttpHandler(options = {}) {
     const settingsFile = options.settingsFile;
-    const expectedToken = typeof options.expectedToken === 'string' && options.expectedToken.trim()
-        ? options.expectedToken.trim()
-        : DEFAULT_BRIDGE_TOKEN;
+    const expectedTokenRaw = typeof options.expectedToken === 'string' ? options.expectedToken.trim() : '';
+    const expectedToken = Object.prototype.hasOwnProperty.call(options, 'expectedToken')
+        ? expectedTokenRaw
+        : (expectedTokenRaw || DEFAULT_BRIDGE_TOKEN);
     const maxBodySize = Number.isFinite(options.maxBodySize) ? options.maxBodySize : 0;
     const httpAgent = options.httpAgent;
     const httpsAgent = options.httpsAgent;
@@ -748,6 +749,11 @@ function createOpenaiBridgeHttpHandler(options = {}) {
             // 为避免在 LAN 暴露无鉴权的代理，这里仅允许 loopback 连接缺省 token。
             const remoteAddr = req && req.socket ? req.socket.remoteAddress : '';
             const isLoopback = isLoopbackAddress(remoteAddr);
+            if (!isLoopback && !expectedToken) {
+                res.writeHead(403, { 'Content-Type': 'application/json; charset=utf-8' });
+                res.end(JSON.stringify({ error: 'Remote access is disabled (set CODEXMATE_HTTP_TOKEN)' }));
+                return;
+            }
             if (!token && !isLoopback) {
                 res.writeHead(401, { 'Content-Type': 'application/json; charset=utf-8' });
                 res.end(JSON.stringify({ error: 'Unauthorized' }));

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -238,6 +238,10 @@ function normalizeResponsesInputToChatMessages(input) {
                 out.push({ type: 'text', text: block.text });
                 continue;
             }
+            if ((type === 'reasoning' || type === 'reasoning_text' || type === 'reasoning_content') && typeof block.text === 'string') {
+                out.push({ type: 'text', text: block.text });
+                continue;
+            }
             if (type === 'input_image') {
                 const raw = block.image_url != null ? block.image_url : block.imageUrl;
                 const url = typeof raw === 'string'
@@ -255,7 +259,21 @@ function normalizeResponsesInputToChatMessages(input) {
             }
             if (type === 'image_url' && block.image_url) {
                 out.push({ type: 'image_url', image_url: block.image_url });
+                continue;
             }
+            const text = typeof block.text === 'string'
+                ? block.text
+                : (typeof block.content === 'string' ? block.content : '');
+            if (text) {
+                out.push({ type: 'text', text });
+                continue;
+            }
+            try {
+                const raw = JSON.stringify(block);
+                if (raw) {
+                    out.push({ type: 'text', text: raw.slice(0, 4000) });
+                }
+            } catch (_) {}
         }
         if (out.length === 0) return '';
         return out;

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -653,6 +653,9 @@ async function proxyRequestJson(targetUrl, options = {}) {
     const parsed = new URL(targetUrl);
     const transport = parsed.protocol === 'https:' ? https : http;
     const bodyText = options.body ? JSON.stringify(options.body) : '';
+    const maxBytes = Number.isFinite(options.maxBytes) && options.maxBytes > 0
+        ? Math.floor(options.maxBytes)
+        : 0;
     const headers = {
         'Accept': 'application/json',
         ...(options.body ? { 'Content-Type': 'application/json' } : {}),
@@ -682,7 +685,21 @@ async function proxyRequestJson(targetUrl, options = {}) {
             agent: parsed.protocol === 'https:' ? options.httpsAgent : options.httpAgent
         }, (upstreamRes) => {
             const chunks = [];
-            upstreamRes.on('data', (chunk) => chunk && chunks.push(chunk));
+            let size = 0;
+            upstreamRes.on('data', (chunk) => {
+                if (!chunk) return;
+                if (maxBytes > 0) {
+                    size += chunk.length;
+                    if (size > maxBytes) {
+                        chunks.length = 0;
+                        try { upstreamRes.destroy(new Error('response too large')); } catch (_) {}
+                        try { req.destroy(new Error('response too large')); } catch (_) {}
+                        finish({ ok: false, error: 'response too large' });
+                        return;
+                    }
+                }
+                chunks.push(chunk);
+            });
             upstreamRes.on('end', () => {
                 const text = chunks.length ? Buffer.concat(chunks).toString('utf-8') : '';
                 finish({
@@ -714,6 +731,9 @@ function createOpenaiBridgeHttpHandler(options = {}) {
     const maxBodySize = Number.isFinite(options.maxBodySize) ? options.maxBodySize : 0;
     const httpAgent = options.httpAgent;
     const httpsAgent = options.httpsAgent;
+    const maxUpstreamBytes = Number.isFinite(options.maxUpstreamBytes) && options.maxUpstreamBytes > 0
+        ? Math.floor(options.maxUpstreamBytes)
+        : Math.max(16 * 1024 * 1024, maxBodySize > 0 ? maxBodySize * 4 : 0);
 
     if (!settingsFile) {
         throw new Error('createOpenaiBridgeHttpHandler 缺少 settingsFile');
@@ -798,6 +818,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                         ...(authHeader ? { Authorization: authHeader } : {}),
                         ...upstreamHeaders
                     },
+                    maxBytes: maxUpstreamBytes,
                     httpAgent,
                     httpsAgent
                 });
@@ -851,6 +872,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                     ...(authHeader ? { Authorization: authHeader } : {}),
                     ...upstreamHeaders
                 },
+                maxBytes: maxUpstreamBytes,
                 httpAgent,
                 httpsAgent
             });
@@ -911,6 +933,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                     ...(authHeader ? { Authorization: authHeader } : {}),
                     ...upstreamHeaders
                 },
+                maxBytes: maxUpstreamBytes,
                 httpAgent,
                 httpsAgent
             });

--- a/lib/automation.js
+++ b/lib/automation.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const path = require('path');
 const http = require('http');
 const https = require('https');
+const net = require('net');
 
 function isPlainObject(value) {
     return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -41,6 +42,32 @@ function expandEnvTemplate(value, env = process.env) {
         const envValue = env && typeof env[key] === 'string' ? env[key] : '';
         return envValue ? envValue : '';
     });
+}
+
+function isPrivateNetworkHost(hostname) {
+    const host = typeof hostname === 'string' ? hostname.trim().toLowerCase() : '';
+    if (!host) return true;
+    if (host === 'localhost') return true;
+    const ipVer = net.isIP(host);
+    if (!ipVer) return false;
+    if (ipVer === 4) {
+        const parts = host.split('.').map((x) => parseInt(x, 10));
+        if (parts.length !== 4 || parts.some((x) => !Number.isFinite(x))) return true;
+        const [a, b] = parts;
+        if (a === 10) return true;
+        if (a === 127) return true;
+        if (a === 169 && b === 254) return true;
+        if (a === 192 && b === 168) return true;
+        if (a === 172 && b >= 16 && b <= 31) return true;
+        return false;
+    }
+    if (ipVer === 6) {
+        if (host === '::1') return true;
+        if (host.startsWith('fe80:')) return true;
+        if (host.startsWith('fc') || host.startsWith('fd')) return true;
+        return false;
+    }
+    return false;
 }
 
 function readAutomationConfig(configPath, options = {}) {
@@ -186,6 +213,13 @@ function httpPostJson(url, payload, headers = {}, options = {}) {
         parsed = new URL(target);
     } catch (_) {
         return Promise.resolve({ ok: false, error: 'invalid url' });
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        return Promise.resolve({ ok: false, error: 'invalid url protocol' });
+    }
+    const allowPrivate = process.env.CODEXMATE_ALLOW_AUTOMATION_PRIVATE_NETWORK === '1';
+    if (!allowPrivate && isPrivateNetworkHost(parsed.hostname || '')) {
+        return Promise.resolve({ ok: false, error: 'refusing to post to private network url' });
     }
     const transport = parsed.protocol === 'http:' ? http : https;
     const data = Buffer.from(JSON.stringify(payload || {}), 'utf-8');

--- a/lib/cli-path-utils.js
+++ b/lib/cli-path-utils.js
@@ -52,8 +52,16 @@ function resolveCopyTargetRoot(targetDir) {
 }
 
 function commandExists(command, args = '') {
+    const cmd = typeof command === 'string' ? command.trim() : '';
+    const argText = typeof args === 'string' ? args.trim() : '';
+    if (!cmd || !/^[A-Za-z0-9._-]+$/.test(cmd)) {
+        return false;
+    }
+    if (argText && /[\r\n;&|<>`$]/.test(argText)) {
+        return false;
+    }
     try {
-        execSync(`${command} ${args}`, { stdio: 'ignore', shell: process.platform === 'win32' });
+        execSync(`${cmd}${argText ? ` ${argText}` : ''}`, { stdio: 'ignore', shell: process.platform === 'win32' });
         return true;
     } catch (e) {
         return false;
@@ -66,4 +74,3 @@ module.exports = {
     resolveCopyTargetRoot,
     commandExists
 };
-

--- a/lib/cli-path-utils.js
+++ b/lib/cli-path-utils.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { spawnSync } = require('child_process');
 
 function normalizePathForCompare(targetPath, options = {}) {
     const ignoreCase = !!options.ignoreCase;
@@ -54,16 +54,25 @@ function resolveCopyTargetRoot(targetDir) {
 function commandExists(command, args = '') {
     const cmd = typeof command === 'string' ? command.trim() : '';
     const argText = typeof args === 'string' ? args.trim() : '';
-    if (!cmd || !/^[A-Za-z0-9._-]+$/.test(cmd)) {
+    if (!cmd || cmd.includes('\0') || /[\r\n]/.test(cmd)) {
         return false;
     }
-    if (argText && /[\r\n;&|<>`$]/.test(argText)) {
-        return false;
+    const argv = argText ? argText.split(/\s+/g).filter(Boolean) : [];
+    const hasSeparators = cmd.includes('/') || cmd.includes('\\');
+    const useShell = process.platform === 'win32' && !hasSeparators;
+    if (useShell) {
+        if (!/^[A-Za-z0-9._-]+$/.test(cmd)) return false;
+        if (argText && /[\r\n;&|<>`$]/.test(argText)) return false;
     }
     try {
-        execSync(`${cmd}${argText ? ` ${argText}` : ''}`, { stdio: 'ignore', shell: process.platform === 'win32' });
-        return true;
-    } catch (e) {
+        const probe = spawnSync(cmd, argv, {
+            stdio: 'ignore',
+            windowsHide: true,
+            timeout: 5000,
+            shell: useShell
+        });
+        return probe.status === 0;
+    } catch (_) {
         return false;
     }
 }

--- a/lib/cli-sessions.js
+++ b/lib/cli-sessions.js
@@ -38,7 +38,25 @@ function isBootstrapLikeText(text) {
         return false;
     }
 
-    return BOOTSTRAP_TEXT_MARKERS.some(marker => normalized.includes(marker));
+    if (normalized.length < 80) {
+        return false;
+    }
+    let hits = 0;
+    for (const marker of BOOTSTRAP_TEXT_MARKERS) {
+        if (normalized.includes(marker)) {
+            hits += 1;
+        }
+    }
+    if (hits >= 2) {
+        return true;
+    }
+    if (normalized.includes('<environment_context>')) {
+        return true;
+    }
+    if (normalized.includes('agents.md instructions')) {
+        return true;
+    }
+    return false;
 }
 
 function removeLeadingSystemMessage(messages) {
@@ -300,6 +318,7 @@ function extractSessionDetailPreviewFromTailText(text, source, messageLimit) {
         });
     }
 
+    state.messages = removeLeadingSystemMessage(state.messages);
     return state;
 }
 

--- a/lib/download-artifacts.js
+++ b/lib/download-artifacts.js
@@ -3,6 +3,7 @@ const path = require('path');
 const crypto = require('crypto');
 
 const DEFAULT_DOWNLOAD_ARTIFACT_TTL_MS = 10 * 60 * 1000;
+const MAX_DOWNLOAD_ARTIFACTS = 200;
 const g_downloadArtifacts = new Map();
 
 function registerDownloadArtifact(filePath, options = {}) {
@@ -23,7 +24,19 @@ function registerDownloadArtifact(filePath, options = {}) {
         expiresAt
     });
 
-    setTimeout(() => {
+    while (g_downloadArtifacts.size > MAX_DOWNLOAD_ARTIFACTS) {
+        const firstKey = g_downloadArtifacts.keys().next().value;
+        if (!firstKey) break;
+        const evicted = g_downloadArtifacts.get(firstKey);
+        g_downloadArtifacts.delete(firstKey);
+        if (evicted && evicted.deleteAfterDownload && evicted.filePath && fs.existsSync(evicted.filePath)) {
+            try {
+                fs.unlinkSync(evicted.filePath);
+            } catch (_) {}
+        }
+    }
+
+    const timer = setTimeout(() => {
         const artifact = g_downloadArtifacts.get(token);
         if (!artifact) return;
         if (Date.now() < artifact.expiresAt) return;
@@ -34,6 +47,9 @@ function registerDownloadArtifact(filePath, options = {}) {
             } catch (_) {}
         }
     }, ttlMs + 2000);
+    if (timer && typeof timer.unref === 'function') {
+        timer.unref();
+    }
 
     return {
         token,
@@ -74,4 +90,3 @@ module.exports = {
     registerDownloadArtifact,
     resolveDownloadArtifact
 };
-

--- a/lib/mcp-stdio.js
+++ b/lib/mcp-stdio.js
@@ -280,6 +280,9 @@ function createMcpStdioServer(options = {}) {
     const stdout = options.stdout || process.stdout;
     const router = createMcpRequestRouter(options);
     const jsonRpcVersion = '2.0';
+    const maxFrameBytes = Number.isFinite(options.maxFrameBytes) && options.maxFrameBytes > 0
+        ? Math.floor(options.maxFrameBytes)
+        : 16 * 1024 * 1024;
 
     let buffer = Buffer.alloc(0);
     let started = false;
@@ -379,6 +382,11 @@ function createMcpStdioServer(options = {}) {
                 writeError(null, jsonRpcError(-32600, 'Invalid Content-Length header'));
                 return;
             }
+            if (length > maxFrameBytes) {
+                buffer = Buffer.alloc(0);
+                writeError(null, jsonRpcError(-32600, 'Content-Length too large'));
+                return;
+            }
 
             const bodyOffset = headerEnd + 4;
             const frameLength = bodyOffset + length;
@@ -394,6 +402,11 @@ function createMcpStdioServer(options = {}) {
 
     const onData = async (chunk) => {
         if (stopped) return;
+        if (chunk && (buffer.length + chunk.length) > (maxFrameBytes + 64 * 1024)) {
+            buffer = Buffer.alloc(0);
+            writeError(null, jsonRpcError(-32600, 'Frame too large'));
+            return;
+        }
         buffer = buffer.length === 0 ? chunk : Buffer.concat([buffer, chunk]);
         try {
             await parseBuffer();


### PR DESCRIPTION
## What changed
This PR hardens CodexMate's local HTTP surfaces and fixes several audit-confirmed issues.

### Remote access hardening
- Any non-loopback access now requires `CODEXMATE_HTTP_TOKEN` for:
  - `/api` (including import routes)
  - `/hooks/*`
  - `/download/*`
  - builtin OpenAI-compatible proxy (codexmate-proxy)
  - builtin Claude-compatible proxy
  - `/bridge/openai/*` (OpenAI bridge)

### Webhook authenticity
- GitHub hooks: `CODEXMATE_GITHUB_WEBHOOK_SECRET` + `X-Hub-Signature-256`
- GitLab hooks: `CODEXMATE_GITLAB_WEBHOOK_SECRET` + `X-Gitlab-Token`
- Keeps delivery-id dedupe

### Fixes from reproducible audit
- `commandExists` supports absolute paths (prevents false "codex not installed" on Linux/macOS)
- MCP stdio enforces max frame size (caps `Content-Length`) to prevent memory DoS
- `/download/<name>` legacy tmpdir fallback is disabled by default
  - Opt-in: `CODEXMATE_ALLOW_LEGACY_DOWNLOAD=1` (loopback only)
- Skills URL import blocks cross-origin redirects by default
  - Allows GitHub archive redirects to `codeload.github.com`
- `models-by-url` refuses private-network targets for non-loopback callers

### Additional hardening
- Automation webhook notifier refuses private-network targets by default
  - Opt-in: `CODEXMATE_ALLOW_AUTOMATION_PRIVATE_NETWORK=1`
- OpenAI bridge caps upstream response buffering
  - Configurable via handler option `maxUpstreamBytes` (default >= 16MB)

## Tests
- `npm run test:unit`
- `npm run test:e2e`
