### PR TITLE
docs: add README header screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 [Docs](https://sakurabytecore.github.io/codexmate/) · [Quick Start](#quick-start) · [Commands](#command-reference) · [Web UI](#web-ui) · [MCP](#mcp) · [中文](README.zh.md)
 
 <br />
-<a href="https://ibb.co/G4rRhTc4"><img src="https://i.ibb.co/Kp8W1wFp/Screen-Shot-2026-04-29-162110-679.png" alt="Codex Mate screenshot" width="960" /></a>
+<a href="https://ibb.co/CKffDS2K"><img src="https://i.ibb.co/5hPPwJFh/3993b7910fc1001e102dd0f9a8673db7.png" alt="Codex Mate screenshot" width="960" /></a>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 [Docs](https://sakurabytecore.github.io/codexmate/) · [Quick Start](#quick-start) · [Commands](#command-reference) · [Web UI](#web-ui) · [MCP](#mcp) · [中文](README.zh.md)
 
+<br />
+<a href="https://ibb.co/G4rRhTc4"><img src="https://i.ibb.co/Kp8W1wFp/Screen-Shot-2026-04-29-162110-679.png" alt="Codex Mate screenshot" width="960" /></a>
+
 </div>
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,6 +16,9 @@
 
 [文档](https://sakurabytecore.github.io/codexmate/) · [快速开始](#快速开始) · [命令速查](#命令速查) · [Web 界面](#web-界面) · [MCP](#mcp) · [English](README.md)
 
+<br />
+<a href="https://ibb.co/G4rRhTc4"><img src="https://i.ibb.co/Kp8W1wFp/Screen-Shot-2026-04-29-162110-679.png" alt="Codex Mate 界面预览" width="960" /></a>
+
 </div>
 
 ---

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,7 @@
 [文档](https://sakurabytecore.github.io/codexmate/) · [快速开始](#快速开始) · [命令速查](#命令速查) · [Web 界面](#web-界面) · [MCP](#mcp) · [English](README.md)
 
 <br />
-<a href="https://ibb.co/G4rRhTc4"><img src="https://i.ibb.co/Kp8W1wFp/Screen-Shot-2026-04-29-162110-679.png" alt="Codex Mate 界面预览" width="960" /></a>
+<a href="https://ibb.co/CKffDS2K"><img src="https://i.ibb.co/5hPPwJFh/3993b7910fc1001e102dd0f9a8673db7.png" alt="Codex Mate 界面预览" width="960" /></a>
 
 </div>
 


### PR DESCRIPTION
## Summary
Add a hero screenshot to the top of both README files to make the project’s Web UI more immediately visible.

## Changes
- Add a linked screenshot banner to:
  - README.md
  - README.zh.md
- Image is hosted on ImgBB and links back to the source page:
  - https://ibb.co/CKffDS2K

## Notes
- This is documentation-only (no runtime / behavior changes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added visual preview screenshot to the README header section in both English and Chinese versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->