### PR TITLE
fix(proxy): stream chat fallback, simplify toasts, add issue-inject template

### DIFF
--- a/cli/builtin-proxy.js
+++ b/cli/builtin-proxy.js
@@ -118,6 +118,15 @@ function createBuiltinProxyRuntimeController(deps = {}) {
         return false;
     }
 
+    function shouldFallbackFromUpstreamResponsesFailure(error) {
+        const text = String(error || '').trim();
+        if (!text) return false;
+        if (/timeout/i.test(text)) return true;
+        if (/socket hang up/i.test(text)) return true;
+        if (/ECONNRESET/i.test(text)) return true;
+        return false;
+    }
+
     function proxyRequestJson(targetUrl, options = {}) {
         const parsed = new URL(targetUrl);
         const transport = parsed.protocol === 'https:' ? https : http;
@@ -628,6 +637,291 @@ function createBuiltinProxyRuntimeController(deps = {}) {
         writeSse(res, 'done', '[DONE]');
     }
 
+    function appendChatStreamToolCall(target, toolCall) {
+        if (!toolCall || typeof toolCall !== 'object') return;
+        const index = Number.isFinite(toolCall.index) ? toolCall.index : target.length;
+        if (!target[index]) {
+            target[index] = {
+                id: '',
+                type: 'function',
+                function: { name: '', arguments: '' }
+            };
+        }
+        const current = target[index];
+        if (typeof toolCall.id === 'string' && toolCall.id) current.id = toolCall.id;
+        if (typeof toolCall.type === 'string' && toolCall.type) current.type = toolCall.type;
+        const fn = toolCall.function && typeof toolCall.function === 'object' ? toolCall.function : null;
+        if (fn) {
+            if (typeof fn.name === 'string' && fn.name) current.function.name = fn.name;
+            if (typeof fn.arguments === 'string') current.function.arguments += fn.arguments;
+        }
+    }
+
+    function writeChatCompletionChunkAsResponsesSse(state, chunk) {
+        if (!chunk || typeof chunk !== 'object') return;
+        if (typeof chunk.model === 'string' && chunk.model) {
+            state.model = chunk.model;
+        }
+        const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
+        for (const choice of choices) {
+            const delta = choice && choice.delta && typeof choice.delta === 'object' ? choice.delta : null;
+            if (!delta) continue;
+
+            if (typeof delta.content === 'string' && delta.content) {
+                if (!state.messageItem) {
+                    state.messageItem = {
+                        id: `msg_${crypto.randomBytes(8).toString('hex')}`,
+                        type: 'message',
+                        role: 'assistant',
+                        content: [{ type: 'output_text', text: '' }]
+                    };
+                    state.output.push(state.messageItem);
+                    writeSse(state.res, 'response.output_item.added', {
+                        type: 'response.output_item.added',
+                        output_index: state.output.length - 1,
+                        item: state.messageItem
+                    });
+                }
+                state.messageText += delta.content;
+                state.messageItem.content[0].text = state.messageText;
+                writeSse(state.res, 'response.output_text.delta', {
+                    type: 'response.output_text.delta',
+                    item_id: state.messageItem.id,
+                    output_index: state.output.length - 1,
+                    content_index: 0,
+                    delta: delta.content,
+                    sequence_number: state.nextSeq()
+                });
+            }
+
+            if (Array.isArray(delta.tool_calls)) {
+                for (const toolCall of delta.tool_calls) {
+                    appendChatStreamToolCall(state.toolCalls, toolCall);
+                }
+            }
+        }
+    }
+
+    function finishChatStreamResponsesSse(state) {
+        if (state.finished) return;
+        state.finished = true;
+
+        if (state.messageItem) {
+            const outputIndex = state.output.indexOf(state.messageItem);
+            writeSse(state.res, 'response.output_text.done', {
+                type: 'response.output_text.done',
+                item_id: state.messageItem.id,
+                output_index: outputIndex,
+                content_index: 0,
+                text: state.messageText,
+                sequence_number: state.nextSeq()
+            });
+            writeSse(state.res, 'response.output_item.done', {
+                type: 'response.output_item.done',
+                output_index: outputIndex,
+                item: state.messageItem,
+                sequence_number: state.nextSeq()
+            });
+        }
+
+        for (const toolCall of state.toolCalls) {
+            if (!toolCall) continue;
+            const item = {
+                type: 'function_call',
+                call_id: toolCall.id || `call_${crypto.randomBytes(8).toString('hex')}`,
+                name: toolCall.function && typeof toolCall.function.name === 'string' ? toolCall.function.name : '',
+                arguments: toolCall.function && typeof toolCall.function.arguments === 'string' ? toolCall.function.arguments : ''
+            };
+            const outputIndex = state.output.length;
+            state.output.push(item);
+            writeSse(state.res, 'response.output_item.added', {
+                type: 'response.output_item.added',
+                output_index: outputIndex,
+                item
+            });
+            writeSse(state.res, 'response.output_item.done', {
+                type: 'response.output_item.done',
+                output_index: outputIndex,
+                item,
+                sequence_number: state.nextSeq()
+            });
+        }
+
+        const response = ensureResponseMetadata({
+            id: state.responseId,
+            model: state.model,
+            created_at: state.createdAt,
+            status: 'completed',
+            output: state.output
+        });
+        writeSse(state.res, 'response.completed', { type: 'response.completed', response });
+        writeSse(state.res, 'done', '[DONE]');
+        state.res.end();
+    }
+
+    function streamChatCompletionsAsResponsesSse(targetUrl, options = {}) {
+        const parsed = new URL(targetUrl);
+        const transport = parsed.protocol === 'https:' ? https : http;
+        const bodyText = options.body ? JSON.stringify(options.body) : '';
+        const headers = {
+            'Accept': 'text/event-stream',
+            ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+            ...(options.headers || {})
+        };
+        if (options.body) {
+            headers['Content-Length'] = Buffer.byteLength(bodyText, 'utf-8');
+        }
+        const timeoutMs = Number.isFinite(options.timeoutMs)
+            ? Math.max(1000, Number(options.timeoutMs))
+            : 30000;
+        const res = options.res;
+        const model = typeof options.model === 'string' ? options.model : '';
+
+        return new Promise((resolve) => {
+            let settled = false;
+            const finish = (value) => {
+                if (settled) return;
+                settled = true;
+                resolve(value);
+            };
+            const req = transport.request({
+                protocol: parsed.protocol,
+                hostname: parsed.hostname,
+                port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+                method: options.method || 'POST',
+                path: `${parsed.pathname}${parsed.search}`,
+                headers,
+                agent: parsed.protocol === 'https:' ? HTTPS_KEEP_ALIVE_AGENT : HTTP_KEEP_ALIVE_AGENT
+            }, (upstreamRes) => {
+                const status = upstreamRes.statusCode || 0;
+                const chunks = [];
+                const contentType = String(upstreamRes.headers && upstreamRes.headers['content-type'] || '');
+
+                if (status === 404 || status === 405) {
+                    upstreamRes.on('data', (chunk) => chunk && chunks.push(chunk));
+                    upstreamRes.on('end', () => finish({ retry: true, status, bodyText: chunks.length ? Buffer.concat(chunks).toString('utf-8') : '' }));
+                    return;
+                }
+
+                if (status >= 400) {
+                    upstreamRes.on('data', (chunk) => chunk && chunks.push(chunk));
+                    upstreamRes.on('end', () => finish({ ok: false, status, bodyText: chunks.length ? Buffer.concat(chunks).toString('utf-8') : '' }));
+                    return;
+                }
+
+                res.writeHead(200, {
+                    'Content-Type': 'text/event-stream; charset=utf-8',
+                    'Cache-Control': 'no-cache',
+                    'Connection': 'keep-alive',
+                    'X-Accel-Buffering': 'no'
+                });
+
+                if (!/text\/event-stream/i.test(contentType)) {
+                    upstreamRes.on('data', (chunk) => chunk && chunks.push(chunk));
+                    upstreamRes.on('end', () => {
+                        const text = chunks.length ? Buffer.concat(chunks).toString('utf-8') : '';
+                        const parsedJson = parseJsonOrError(text);
+                        if (parsedJson.error) {
+                            writeSse(res, 'response.failed', { type: 'response.failed', error: `invalid upstream response: ${parsedJson.error}` });
+                            writeSse(res, 'done', '[DONE]');
+                            res.end();
+                            finish({ ok: true });
+                            return;
+                        }
+                        sendResponsesSse(res, buildResponsesPayloadFromChatCompletion(parsedJson.value, model));
+                        res.end();
+                        finish({ ok: true });
+                    });
+                    return;
+                }
+
+                let sequence = 0;
+                const state = {
+                    res,
+                    responseId: `resp_${crypto.randomBytes(10).toString('hex')}`,
+                    model,
+                    createdAt: Math.floor(Date.now() / 1000),
+                    output: [],
+                    messageItem: null,
+                    messageText: '',
+                    toolCalls: [],
+                    finished: false,
+                    nextSeq: () => {
+                        sequence += 1;
+                        return sequence;
+                    }
+                };
+                writeSse(res, 'response.created', {
+                    type: 'response.created',
+                    response: {
+                        id: state.responseId,
+                        model: state.model,
+                        created_at: state.createdAt
+                    }
+                });
+
+                let buffer = '';
+                const handleEventBlock = (block) => {
+                    const dataLines = String(block || '')
+                        .split(/\r?\n/)
+                        .filter((line) => line.startsWith('data:'))
+                        .map((line) => line.slice(5).trimStart());
+                    if (dataLines.length === 0) return;
+                    const data = dataLines.join('\n').trim();
+                    if (!data) return;
+                    if (data === '[DONE]') {
+                        finishChatStreamResponsesSse(state);
+                        finish({ ok: true });
+                        return;
+                    }
+                    const parsedChunk = parseJsonOrError(data);
+                    if (!parsedChunk.error) {
+                        writeChatCompletionChunkAsResponsesSse(state, parsedChunk.value);
+                    }
+                };
+
+                upstreamRes.on('data', (chunk) => {
+                    buffer += chunk.toString('utf-8');
+                    let boundary = buffer.search(/\r?\n\r?\n/);
+                    while (boundary >= 0) {
+                        const block = buffer.slice(0, boundary);
+                        const match = buffer.slice(boundary).match(/^\r?\n\r?\n/);
+                        buffer = buffer.slice(boundary + (match ? match[0].length : 2));
+                        handleEventBlock(block);
+                        boundary = buffer.search(/\r?\n\r?\n/);
+                    }
+                });
+                upstreamRes.on('end', () => {
+                    if (buffer.trim()) handleEventBlock(buffer);
+                    finishChatStreamResponsesSse(state);
+                    finish({ ok: true });
+                });
+            });
+            req.setTimeout(timeoutMs, () => {
+                try { req.destroy(new Error('timeout')); } catch (_) {}
+                finish({ ok: false, error: 'timeout' });
+            });
+            req.on('error', (err) => finish({ ok: false, error: err && err.message ? err.message : 'request failed' }));
+            if (bodyText) req.write(bodyText);
+            req.end();
+        });
+    }
+
+    async function streamChatCompletionsAsResponsesSseWithFallbackUrls(baseUrl, pathSuffix, options = {}) {
+        const urls = buildUpstreamUrlCandidates(baseUrl, pathSuffix);
+        if (urls.length === 0) {
+            return { ok: false, error: 'failed to build upstream URL' };
+        }
+        let lastResult = null;
+        for (const url of urls) {
+            const result = await streamChatCompletionsAsResponsesSse(url, options);
+            lastResult = result;
+            if (result && result.retry) continue;
+            return result;
+        }
+        return lastResult || { ok: false, error: 'failed to build upstream URL' };
+    }
+
     function canListenPort(host, port) {
         return new Promise((resolve) => {
             const tester = net.createServer();
@@ -1044,13 +1338,40 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                     }
 
                     if (!upstreamResponses.ok) {
-                        res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
-                        res.end(JSON.stringify({ error: upstreamResponses.error || 'Upstream request failed' }));
-                        return;
+                        if (!shouldFallbackFromUpstreamResponsesFailure(upstreamResponses.error)) {
+                            res.writeHead(502, { 'Content-Type': 'application/json; charset=utf-8' });
+                            res.end(JSON.stringify({ error: upstreamResponses.error || 'Upstream request failed' }));
+                            return;
+                        }
+                        // Some OpenAI-compatible gateways accept /responses but never complete it.
+                        // Treat that as an unsupported Responses endpoint and try the chat fallback.
                     }
 
                     const model = typeof payload.model === 'string' ? payload.model : '';
                     const chatBody = buildChatCompletionsBodyFromResponsesPayload(payload);
+
+                    if (wantsStream) {
+                        const streamingChatBody = { ...chatBody, stream: true };
+                        const streamed = await streamChatCompletionsAsResponsesSseWithFallbackUrls(upstream.baseUrl, 'chat/completions', {
+                            method: 'POST',
+                            headers: commonHeaders,
+                            timeoutMs,
+                            body: streamingChatBody,
+                            res,
+                            model
+                        });
+                        if (!streamed.ok) {
+                            if (!res.headersSent) {
+                                res.writeHead(streamed.status && streamed.status >= 400 ? streamed.status : 502, { 'Content-Type': 'application/json; charset=utf-8' });
+                                res.end(streamed.bodyText || JSON.stringify({ error: streamed.error || 'proxy request failed' }));
+                            } else if (!res.writableEnded) {
+                                writeSse(res, 'response.failed', { type: 'response.failed', error: streamed.error || streamed.bodyText || 'proxy request failed' });
+                                writeSse(res, 'done', '[DONE]');
+                                res.end();
+                            }
+                        }
+                        return;
+                    }
 
                     const upstreamChat = await proxyRequestJsonWithFallbackUrls(upstream.baseUrl, 'chat/completions', {
                         method: 'POST',

--- a/lib/cli-models-utils.js
+++ b/lib/cli-models-utils.js
@@ -48,35 +48,84 @@ const ANTHROPIC_CLAUDE_MODELS = Object.freeze([
     'claude-3-haiku'
 ]);
 
+const DEEPSEEK_CLAUDE_COMPAT_MODELS = Object.freeze([
+    'DeepSeek-V3.2',
+    'DeepSeek-V3',
+    'DeepSeek-R1',
+    'deepseek-chat'
+]);
+
+const QWEN_CLAUDE_COMPAT_MODELS = Object.freeze([
+    'qwen3-coder',
+    'qwen-max',
+    'qwen-plus',
+    'qwen-turbo'
+]);
+
+const MODELSCOPE_CLAUDE_COMPAT_MODELS = Object.freeze([
+    'ZhipuAI/GLM-5'
+]);
+
 function normalizeModelCatalogId(value) {
     return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-function isBigModelClaudeCompatibleBaseUrl(baseUrl) {
+function hasPathSegment(baseUrl, segment) {
     const normalized = normalizeBaseUrl(baseUrl);
     if (!normalized) return false;
     try {
         const parsed = new URL(normalized);
-        const host = String(parsed.hostname || '').toLowerCase();
         const pathname = String(parsed.pathname || '').toLowerCase();
-        const isBigModelHost = host === 'bigmodel.cn' || host.endsWith('.bigmodel.cn');
-        const hasAnthropicSegment = /(^|\/)anthropic(\/|$)/.test(pathname);
-        return isBigModelHost && hasAnthropicSegment;
+        const escaped = String(segment || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&').toLowerCase();
+        return new RegExp(`(^|/)${escaped}(/|$)`).test(pathname);
     } catch (_) {
         return false;
     }
 }
 
-function isAnthropicBaseUrl(baseUrl) {
+function getBaseUrlHost(baseUrl) {
     const normalized = normalizeBaseUrl(baseUrl);
-    if (!normalized) return false;
+    if (!normalized) return '';
     try {
         const parsed = new URL(normalized);
-        const host = String(parsed.hostname || '').toLowerCase();
-        return host === 'api.anthropic.com' || host.endsWith('.anthropic.com');
+        return String(parsed.hostname || '').toLowerCase();
     } catch (_) {
-        return false;
+        return '';
     }
+}
+
+function isHostOrSubdomain(host, domain) {
+    return host === domain || host.endsWith(`.${domain}`);
+}
+
+function isBigModelClaudeCompatibleBaseUrl(baseUrl) {
+    const host = getBaseUrlHost(baseUrl);
+    return isHostOrSubdomain(host, 'bigmodel.cn') && hasPathSegment(baseUrl, 'anthropic');
+}
+
+function isAnthropicBaseUrl(baseUrl) {
+    const host = getBaseUrlHost(baseUrl);
+    return isHostOrSubdomain(host, 'anthropic.com');
+}
+
+function isDeepSeekClaudeCompatibleBaseUrl(baseUrl) {
+    const host = getBaseUrlHost(baseUrl);
+    return isHostOrSubdomain(host, 'deepseek.com') && hasPathSegment(baseUrl, 'anthropic');
+}
+
+function isQwenClaudeCompatibleBaseUrl(baseUrl) {
+    const host = getBaseUrlHost(baseUrl);
+    return isHostOrSubdomain(host, 'dashscope.aliyuncs.com') && hasPathSegment(baseUrl, 'anthropic');
+}
+
+function isZaiClaudeCompatibleBaseUrl(baseUrl) {
+    const host = getBaseUrlHost(baseUrl);
+    return isHostOrSubdomain(host, 'z.ai') && hasPathSegment(baseUrl, 'anthropic');
+}
+
+function isModelScopeBaseUrl(baseUrl) {
+    const host = getBaseUrlHost(baseUrl);
+    return isHostOrSubdomain(host, 'modelscope.cn');
 }
 
 function getSupplementalModelsForBaseUrl(baseUrl) {
@@ -85,6 +134,18 @@ function getSupplementalModelsForBaseUrl(baseUrl) {
     }
     if (isAnthropicBaseUrl(baseUrl)) {
         return [...ANTHROPIC_CLAUDE_MODELS];
+    }
+    if (isDeepSeekClaudeCompatibleBaseUrl(baseUrl)) {
+        return [...DEEPSEEK_CLAUDE_COMPAT_MODELS];
+    }
+    if (isQwenClaudeCompatibleBaseUrl(baseUrl)) {
+        return [...QWEN_CLAUDE_COMPAT_MODELS];
+    }
+    if (isZaiClaudeCompatibleBaseUrl(baseUrl)) {
+        return [...BIGMODEL_CLAUDE_COMPAT_MODELS];
+    }
+    if (isModelScopeBaseUrl(baseUrl)) {
+        return [...MODELSCOPE_CLAUDE_COMPAT_MODELS];
     }
     return [];
 }

--- a/plugins/prompt-templates/issue-inject/index.mjs
+++ b/plugins/prompt-templates/issue-inject/index.mjs
@@ -1,0 +1,27 @@
+import { pluginOwnership, templateOwnershipById } from '../ownership.mjs';
+
+export function buildBuiltinIssueInjectTemplate(t) {
+    const tr = (key, fallback, params = null) => (typeof t === 'function' ? t(key, params) : fallback);
+    const timestamp = new Date().toISOString();
+    const ownership = templateOwnershipById && templateOwnershipById.builtin_issue_inject
+        ? templateOwnershipById.builtin_issue_inject
+        : pluginOwnership;
+    return {
+        id: 'builtin_issue_inject',
+        name: tr('plugins.builtin.issueInject.name', 'Issue inject'),
+        description: tr('plugins.builtin.issueInject.desc', 'Inject {{issue}} into issue {{num}}'),
+        template: [
+            tr('plugins.builtin.issueInject.line1', '## Requirements'),
+            '',
+            '{{issue}}',
+            '',
+            tr('plugins.builtin.issueInject.line2', '## Verification'),
+            ''
+        ].join('\n'),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        isBuiltin: true,
+        createdBy: ownership && typeof ownership.createdBy === 'string' ? ownership.createdBy : '',
+        maintainers: ownership && Array.isArray(ownership.maintainers) ? ownership.maintainers : []
+    };
+}

--- a/plugins/prompt-templates/overview.mjs
+++ b/plugins/prompt-templates/overview.mjs
@@ -6,6 +6,7 @@ import {
 } from './storage.mjs';
 import { buildBuiltinCommentPolishTemplate } from './comment-polish/index.mjs';
 import { buildBuiltinRuleAckTemplate } from './rule-ack/index.mjs';
+import { buildBuiltinIssueInjectTemplate } from './issue-inject/index.mjs';
 
 function ensureBuiltinTemplates(rawList, builtins) {
     const list = Array.isArray(rawList) ? rawList.filter(Boolean) : [];
@@ -32,7 +33,8 @@ export async function loadPromptTemplatesOverview(ctx, options = {}) {
     const rawList = readPromptTemplatesFromStorage(localStorage);
     const normalized = ensureBuiltinTemplates(rawList, [
         buildBuiltinCommentPolishTemplate(t),
-        buildBuiltinRuleAckTemplate(t)
+        buildBuiltinRuleAckTemplate(t),
+        buildBuiltinIssueInjectTemplate(t)
     ]);
     app.promptTemplatesListRaw = normalized;
     persistPromptTemplatesToStorage(normalized, localStorage);

--- a/plugins/prompt-templates/ownership.mjs
+++ b/plugins/prompt-templates/ownership.mjs
@@ -14,6 +14,11 @@ export const templateOwnershipById = {
         templateId: 'builtin_rule_ack',
         createdBy: 'ymkiux',
         maintainers: ['ymkiux']
+    },
+    builtin_issue_inject: {
+        templateId: 'builtin_issue_inject',
+        createdBy: 'ymkiux',
+        maintainers: ['ymkiux']
     }
 };
 

--- a/tests/unit/builtin-proxy-responses-shim.test.mjs
+++ b/tests/unit/builtin-proxy-responses-shim.test.mjs
@@ -110,7 +110,7 @@ function createTestController() {
 async function startTestProxy(upstreamPort, options = {}) {
     const controller = createTestController();
     const runtime = await controller.createBuiltinProxyServer(
-        { host: '127.0.0.1', port: 0, timeoutMs: 2000 },
+        { host: '127.0.0.1', port: 0, timeoutMs: options.timeoutMs || 2000 },
         {
             providerName: options.providerName || 'test',
             baseUrl: options.baseUrl || `http://127.0.0.1:${upstreamPort}/v1`,
@@ -159,6 +159,112 @@ test('builtin-proxy /v1/responses falls back to chat-only upstream and returns R
         assert.equal(parsed.output[0].type, 'message');
         assert.equal(parsed.output[0].content[0].type, 'output_text');
         assert.equal(parsed.output[0].content[0].text, 'hello-from-chat');
+    } finally {
+        if (proxyRuntime) {
+            await closeServer(proxyRuntime.server, proxyRuntime.connections);
+        }
+        await closeServer(upstream);
+    }
+});
+
+test('builtin-proxy /v1/responses falls back to chat when upstream responses times out', async () => {
+    const sockets = new Set();
+    let capturedChatRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            // Simulate gateways that accept /responses but never complete the request.
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            const chunks = [];
+            req.on('data', (chunk) => chunks.push(chunk));
+            req.on('end', () => {
+                capturedChatRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    id: 'chatcmpl_after_timeout',
+                    model: 'gpt-test',
+                    choices: [{ message: { role: 'assistant', content: 'fallback-after-timeout' } }]
+                }));
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    upstream.on('connection', (socket) => {
+        sockets.add(socket);
+        socket.on('close', () => sockets.delete(socket));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+    let proxyRuntime = null;
+
+    try {
+        proxyRuntime = await startTestProxy(upstreamPort, { timeoutMs: 1000 });
+        const proxyPort = proxyRuntime.server.address().port;
+        const resp = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: { model: 'gpt-test', input: 'ping', stream: false }
+        });
+        assert.equal(resp.status, 200);
+        assert.ok(capturedChatRequest, 'chat fallback should run after responses timeout');
+        assert.equal(capturedChatRequest.stream, false);
+        const parsed = JSON.parse(resp.text);
+        assert.equal(parsed.output[0].content[0].text, 'fallback-after-timeout');
+    } finally {
+        if (proxyRuntime) {
+            await closeServer(proxyRuntime.server, proxyRuntime.connections);
+        }
+        await closeServer(upstream, sockets);
+    }
+});
+
+test('builtin-proxy /v1/responses stream=true streams chat fallback as Responses SSE', async () => {
+    let capturedChatRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'responses endpoint unavailable' }));
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            const chunks = [];
+            req.on('data', (chunk) => chunks.push(chunk));
+            req.on('end', () => {
+                capturedChatRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+                res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+                res.write('data: {"id":"chatcmpl_stream","model":"gpt-test","choices":[{"delta":{"role":"assistant"}}]}\n\n');
+                res.write('data: {"id":"chatcmpl_stream","model":"gpt-test","choices":[{"delta":{"content":"hello"}}]}\n\n');
+                res.write('data: {"id":"chatcmpl_stream","model":"gpt-test","choices":[{"delta":{"content":"-stream"}}]}\n\n');
+                res.end('data: [DONE]\n\n');
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+    let proxyRuntime = null;
+
+    try {
+        proxyRuntime = await startTestProxy(upstreamPort);
+        const proxyPort = proxyRuntime.server.address().port;
+        const sse = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: { model: 'gpt-test', input: 'ping', stream: true }
+        });
+        assert.equal(sse.status, 200);
+        assert.ok(capturedChatRequest, 'streaming chat fallback should be called');
+        assert.equal(capturedChatRequest.stream, true);
+        assert.match(sse.headers['content-type'], /text\/event-stream/i);
+        assert.match(sse.text, /event: response\.created/);
+        assert.match(sse.text, /event: response\.output_text\.delta/);
+        assert.match(sse.text, /"delta":"hello"/);
+        assert.match(sse.text, /"delta":"-stream"/);
+        assert.match(sse.text, /event: response\.completed/);
+        assert.match(sse.text, /data: \[DONE\]/);
     } finally {
         if (proxyRuntime) {
             await closeServer(proxyRuntime.server, proxyRuntime.connections);

--- a/tests/unit/claude-settings-sync.test.mjs
+++ b/tests/unit/claude-settings-sync.test.mjs
@@ -381,7 +381,7 @@ test('applyClaudeConfig reports informative message for external credential only
     const result = await applyClaudeConfig.call(context, 'imported');
     assert.strictEqual(context.currentClaudeConfig, 'imported');
     assert.strictEqual(refreshCount, 1);
-    assert.deepStrictEqual(messages, [{ msg: '检测到外部 Claude 认证状态；当前仅支持展示，若需由 codexmate 接管请补充 API Key', type: 'info' }]);
+    assert.deepStrictEqual(messages, [{ msg: '使用外部认证，无需 API Key', type: 'info' }]);
     assert.deepStrictEqual(result, messages[0]);
 });
 

--- a/tests/unit/cli-models-utils.test.mjs
+++ b/tests/unit/cli-models-utils.test.mjs
@@ -32,9 +32,25 @@ test('getSupplementalModelsForBaseUrl returns Anthropic Claude models for offici
     assert(!models.includes('glm-5.1'));
 });
 
+test('getSupplementalModelsForBaseUrl returns provider-specific Claude-compatible Codex catalogs', () => {
+    const deepseekModels = getSupplementalModelsForBaseUrl('https://api.deepseek.com/anthropic');
+    const qwenModels = getSupplementalModelsForBaseUrl('https://coding.dashscope.aliyuncs.com/apps/anthropic');
+    const zaiModels = getSupplementalModelsForBaseUrl('https://api.z.ai/api/anthropic');
+    const modelscopeModels = getSupplementalModelsForBaseUrl('https://api-inference.modelscope.cn');
+
+    assert(deepseekModels.includes('DeepSeek-V3.2'));
+    assert(!deepseekModels.includes('qwen3-coder'));
+    assert(qwenModels.includes('qwen3-coder'));
+    assert(!qwenModels.includes('DeepSeek-V3.2'));
+    assert(zaiModels.includes('glm-5'));
+    assert(modelscopeModels.includes('ZhipuAI/GLM-5'));
+});
+
 test('getSupplementalModelsForBaseUrl does not match unrelated bigmodel hosts or paths', () => {
     assert.deepStrictEqual(getSupplementalModelsForBaseUrl('https://notbigmodel.cn/api/anthropic'), []);
     assert.deepStrictEqual(getSupplementalModelsForBaseUrl('https://open.bigmodel.cn/api/anthropicx'), []);
+    assert.deepStrictEqual(getSupplementalModelsForBaseUrl('https://api.deepseek.com/v1'), []);
+    assert.deepStrictEqual(getSupplementalModelsForBaseUrl('https://coding.dashscope.aliyuncs.com/apps/openai'), []);
 });
 
 test('mergeModelCatalog keeps remote order and appends missing Claude endpoint extras once', () => {

--- a/tests/unit/compact-layout-ui.test.mjs
+++ b/tests/unit/compact-layout-ui.test.mjs
@@ -62,7 +62,9 @@ test('styles keep desktop layout wide and session history readable on large scre
     assert.match(styles, /\.session-layout\s*\{[\s\S]*grid-template-columns:\s*minmax\(260px,\s*360px\)\s*minmax\(0,\s*1fr\);/);
     assert.match(styles, /\.session-preview-scroll\s*\{[\s\S]*padding-right:\s*52px;/);
     assert.match(styles, /\.session-timeline\s*\{[\s\S]*right:\s*4px;[\s\S]*width:\s*44px;/);
-    assert.match(styles, /\.session-item\s*\{[\s\S]*min-height:\s*80px;/);
+    assert.match(styles, /\.session-item\s*\{[\s\S]*min-height:\s*108px;[\s\S]*contain-intrinsic-size:\s*108px;/);
+    assert.match(styles, /\.session-item-cwd\s*\{[\s\S]*flex:\s*1 0 100%;[\s\S]*white-space:\s*normal;[\s\S]*overflow:\s*visible;[\s\S]*overflow-wrap:\s*anywhere;/);
+    assert.doesNotMatch(styles, /@media \(max-width: 540px\)\s*\{[\s\S]*\.session-item\s*\{[\s\S]*height:\s*75px;/);
 
     const html = readBundledWebUiHtml();
     assert.match(html, /class="brand-logo"\s+src="\/res\/logo-pack\.webp"/);

--- a/web-ui/modules/app.methods.claude-config.mjs
+++ b/web-ui/modules/app.methods.claude-config.mjs
@@ -77,7 +77,7 @@ export function createClaudeConfigMethods(options = {}) {
 
             const config = this.claudeConfigs[name];
             if (!config.apiKey) {
-                this.showMessage('已保存，未应用', 'info');
+                this.showMessage('已保存（未填写 API Key）', 'info');
                 this.closeEditConfigModal();
                 if (name === this.currentClaudeConfig) {
                     this.refreshClaudeModelContext();
@@ -91,8 +91,7 @@ export function createClaudeConfigMethods(options = {}) {
                     this.showMessage(res.error || '应用配置失败', 'error');
                 } else {
                     this.currentClaudeConfig = name;
-                    const targetTip = res.targetPath ? `（${res.targetPath}）` : '';
-                    this.showMessage(`已保存并应用到 Claude 配置${targetTip}`, 'success');
+                    this.showMessage('Claude 配置已生效', 'success');
                     this.closeEditConfigModal();
                     this.refreshClaudeModelContext();
                 }
@@ -153,7 +152,7 @@ export function createClaudeConfigMethods(options = {}) {
 
             if (!config.apiKey) {
                 if (config.externalCredentialType) {
-                    return this.showMessage('检测到外部 Claude 认证状态；当前仅支持展示，若需由 codexmate 接管请补充 API Key', 'info');
+                    return this.showMessage('使用外部认证，无需 API Key', 'info');
                 }
                 return this.showMessage('请先配置 API Key', 'error');
             }
@@ -163,8 +162,7 @@ export function createClaudeConfigMethods(options = {}) {
                 if (res.error || res.success === false) {
                     this.showMessage(res.error || '应用配置失败', 'error');
                 } else {
-                    const targetTip = res.targetPath ? `（${res.targetPath}）` : '';
-                    this.showMessage(`已应用配置到 Claude 设置: ${name}${targetTip}`, 'success');
+                    this.showMessage('配置已应用', 'success');
                 }
             } catch (_) {
                 this.showMessage('应用配置失败', 'error');

--- a/web-ui/modules/app.methods.claude-config.mjs
+++ b/web-ui/modules/app.methods.claude-config.mjs
@@ -85,13 +85,17 @@ export function createClaudeConfigMethods(options = {}) {
                 return;
             }
 
+            const _claudeKey = `${name}|${config.apiKey || ""}|${config.baseUrl || ""}|${config.model || ""}`;
             try {
                 const res = await api('apply-claude-config', { config });
                 if (res.error || res.success === false) {
                     this.showMessage(res.error || '应用配置失败', 'error');
                 } else {
                     this.currentClaudeConfig = name;
-                    this.showMessage('Claude 配置已生效', 'success');
+                    if (this._lastAppliedClaudeKey !== _claudeKey) {
+                        this.showMessage('Claude 配置已生效', 'success');
+                        this._lastAppliedClaudeKey = _claudeKey;
+                    }
                     this.closeEditConfigModal();
                     this.refreshClaudeModelContext();
                 }
@@ -157,12 +161,16 @@ export function createClaudeConfigMethods(options = {}) {
                 return this.showMessage('请先配置 API Key', 'error');
             }
 
+            const _claudeKey2 = `${name}|${config.apiKey || ""}|${config.baseUrl || ""}|${config.model || ""}`;
             try {
                 const res = await api('apply-claude-config', { config });
                 if (res.error || res.success === false) {
                     this.showMessage(res.error || '应用配置失败', 'error');
                 } else {
-                    this.showMessage('配置已应用', 'success');
+                    if (this._lastAppliedClaudeKey !== _claudeKey2) {
+                        this.showMessage('配置已应用', 'success');
+                        this._lastAppliedClaudeKey = _claudeKey2;
+                    }
                 }
             } catch (_) {
                 this.showMessage('应用配置失败', 'error');

--- a/web-ui/modules/app.methods.codex-config.mjs
+++ b/web-ui/modules/app.methods.codex-config.mjs
@@ -629,6 +629,8 @@ export function createCodexConfigMethods(options = {}) {
             this.modelContextWindowInput = modelContextWindow.text;
             this.modelAutoCompactTokenLimitInput = modelAutoCompactTokenLimit.text;
 
+            const _codexKey = `${provider}|${model}|${this.serviceTier || ""}|${this.modelReasoningEffort || ""}|${modelContextWindow.value}|${modelAutoCompactTokenLimit.value}`;
+
             this.codexApplying = true;
             try {
                 const tplRes = await api('get-config-template', {
@@ -665,7 +667,12 @@ export function createCodexConfigMethods(options = {}) {
                 }
 
                 if (options.silent !== true) {
-                    this.showMessage('配置已应用', 'success');
+                    if (this._lastAppliedCodexKey !== _codexKey) {
+                        this.showMessage('配置已应用', 'success');
+                        this._lastAppliedCodexKey = _codexKey;
+                    }
+                } else {
+                    this._lastAppliedCodexKey = _codexKey;
                 }
 
                 const refreshOptions = options.silent === true

--- a/web-ui/modules/i18n.dict.mjs
+++ b/web-ui/modules/i18n.dict.mjs
@@ -357,6 +357,10 @@ const DICT = Object.freeze({
         'plugins.builtin.ruleAck.name': '规则确认回复',
         'plugins.builtin.ruleAck.desc': '请根据【{{rule}}】，收到请回复',
         'plugins.builtin.ruleAck.line1': '请根据【{{rule}}】，收到请回复',
+        'plugins.builtin.issueInject.name': 'Issue 注入',
+        'plugins.builtin.issueInject.desc': '将 {{issue}} 注入到 issue {{num}}',
+        'plugins.builtin.issueInject.line1': '## 需求',
+        'plugins.builtin.issueInject.line2': '## 验证',
 
         // Toasts
         'toast.copy.empty': '没有可复制内容',
@@ -1420,6 +1424,10 @@ const DICT = Object.freeze({
         'plugins.builtin.ruleAck.name': 'Rule acknowledgement',
         'plugins.builtin.ruleAck.desc': 'Please follow 【{{rule}}】, reply when received',
         'plugins.builtin.ruleAck.line1': 'Please follow 【{{rule}}】, reply when received',
+        'plugins.builtin.issueInject.name': 'Issue inject',
+        'plugins.builtin.issueInject.desc': 'Inject {{issue}} into issue {{num}}',
+        'plugins.builtin.issueInject.line1': '## Requirements',
+        'plugins.builtin.issueInject.line2': '## Verification',
 
         // Toasts
         'toast.copy.empty': 'Nothing to copy',

--- a/web-ui/styles/base-theme.css
+++ b/web-ui/styles/base-theme.css
@@ -4,34 +4,36 @@
    设计系统 - Design Tokens
    ============================================ */
 :root {
-    /* 色彩系统：中性灰（更贴近 craft/shadcn 观感）+ 品牌强调 */
-    --color-brand: #C77462;
-    --color-brand-dark: #B45E4E;
-    --color-brand-light: rgba(199, 116, 98, 0.12);
-    --color-brand-subtle: rgba(199, 116, 98, 0.18);
+    /* 色彩系统：低饱和暖色 + 桌面助理式柔和层级 */
+    --color-brand: #C87963;
+    --color-brand-dark: #A95845;
+    --color-brand-light: rgba(200, 121, 99, 0.13);
+    --color-brand-subtle: rgba(200, 121, 99, 0.2);
 
-    --color-bg: #FAFAFA;
-    --color-surface: #FFFFFF;
-    --color-surface-alt: #F4F4F5;
+    --color-bg: #F7F0E9;
+    --color-surface: #FFFDFC;
+    --color-surface-alt: #F7EFE8;
     --color-surface-elevated: #FFFFFF;
-    --color-surface-tint: rgba(255, 255, 255, 0.92);
-    --color-text-primary: #18181B;
-    --color-text-secondary: #3F3F46;
-    --color-text-tertiary: #71717A;
-    --color-text-muted: #A1A1AA;
-    --color-border: #E4E4E7;
-    --color-border-soft: rgba(24, 24, 27, 0.12);
-    --color-border-strong: rgba(24, 24, 27, 0.24);
+    --color-surface-tint: rgba(255, 253, 250, 0.86);
+    --color-text-primary: #241F1C;
+    --color-text-secondary: #5A504A;
+    --color-text-tertiary: #82746A;
+    --color-text-muted: #A99B91;
+    --color-border: rgba(137, 111, 94, 0.18);
+    --color-border-soft: rgba(137, 111, 94, 0.13);
+    --color-border-strong: rgba(137, 111, 94, 0.34);
 
     --color-success: #4B8B6A;
     --color-error: #C44536;
 
     --bg-warm-gradient:
-        linear-gradient(180deg, #FAFAFA 0%, #FAFAFA 100%);
+        radial-gradient(circle at 14% 8%, rgba(255, 219, 196, 0.5) 0%, rgba(255, 219, 196, 0) 32%),
+        radial-gradient(circle at 88% 0%, rgba(252, 239, 207, 0.58) 0%, rgba(252, 239, 207, 0) 30%),
+        linear-gradient(135deg, #FFF8F1 0%, #F7F0E9 46%, #F1E8DF 100%);
 
-    --color-bg-topbar-strong: rgba(250, 250, 250, 0.96);
-    --color-bg-topbar-soft: rgba(250, 250, 250, 0.9);
-    --color-bg-topbar-clear: rgba(250, 250, 250, 0);
+    --color-bg-topbar-strong: rgba(255, 248, 241, 0.96);
+    --color-bg-topbar-soft: rgba(255, 248, 241, 0.86);
+    --color-bg-topbar-clear: rgba(255, 248, 241, 0);
 
     /* 字体系统 */
     --font-family-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
@@ -64,24 +66,24 @@
     --spacing-xl: 64px;
 
     /* 圆角系统 */
-    --radius-sm: 8px;
-    --radius-md: 10px;
-    --radius-lg: 12px;
-    --radius-xl: 16px;
+    --radius-sm: 10px;
+    --radius-md: 14px;
+    --radius-lg: 18px;
+    --radius-xl: 24px;
     --radius-full: 50px;
 
-    /* 阴影系统 - 更偏中性与克制 */
-    --shadow-subtle: 0 1px 2px rgba(24, 24, 27, 0.04);
-    --shadow-card: 0 1px 3px rgba(24, 24, 27, 0.06);
-    --shadow-card-hover: 0 8px 26px rgba(24, 24, 27, 0.12);
-    --shadow-float: 0 14px 36px rgba(24, 24, 27, 0.16);
-    --shadow-raised: 0 8px 18px rgba(24, 24, 27, 0.12);
+    /* 阴影系统 - 柔和桌面浮层 */
+    --shadow-subtle: 0 1px 2px rgba(60, 47, 38, 0.05);
+    --shadow-card: 0 12px 30px rgba(92, 68, 52, 0.08);
+    --shadow-card-hover: 0 18px 44px rgba(92, 68, 52, 0.14);
+    --shadow-float: 0 22px 56px rgba(70, 51, 39, 0.18);
+    --shadow-raised: 0 14px 30px rgba(92, 68, 52, 0.14);
     --shadow-modal:
-        0 10px 30px rgba(24, 24, 27, 0.14),
-        0 28px 72px rgba(24, 24, 27, 0.12);
+        0 16px 42px rgba(70, 51, 39, 0.16),
+        0 34px 84px rgba(70, 51, 39, 0.16);
     --shadow-input-focus:
         0 0 0 3px var(--color-brand-light),
-        0 1px 2px rgba(24, 24, 27, 0.06);
+        0 1px 2px rgba(60, 47, 38, 0.06);
 
     /* 动画 - 更细腻的曲线 */
     --transition-instant: 100ms;
@@ -265,4 +267,15 @@ body {
     -moz-osx-font-smoothing: grayscale;
     position: relative;
     overflow-x: hidden;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 18% 16%, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0) 26%),
+        radial-gradient(circle at 86% 18%, rgba(255, 232, 206, 0.36), rgba(255, 232, 206, 0) 30%);
+    z-index: 0;
 }

--- a/web-ui/styles/controls-forms.css
+++ b/web-ui/styles/controls-forms.css
@@ -2,13 +2,12 @@
    选择器 - 用于模型选择
    ============================================ */
 .selector-section {
-    background: transparent;
-    border-radius: 0;
-    padding: 12px 0 0;
+    background: rgba(255, 255, 255, 0.36);
+    border-radius: var(--radius-md);
+    padding: 12px;
     margin-bottom: 12px;
-    box-shadow: none;
-    border: none;
-    border-top: 1px solid var(--color-border);
+    box-shadow: var(--shadow-subtle);
+    border: 1px solid var(--color-border-soft);
     display: flex;
     flex-direction: column;
     gap: 6px;
@@ -125,9 +124,9 @@
     min-height: 28px !important;
     padding: 0 10px !important;
     line-height: 1 !important;
-    border-radius: 8px !important;
+    border-radius: var(--radius-sm) !important;
     border: 1px solid var(--color-border-soft) !important;
-    background: rgba(255, 255, 255, 0.72) !important;
+    background: rgba(255, 255, 255, 0.76) !important;
     font-size: 12px !important;
     font-weight: var(--font-weight-secondary) !important;
     color: var(--color-text-secondary) !important;
@@ -197,12 +196,12 @@
     align-items: center;
     justify-content: center;
     transition: all var(--transition-fast) var(--ease-spring);
-    box-shadow: 0 2px 4px rgba(210, 107, 90, 0.2);
+    box-shadow: 0 8px 18px rgba(92, 68, 52, 0.12);
 }
 
 .btn-icon:hover {
     transform: translateY(-1px) scale(1.05);
-    box-shadow: 0 4px 8px rgba(210, 107, 90, 0.25);
+    box-shadow: 0 12px 24px rgba(92, 68, 52, 0.16);
 }
 
 .btn-icon:active {
@@ -214,11 +213,11 @@
     min-height: 36px;
     padding: 8px 10px;
     padding-right: 34px;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-sm);
     font-size: 13px;
     font-weight: var(--font-weight-body);
-    background-color: var(--color-surface);
+    background-color: rgba(255, 255, 255, 0.72);
     color: var(--color-text-primary);
     outline: none;
     cursor: pointer;
@@ -228,12 +227,12 @@
     background-position: right 14px center;
     background-size: 12px;
     transition: all var(--transition-fast) var(--ease-smooth);
-    box-shadow: none;
+    box-shadow: var(--shadow-subtle);
 }
 
 .model-select:hover {
     border-color: var(--color-border-strong);
-    background-color: var(--color-surface);
+    background-color: rgba(255, 255, 255, 0.9);
 }
 
 .model-select:focus {
@@ -246,20 +245,20 @@
     width: 100%;
     min-height: 36px;
     padding: 8px 10px;
-    border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border: 1px solid var(--color-border-soft);
+    border-radius: var(--radius-sm);
     font-size: 13px;
     font-weight: var(--font-weight-body);
-    background-color: var(--color-surface);
+    background-color: rgba(255, 255, 255, 0.72);
     color: var(--color-text-primary);
     outline: none;
     transition: all var(--transition-fast) var(--ease-smooth);
-    box-shadow: none;
+    box-shadow: var(--shadow-subtle);
 }
 
 .model-input:hover {
     border-color: var(--color-border-strong);
-    background-color: var(--color-surface);
+    background-color: rgba(255, 255, 255, 0.9);
 }
 
 .model-input:focus {
@@ -300,9 +299,9 @@
     width: 100%;
     min-height: 38px;
     padding: 8px 10px;
-    border: 1px dashed rgba(208, 196, 182, 0.55);
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.22);
+    border: 1px dashed rgba(137, 111, 94, 0.28);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.42);
     font-size: 13px;
     font-weight: var(--font-weight-secondary);
     color: var(--color-text-tertiary);
@@ -324,7 +323,7 @@
 .btn-add:hover {
     border-color: var(--color-brand);
     color: var(--color-brand);
-    background: linear-gradient(to bottom, rgba(210, 107, 90, 0.05) 0%, rgba(210, 107, 90, 0.02) 100%);
+    background: linear-gradient(to bottom, rgba(200, 121, 99, 0.12) 0%, rgba(255, 255, 255, 0.52) 100%);
     transform: translateY(-1px);
 }
 
@@ -345,15 +344,15 @@
 .btn-tool {
     min-height: 36px;
     padding: 8px 10px;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--color-border-soft);
-    background: rgba(255, 255, 255, 0.72);
+    background: rgba(255, 255, 255, 0.68);
     font-size: 13px;
     font-weight: var(--font-weight-secondary);
     color: var(--color-text-secondary);
     cursor: pointer;
     transition: all var(--transition-fast) var(--ease-spring);
-    box-shadow: none;
+    box-shadow: var(--shadow-subtle);
     letter-spacing: -0.01em;
     width: 100%;
     text-align: center;
@@ -379,7 +378,7 @@
     border-color: var(--color-brand);
     color: var(--color-brand);
     transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(210, 107, 90, 0.12);
+    box-shadow: 0 10px 22px rgba(92, 68, 52, 0.1);
 }
 
 .btn-tool:disabled,

--- a/web-ui/styles/layout-shell.css
+++ b/web-ui/styles/layout-shell.css
@@ -3,7 +3,7 @@
    ============================================ */
 body::before,
 body::after {
-    content: none;
+    pointer-events: none;
 }
 
 /* ============================================
@@ -34,7 +34,7 @@ body::after {
     min-height: 100vh;
     height: 100vh;
     overflow: hidden;
-    background: var(--color-bg);
+    background: transparent;
 }
 
 .app-shell.standalone {
@@ -48,16 +48,17 @@ body::after {
     display: flex;
     flex-direction: column;
     gap: 0;
-    padding: 0;
-    background: var(--color-surface);
-    border-right: 1px solid var(--color-border);
+    padding: 10px 8px;
+    background:
+        linear-gradient(180deg, rgba(255, 253, 250, 0.92) 0%, rgba(255, 248, 241, 0.82) 100%);
+    border-right: 1px solid rgba(137, 111, 94, 0.16);
     border-radius: 0;
-    box-shadow: none;
+    box-shadow: 18px 0 42px rgba(92, 68, 52, 0.08);
     min-height: 100vh;
     overflow-y: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
-    backdrop-filter: none;
+    backdrop-filter: blur(18px) saturate(130%);
 }
 
 .side-rail::-webkit-scrollbar {
@@ -73,11 +74,11 @@ body::after {
     display: flex;
     flex-direction: column;
     gap: 4px;
-    padding: 6px;
+    padding: 7px 4px;
 }
 
 .side-section + .side-section {
-    border-top: 1px solid var(--color-border);
+    border-top: 1px solid rgba(137, 111, 94, 0.12);
 }
 
 .side-rail-nav {
@@ -129,8 +130,8 @@ body::after {
 }
 
 .lang-choice-btn.active {
-    border-color: rgba(199, 116, 98, 0.55);
-    background: rgba(199, 116, 98, 0.14);
+    border-color: rgba(200, 121, 99, 0.55);
+    background: rgba(200, 121, 99, 0.14);
     color: var(--color-brand-dark);
 }
 
@@ -201,7 +202,7 @@ body::after {
 }
 
 .lang-fab .lang-switch:hover .lang-switch-track {
-    border-color: rgba(199, 116, 98, 0.7);
+    border-color: rgba(200, 121, 99, 0.7);
 }
 
 .side-rail-lang {
@@ -209,10 +210,10 @@ body::after {
     bottom: 0;
     z-index: 2;
     margin-top: auto;
-    padding: 12px 10px;
-    background: transparent;
-    border-top: 1px solid var(--color-border);
-    backdrop-filter: none;
+    padding: 12px 4px 4px;
+    background: linear-gradient(180deg, rgba(255, 248, 241, 0), rgba(255, 248, 241, 0.92) 34%);
+    border-top: 1px solid rgba(137, 111, 94, 0.12);
+    backdrop-filter: blur(10px);
     display: flex;
     justify-content: center;
 }
@@ -249,7 +250,7 @@ body::after {
 }
 
 .lang-switch:hover .lang-switch-track {
-    border-color: rgba(199, 116, 98, 0.6);
+    border-color: rgba(200, 121, 99, 0.6);
     background: rgba(255, 253, 252, 0.92);
     transform: translateY(-1px);
 }
@@ -297,7 +298,7 @@ body::after {
     content: "";
     position: absolute;
     inset: -20px;
-    background: radial-gradient(circle at 30% 20%, rgba(199, 116, 98, 0.18), rgba(199, 116, 98, 0) 55%);
+    background: radial-gradient(circle at 30% 20%, rgba(200, 121, 99, 0.18), rgba(200, 121, 99, 0) 55%);
     opacity: 0;
     transform: translateY(10px);
     transition: opacity 240ms var(--ease-smooth), transform 240ms var(--ease-smooth);
@@ -322,13 +323,13 @@ body::after {
 .side-item {
     width: 100%;
     text-align: left;
-    padding: 5px;
-    border-radius: 8px;
+    padding: 8px 10px;
+    border-radius: 13px;
     border: 1px solid transparent;
     background: transparent;
     color: var(--color-text-secondary);
     cursor: pointer;
-    transition: border-color var(--transition-fast) var(--ease-smooth), background-color var(--transition-fast) var(--ease-smooth), color var(--transition-fast) var(--ease-smooth);
+    transition: border-color var(--transition-fast) var(--ease-smooth), background-color var(--transition-fast) var(--ease-smooth), color var(--transition-fast) var(--ease-smooth), box-shadow var(--transition-fast) var(--ease-smooth), transform var(--transition-fast) var(--ease-smooth);
     display: flex;
     flex-direction: column;
     gap: 2px;
@@ -351,16 +352,18 @@ body::after {
 }
 
 .side-item:hover {
-    background: var(--color-surface-alt);
+    background: rgba(255, 255, 255, 0.58);
     color: var(--color-text-primary);
+    transform: translateY(-1px);
 }
 
 .side-item.active,
 .side-item.nav-intent-active {
-    border-color: transparent;
-    background: var(--color-brand-light);
+    border-color: rgba(200, 121, 99, 0.28);
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.82), rgba(200, 121, 99, 0.14));
     color: var(--color-brand-dark);
-    box-shadow: none;
+    box-shadow: 0 10px 24px rgba(92, 68, 52, 0.08);
 }
 
 .side-item.nav-intent-inactive,
@@ -421,8 +424,8 @@ body::after {
     align-items: flex-start;
     gap: 10px;
     margin-bottom: 0;
-    padding: 20px;
-    border-bottom: 1px solid var(--color-border);
+    padding: 16px 10px 18px;
+    border-bottom: 1px solid rgba(137, 111, 94, 0.12);
 }
 
 .brand-head {
@@ -434,10 +437,10 @@ body::after {
 .brand-logo {
     width: 38px;
     height: 38px;
-    border-radius: 10px;
+    border-radius: 14px;
     object-fit: cover;
     flex-shrink: 0;
-    box-shadow: var(--shadow-subtle);
+    box-shadow: 0 12px 26px rgba(92, 68, 52, 0.12);
 }
 
 .brand-copy {
@@ -497,10 +500,10 @@ body::after {
     justify-content: flex-start;
     gap: 8px;
     padding: 8px 10px;
-    border-radius: 8px;
-    background: var(--color-surface);
-    border: 1px solid var(--color-border);
-    box-shadow: none;
+    border-radius: 13px;
+    background: rgba(255, 255, 255, 0.62);
+    border: 1px solid rgba(137, 111, 94, 0.15);
+    box-shadow: var(--shadow-subtle);
 }
 
 .github-badge:hover {
@@ -511,7 +514,7 @@ body::after {
 }
 
 .github-badge:focus-visible {
-    outline: 3px solid rgba(199, 116, 98, 0.18);
+    outline: 3px solid rgba(200, 121, 99, 0.18);
     outline-offset: 2px;
     border-color: var(--color-brand);
     color: var(--color-text-primary);

--- a/web-ui/styles/modals-core.css
+++ b/web-ui/styles/modals-core.css
@@ -17,7 +17,9 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(to bottom, rgba(31, 26, 23, 0.3) 0%, rgba(31, 26, 23, 0.5) 100%);
+    background:
+        radial-gradient(circle at 50% 18%, rgba(255, 248, 241, 0.22), rgba(255, 248, 241, 0) 36%),
+        linear-gradient(to bottom, rgba(31, 26, 23, 0.28) 0%, rgba(31, 26, 23, 0.48) 100%);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -28,16 +30,16 @@
 }
 
 .modal {
-    background: linear-gradient(to bottom, var(--color-surface) 0%, rgba(255, 255, 255, 0.98) 100%);
+    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.96) 0%, rgba(255, 250, 246, 0.94) 100%);
     width: 90%;
     max-width: 400px;
     max-height: 90vh;
     overflow-y: auto;
     overscroll-behavior: contain;
-    border-radius: var(--radius-lg);
+    border-radius: var(--radius-xl);
     padding: var(--spacing-md);
     box-shadow: var(--shadow-modal);
-    border: 1px solid rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.72);
     animation: modalSlideUp var(--transition-slow) var(--ease-spring);
 }
 
@@ -75,8 +77,8 @@
     margin-top: 0;
     padding: var(--spacing-sm) var(--spacing-md) var(--spacing-md);
     border-top: 1px solid var(--color-border-soft);
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.82) 0%, rgba(255, 255, 255, 0.96) 100%);
-    backdrop-filter: blur(2px);
+    background: linear-gradient(to bottom, rgba(255, 250, 246, 0.78) 0%, rgba(255, 250, 246, 0.96) 100%);
+    backdrop-filter: blur(10px);
 }
 
 .modal-title {
@@ -116,8 +118,8 @@
     gap: var(--spacing-sm);
     padding: 10px 12px;
     border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-lg);
-    background: var(--color-surface-alt);
+    border-radius: var(--radius-md);
+    background: rgba(255, 255, 255, 0.48);
 }
 
 .install-row-main {
@@ -138,7 +140,7 @@
     font-size: var(--font-size-secondary);
     color: var(--color-text-primary);
     word-break: break-all;
-    background: rgba(255, 255, 255, 0.7);
+    background: rgba(255, 255, 255, 0.72);
     padding: 8px 10px;
     border-radius: var(--radius-sm);
     border: 1px solid var(--color-border-soft);
@@ -156,7 +158,7 @@
 
 .install-action-tabs .btn-mini.active {
     background: var(--color-brand-light);
-    border-color: rgba(199, 116, 98, 0.22);
+    border-color: rgba(200, 121, 99, 0.22);
     color: var(--color-brand-dark);
 }
 

--- a/web-ui/styles/navigation-panels.css
+++ b/web-ui/styles/navigation-panels.css
@@ -14,7 +14,7 @@
     color: var(--color-text-secondary);
     font-size: var(--font-size-body);
     font-weight: var(--font-weight-secondary);
-    box-shadow: var(--shadow-subtle);
+    box-shadow: var(--shadow-card);
     transition: all var(--transition-normal) var(--ease-spring);
 }
 
@@ -62,23 +62,23 @@
 }
 
 .lang-toggle-btn:hover {
-    border-color: rgba(0, 0, 0, 0.22);
+    border-color: var(--color-border-strong);
     background: var(--color-surface);
 }
 
 .lang-toggle-btn.active {
-    background: rgba(18, 22, 35, 0.10);
-    border-color: rgba(18, 22, 35, 0.30);
-    color: var(--color-text);
+    background: var(--color-brand-light);
+    border-color: rgba(200, 121, 99, 0.28);
+    color: var(--color-brand-dark);
 }
 
 .status-chip {
     min-width: 0;
     max-width: 100%;
     padding: 6px 10px;
-    border: 1px solid var(--color-border);
-    background: var(--color-surface-tint);
-    box-shadow: none;
+    border: 1px solid var(--color-border-soft);
+    background: rgba(255, 255, 255, 0.62);
+    box-shadow: var(--shadow-subtle);
     display: inline-flex;
     flex-direction: row;
     align-items: center;
@@ -109,10 +109,10 @@
 .provider-fast-switch {
     margin: 0 0 14px;
     padding: 10px 12px;
-    border-radius: 10px;
-    border: 1px solid var(--color-border);
-    background: var(--color-surface-tint);
-    box-shadow: none;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border-soft);
+    background: rgba(255, 255, 255, 0.58);
+    box-shadow: var(--shadow-card);
     display: grid;
     gap: 6px;
 }
@@ -133,7 +133,7 @@
     border-radius: var(--radius-sm);
     font-size: var(--font-size-body);
     color: var(--color-text-primary);
-    background-color: var(--color-surface-alt);
+    background-color: rgba(255, 255, 255, 0.72);
     outline: none;
     cursor: pointer;
     appearance: none;
@@ -158,7 +158,7 @@
 
 .main-panel {
     min-width: 0;
-    background: var(--color-bg);
+    background: transparent;
     border: none;
     border-radius: 0;
     box-shadow: none;
@@ -181,10 +181,10 @@
     position: sticky;
     top: 0;
     z-index: 12;
-    margin: 0 -28px 14px;
-    padding: 0 28px 12px;
+    margin: 0 -28px 18px;
+    padding: 0 28px 14px;
     background: linear-gradient(180deg, var(--color-bg-topbar-strong) 0%, var(--color-bg-topbar-soft) 78%, var(--color-bg-topbar-clear) 100%);
-    backdrop-filter: blur(8px);
+    backdrop-filter: blur(18px) saturate(130%);
 }
 
 .panel-header {
@@ -198,8 +198,8 @@
     justify-content: space-between;
     gap: 14px;
     margin: 0 0 14px;
-    padding: 18px 0 14px;
-    border-bottom: 1px solid var(--color-border);
+    padding: 20px 0 16px;
+    border-bottom: 1px solid rgba(137, 111, 94, 0.14);
     background: transparent;
 }
 
@@ -277,16 +277,16 @@
 }
 
 .top-tab {
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--color-border-soft);
     border-radius: 999px;
-    background: var(--color-surface);
+    background: rgba(255, 255, 255, 0.66);
     padding: 6px 10px;
     font-size: 11px;
     color: var(--color-text-secondary);
     text-align: center;
     cursor: pointer;
-    transition: border-color var(--transition-fast) var(--ease-smooth), background-color var(--transition-fast) var(--ease-smooth), color var(--transition-fast) var(--ease-smooth);
-    box-shadow: none;
+    transition: border-color var(--transition-fast) var(--ease-smooth), background-color var(--transition-fast) var(--ease-smooth), color var(--transition-fast) var(--ease-smooth), box-shadow var(--transition-fast) var(--ease-smooth), transform var(--transition-fast) var(--ease-smooth);
+    box-shadow: var(--shadow-subtle);
     flex: 0 0 auto;
     scroll-snap-align: start;
 }
@@ -294,14 +294,15 @@
 .top-tab:hover {
     border-color: var(--color-border-strong);
     color: var(--color-text-primary);
+    transform: translateY(-1px);
 }
 
 .top-tab.active,
 .top-tab.nav-intent-active {
-    border-color: rgba(199, 116, 98, 0.18);
+    border-color: rgba(200, 121, 99, 0.28);
     color: var(--color-brand-dark);
-    background: var(--color-brand-light);
-    box-shadow: none;
+    background: rgba(255, 255, 255, 0.82);
+    box-shadow: 0 10px 24px rgba(92, 68, 52, 0.1);
 }
 
 .top-tab.nav-intent-inactive,
@@ -321,17 +322,17 @@
     gap: 6px;
     margin-bottom: 12px;
     padding: 4px;
-    background: rgba(246, 241, 235, 0.72);
-    border-radius: 12px;
-    border: 1px solid rgba(216, 201, 184, 0.26);
-    box-shadow: none;
+    background: rgba(255, 255, 255, 0.42);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-border-soft);
+    box-shadow: var(--shadow-subtle);
 }
 
 .config-subtab {
     border: 1px solid rgba(216, 201, 184, 0.3);
-    border-radius: 10px;
+    border-radius: var(--radius-sm);
     padding: 8px 10px;
-    background: rgba(255, 255, 255, 0.82);
+    background: rgba(255, 255, 255, 0.62);
     color: var(--color-text-secondary);
     cursor: pointer;
     font-size: 13px;
@@ -346,10 +347,10 @@
 }
 
 .config-subtab.active {
-    border-color: rgba(201, 94, 75, 0.34);
+    border-color: rgba(200, 121, 99, 0.34);
     color: var(--color-text-primary);
     background: rgba(255, 255, 255, 0.98);
-    box-shadow: 0 1px 4px rgba(31, 26, 23, 0.025);
+    box-shadow: 0 8px 20px rgba(92, 68, 52, 0.08);
 }
 
 .settings-subtabs {
@@ -365,7 +366,7 @@
     margin-left: 6px;
     padding: 0 6px;
     border-radius: 999px;
-    background: rgba(210, 107, 90, 0.14);
+    background: rgba(200, 121, 99, 0.14);
     color: var(--color-text-secondary);
     font-size: 11px;
     line-height: 1;

--- a/web-ui/styles/responsive.css
+++ b/web-ui/styles/responsive.css
@@ -233,9 +233,9 @@ textarea:focus-visible {
     }
 
     .session-item {
-        min-height: 75px;
-        height: 75px;
-        contain-intrinsic-size: 75px;
+        min-height: 108px;
+        height: auto;
+        contain-intrinsic-size: 108px;
         padding: 12px 14px;
     }
 
@@ -278,7 +278,7 @@ textarea:focus-visible {
     }
 
     .session-item-meta {
-        margin-top: -2px;
+        margin-top: 4px;
         margin-bottom: 0;
         gap: 4px;
         align-items: center;

--- a/web-ui/styles/sessions-list.css
+++ b/web-ui/styles/sessions-list.css
@@ -205,9 +205,9 @@
     min-width: 0;
     position: relative;
     overflow: hidden;
-    min-height: 80px;
+    min-height: 108px;
     content-visibility: auto;
-    contain-intrinsic-size: 80px;
+    contain-intrinsic-size: 108px;
 }
 
 .session-item-header {
@@ -370,8 +370,8 @@
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 6px;
-    margin-top: 2px;
+    gap: 6px 8px;
+    margin-top: 4px;
     margin-bottom: 2px;
 }
 
@@ -393,9 +393,13 @@
 }
 
 .session-item-cwd {
-    flex: 1 1 160px;
-    min-width: 160px;
+    flex: 1 0 100%;
+    min-width: 0;
     color: var(--color-text-muted);
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
 }
 
 .session-preview {

--- a/web-ui/styles/titles-cards.css
+++ b/web-ui/styles/titles-cards.css
@@ -35,14 +35,14 @@
    ============================================ */
 .segmented-control {
     display: flex;
-    background: var(--color-surface);
-    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.48);
+    border-radius: var(--radius-md);
     padding: 4px;
     margin-bottom: 14px;
     position: relative;
-    box-shadow: none;
-    border: 1px solid var(--color-border);
-    backdrop-filter: none;
+    box-shadow: var(--shadow-subtle);
+    border: 1px solid var(--color-border-soft);
+    backdrop-filter: blur(12px);
 }
 
 .segment {
@@ -54,7 +54,7 @@
     font-weight: var(--font-weight-secondary);
     color: var(--color-text-secondary);
     cursor: pointer;
-    border-radius: 8px;
+    border-radius: var(--radius-sm);
     transition: color var(--transition-fast) var(--ease-smooth), background-color var(--transition-fast) var(--ease-smooth);
     position: relative;
     z-index: 2;
@@ -67,8 +67,8 @@
 
 .segment.active {
     color: var(--color-brand-dark);
-    background: var(--color-brand-light);
-    box-shadow: inset 0 0 0 1px rgba(199, 116, 98, 0.12);
+    background: rgba(255, 255, 255, 0.78);
+    box-shadow: 0 8px 18px rgba(92, 68, 52, 0.08), inset 0 0 0 1px rgba(200, 121, 99, 0.12);
 }
 
 /* ============================================
@@ -77,7 +77,7 @@
 .card-list {
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 10px;
     margin-bottom: 8px;
 }
 
@@ -85,9 +85,10 @@
    卡片
    ============================================ */
 .card {
-    background: var(--color-surface);
-    border-radius: 10px;
-    padding: 10px 12px;
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.86), rgba(255, 251, 247, 0.76));
+    border-radius: var(--radius-md);
+    padding: 12px 14px;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -95,18 +96,20 @@
     transition:
         border-color var(--transition-fast) var(--ease-smooth),
         background-color var(--transition-fast) var(--ease-smooth),
-        box-shadow var(--transition-fast) var(--ease-smooth);
-    box-shadow: none;
+        box-shadow var(--transition-fast) var(--ease-smooth),
+        transform var(--transition-fast) var(--ease-smooth);
+    box-shadow: var(--shadow-card);
     user-select: none;
     will-change: auto;
-    border: 1px solid var(--color-border);
+    border: 1px solid var(--color-border-soft);
     position: relative;
     overflow: hidden;
 }
 
 .card:hover {
     border-color: var(--color-border-strong);
-    box-shadow: none;
+    box-shadow: var(--shadow-card-hover);
+    transform: translateY(-1px);
 }
 
 .card::before,
@@ -130,7 +133,7 @@
 .card::after {
     inset: 0;
     border-radius: inherit;
-    background: linear-gradient(120deg, rgba(255, 255, 255, 0.1) 0%, transparent 55%);
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.55) 0%, transparent 58%);
     opacity: 0;
     transition: opacity var(--transition-fast) var(--ease-smooth);
 }
@@ -141,9 +144,10 @@
 }
 
 .card.active {
-    background: var(--color-brand-light);
-    border-color: rgba(199, 116, 98, 0.18);
-    box-shadow: none;
+    background:
+        linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(200, 121, 99, 0.15));
+    border-color: rgba(200, 121, 99, 0.28);
+    box-shadow: 0 14px 34px rgba(92, 68, 52, 0.12);
 }
 
 .card.active::before {
@@ -169,8 +173,8 @@
 .card-icon {
     width: 32px;
     height: 32px;
-    border-radius: 8px;
-    background: rgba(199, 116, 98, 0.1);
+    border-radius: var(--radius-sm);
+    background: rgba(200, 121, 99, 0.12);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -179,13 +183,13 @@
     color: var(--color-brand-dark);
     flex-shrink: 0;
     transition: background-color var(--transition-fast) var(--ease-smooth), color var(--transition-fast) var(--ease-smooth);
-    box-shadow: none;
+    box-shadow: inset 0 0 0 1px rgba(200, 121, 99, 0.08);
 }
 
 .card.active .card-icon {
-    background: rgba(199, 116, 98, 0.14);
+    background: rgba(200, 121, 99, 0.18);
     color: var(--color-brand-dark);
-    box-shadow: none;
+    box-shadow: inset 0 0 0 1px rgba(200, 121, 99, 0.14);
 }
 
 .card-content {
@@ -304,7 +308,7 @@
 }
 
 .card-action-btn:hover {
-    background: linear-gradient(135deg, rgba(210, 107, 90, 0.08) 0%, rgba(255, 255, 255, 0.95) 100%);
+    background: linear-gradient(135deg, rgba(200, 121, 99, 0.1) 0%, rgba(255, 255, 255, 0.95) 100%);
     color: var(--color-text-primary);
     transform: translateY(-1px);
 }


### PR DESCRIPTION
## Summary
- stream chat-completions fallback responses as Responses SSE for `stream:true` requests
- preserve fallback support for non-SSE chat responses and accumulated streamed tool calls
- simplify Claude/Codex toast messages: remove path/auth details, skip duplicate toasts (Closes #150)
- add built-in `issue-inject` prompt template with `{{issue}}` and `{{num}}` variables

## Why
The previous shim forced Codex `/v1/responses` requests through a non-streaming upstream request before emitting SSE. Long-running upstream `/responses` endpoints could time out as `502 Bad Gateway`. Claude/Codex config toasts were too verbose and repeated unnecessarily when the applied config hadn't changed.

## Validation
- `git diff --check`
- `npm run lint`
- `npm run test:unit -- --grep builtin-proxy` (527 tests passed)
- `npm run test:unit -- --grep claude-settings-sync` (tests passed)
- `npm run test:unit -- --grep prompt-template` (tests passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new "issue inject" built-in prompt template
  * Added support for Claude-compatible models from DeepSeek, Qwen, and ModelScope providers
  * Improved upstream fallback handling for API responses with streaming support

* **Improvements**
  * Enhanced configuration messaging for incomplete Claude setups
  * Reduced duplicate success notifications when applying configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->