### PR TITLE
feat(web-ui): skip full reload on provider add/delete/update

### DIFF
--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -281,7 +281,10 @@ function normalizeResponsesInputToChatMessages(input) {
 
     const toRole = (value) => {
         const roleRaw = typeof value === 'string' ? value.trim().toLowerCase() : '';
-        return roleRaw === 'assistant' ? 'assistant' : (roleRaw === 'system' ? 'system' : 'user');
+        if (roleRaw === 'assistant') return 'assistant';
+        // codex 把 AGENTS.md 注入 developer 角色；Responses 的 developer 在 chat 侧等价于 system。
+        if (roleRaw === 'system' || roleRaw === 'developer') return 'system';
+        return 'user';
     };
 
     if (input && typeof input === 'object' && !Array.isArray(input)) {
@@ -439,6 +442,43 @@ function normalizeResponsesToolsForResponsesApi(tools) {
         .filter(Boolean);
 }
 
+function mergeLeadingSystemMessages(messages, leadingInstructions) {
+    const segments = [];
+    const seen = new Set();
+    const pushSegment = (text) => {
+        const trimmed = typeof text === 'string' ? text.trim() : '';
+        if (!trimmed || seen.has(trimmed)) return;
+        seen.add(trimmed);
+        segments.push(trimmed);
+    };
+    if (typeof leadingInstructions === 'string') {
+        pushSegment(leadingInstructions);
+    }
+    const rest = [];
+    for (const msg of messages) {
+        if (msg && msg.role === 'system') {
+            const content = msg.content;
+            if (typeof content === 'string') {
+                pushSegment(content);
+            } else if (Array.isArray(content)) {
+                for (const part of content) {
+                    if (part && typeof part === 'object' && typeof part.text === 'string') {
+                        pushSegment(part.text);
+                    }
+                }
+            }
+            continue;
+        }
+        rest.push(msg);
+    }
+    const out = [];
+    if (segments.length) {
+        out.push({ role: 'system', content: segments.join('\n\n---\n\n') });
+    }
+    for (const msg of rest) out.push(msg);
+    return out;
+}
+
 function convertResponsesRequestToChatCompletions(payload) {
     const body = payload && typeof payload === 'object' ? payload : {};
     const model = typeof body.model === 'string' ? body.model.trim() : '';
@@ -446,12 +486,10 @@ function convertResponsesRequestToChatCompletions(payload) {
         return { error: 'responses 请求缺少 model' };
     }
 
-    const messages = [];
-    // Align with Maxx/CLIProxyAPI style: map "instructions" to a leading system message.
-    if (typeof body.instructions === 'string' && body.instructions.trim()) {
-        messages.push({ role: 'system', content: body.instructions.trim() });
-    }
-    messages.push(...normalizeResponsesInputToChatMessages(body.input));
+    const rawMessages = normalizeResponsesInputToChatMessages(body.input);
+    // codex 同时下发 body.instructions（内置 prompt）与 input 内 developer/system 消息（AGENTS.md）。
+    // 合流为一条领头 system，避免某些上游"只认第一条 system"导致 AGENTS.md 失效。
+    const messages = mergeLeadingSystemMessages(rawMessages, body.instructions);
     if (!messages.length) {
         // codex sometimes sends empty input for probes; tolerate.
         messages.push({ role: 'user', content: '' });

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -810,3 +810,152 @@ test('openai-bridge falls back to /chat/completions when upstream /responses ret
     await upstream.close();
     await rm(tmpDir, { recursive: true, force: true });
 });
+
+test('openai-bridge merges codex developer-role AGENTS.md into a single leading system message', async () => {
+    let capturedChatRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses') {
+            // 模拟上游接受 /responses 但不可用，强制走 fallback。
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'not implemented' }));
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            let body = '';
+            req.on('data', (c) => (body += c));
+            req.on('end', () => {
+                capturedChatRequest = JSON.parse(body || '{}');
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    id: 'chatcmpl_dev',
+                    model: 'gpt-test',
+                    choices: [{ message: { role: 'assistant', content: 'ok' } }]
+                }));
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate' });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const url = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
+    const resp = await requestText(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer codexmate' },
+        body: {
+            model: 'gpt-test',
+            instructions: 'codex-base-prompt',
+            input: [
+                { role: 'developer', content: [{ type: 'input_text', text: 'MISAKA_TOKEN_XYZ from AGENTS.md' }] },
+                { role: 'user', content: [{ type: 'input_text', text: 'hi there' }] }
+            ],
+            stream: false
+        }
+    });
+
+    assert.equal(resp.status, 200);
+    assert.ok(capturedChatRequest, 'fallback should hit chat/completions');
+    const msgs = capturedChatRequest.messages;
+    assert.ok(Array.isArray(msgs) && msgs.length >= 2, 'should produce system + user');
+    assert.equal(msgs[0].role, 'system', 'first message must be system');
+    assert.match(msgs[0].content, /codex-base-prompt/);
+    assert.match(msgs[0].content, /MISAKA_TOKEN_XYZ from AGENTS\.md/);
+    const systemCount = msgs.filter((m) => m && m.role === 'system').length;
+    assert.equal(systemCount, 1, 'multiple system sources must be merged into one');
+    const devLeak = msgs.find((m) => m && m.role !== 'system' && typeof m.content === 'string' && /MISAKA_TOKEN_XYZ/.test(m.content));
+    assert.equal(devLeak, undefined, 'AGENTS.md must not leak into user/assistant role');
+    const userMsg = msgs.find((m) => m && m.role === 'user');
+    assert.ok(userMsg, 'user message preserved');
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});
+
+test('openai-bridge SSE fast path also merges developer-role AGENTS.md into leading system', async () => {
+    let capturedChatRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            let body = '';
+            req.on('data', (c) => (body += c));
+            req.on('end', () => {
+                capturedChatRequest = JSON.parse(body || '{}');
+                res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+                res.write('data: {"id":"x","model":"gpt-test","choices":[{"delta":{"content":"ok"}}]}\n\n');
+                res.end('data: [DONE]\n\n');
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate' });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const url = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
+    await requestText(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream',
+            'Authorization': 'Bearer codexmate'
+        },
+        body: {
+            model: 'gpt-test',
+            instructions: 'codex-base-prompt',
+            input: [
+                { role: 'developer', content: [{ type: 'input_text', text: 'AGENTS_MARK_STREAM' }] },
+                { role: 'user', content: [{ type: 'input_text', text: 'hi' }] }
+            ],
+            stream: true
+        }
+    });
+
+    assert.ok(capturedChatRequest, 'fast path should call chat/completions');
+    const msgs = capturedChatRequest.messages;
+    assert.equal(msgs[0].role, 'system');
+    assert.match(msgs[0].content, /codex-base-prompt/);
+    assert.match(msgs[0].content, /AGENTS_MARK_STREAM/);
+    const leak = msgs.find((m) => m && m.role !== 'system' && typeof m.content === 'string' && /AGENTS_MARK_STREAM/.test(m.content));
+    assert.equal(leak, undefined, 'developer content must not leak into non-system role');
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});

--- a/tests/unit/provider-switch-regression.test.mjs
+++ b/tests/unit/provider-switch-regression.test.mjs
@@ -65,6 +65,13 @@ function createProviderUpdateContext() {
             readOnly: false,
             nonEditable: false
         },
+        // c3c9ee5：updateProvider 改为本地 providersList 增量更新，fixture 须提供初始列表。
+        providersList: [{
+            name: 'alpha',
+            url: 'https://api.example.com/v1-old',
+            key: 'sk-***old',
+            hasKey: true
+        }],
         showEditModal: true,
         messages,
         loadAllCalls: 0,
@@ -251,7 +258,9 @@ test('updateProvider keeps existing key when edit key input is blank', async () 
     }]);
     assert.strictEqual(context.showEditModal, false);
     assert.deepStrictEqual(context.editingProvider, { name: '', url: '', key: '', readOnly: false, nonEditable: false, useTransform: false });
-    assert.strictEqual(context.loadAllCalls, 1);
+    // c3c9ee5：不再 loadAll，断言本地 providersList url 已更新。
+    assert.strictEqual(context.loadAllCalls, 0);
+    assert.strictEqual(context.providersList[0].url, 'https://api.example.com/v1');
     assert.deepStrictEqual(context.messages, [{
         text: '操作成功',
         type: 'success'
@@ -280,7 +289,9 @@ test('updateProvider sends explicit key when user enters a new key', async () =>
         }
     }]);
     assert.strictEqual(context.showEditModal, false);
-    assert.strictEqual(context.loadAllCalls, 1);
+    // c3c9ee5：不再 loadAll，断言本地 providersList 已挂上新 key。
+    assert.strictEqual(context.loadAllCalls, 0);
+    assert.strictEqual(context.providersList[0].hasKey, true);
     assert.deepStrictEqual(context.messages, [{
         text: '操作成功',
         type: 'success'

--- a/tests/unit/providers-validation.test.mjs
+++ b/tests/unit/providers-validation.test.mjs
@@ -79,7 +79,12 @@ test('addProvider normalizes trimmed values and submits sanitized payload', asyn
     }]);
     assert.strictEqual(context.showAddModal, false);
     assert.deepStrictEqual(context.newProvider, { name: '', url: '', key: '', useTransform: false, _suggestedModel: '' });
-    assert.deepStrictEqual(loadAllCalls, ['loadAll']);
+    // c3c9ee5：增删改不再触发 loadAll，改为本地 providersList 增量更新。
+    assert.deepStrictEqual(loadAllCalls, []);
+    assert.ok(
+        context.providersList.some((p) => p && p.name === 'beta.provider' && p.url === 'https://api.example.com/v1'),
+        'new provider should be appended to providersList locally'
+    );
     assert.strictEqual(messages.length, 1);
     assert.deepStrictEqual(messages[0], {
         text: '操作成功',

--- a/web-ui/modules/app.methods.providers.mjs
+++ b/web-ui/modules/app.methods.providers.mjs
@@ -48,6 +48,12 @@ function normalizeProviderDraftState(target) {
     }
 }
 
+function maskKeyLocal(key) {
+    if (!key) return '';
+    if (key.length <= 8) return '****';
+    return key.substring(0, 4) + '...' + key.substring(key.length - 4);
+}
+
 function getProviderValidationForContext(vm, mode = 'add') {
     const draft = mode === 'edit' ? vm.editingProvider : vm.newProvider;
     const editingName = mode === 'edit' ? normalizeText(draft && draft.name) : '';
@@ -158,10 +164,25 @@ export function createProvidersMethods(options = {}) {
                     return;
                 }
 
+                // 本地更新：构造新 provider 对象并追加到列表
+                const newProvider = {
+                    name: validation.name,
+                    url: validation.url,
+                    upstreamUrl: '',
+                    codexmate_bridge: payload.useTransform ? 'openai' : '',
+                    key: maskKeyLocal(payload.key),
+                    hasKey: !!payload.key,
+                    models: [],
+                    current: false,
+                    readOnly: false,
+                    nonDeletable: false,
+                    nonEditable: false
+                };
+                this.providersList = [...this.providersList, newProvider];
+
                 this.showMessage('操作成功', 'success');
                 this.closeAddModal();
-                await this.loadAll();
-                // loadAll 会重拉 status 覆盖字典，所以暗示模型在 loadAll 之后再写。
+
                 if (suggestedModel) {
                     if (!this.currentModels || typeof this.currentModels !== 'object') this.currentModels = {};
                     this.currentModels[validation.name] = suggestedModel;
@@ -237,12 +258,27 @@ export function createProvidersMethods(options = {}) {
                     this.showMessage(res.error, 'error');
                     return;
                 }
+
+                // 本地更新：从列表中移除
+                this.providersList = this.providersList.filter(p => p.name !== name);
+
+                // 清理 currentModels
+                if (this.currentModels && this.currentModels[name]) {
+                    delete this.currentModels[name];
+                }
+
                 if (res.switched && res.provider) {
+                    this.currentProvider = res.provider;
+                    if (res.model) this.currentModel = res.model;
+                    // 更新 current 标记
+                    this.providersList = this.providersList.map(p => ({
+                        ...p,
+                        current: p.name === res.provider
+                    }));
                     this.showMessage(`已删除提供商，自动切换到 ${res.provider}${res.model ? ` / ${res.model}` : ''}`, 'success');
                 } else {
                     this.showMessage('操作成功', 'success');
                 }
-                await this.loadAll();
             } catch (_) {
                 this.showMessage('删除失败', 'error');
             }
@@ -329,9 +365,22 @@ export function createProvidersMethods(options = {}) {
                     this.showMessage(res.error, 'error');
                     return;
                 }
+
+                // 本地更新：更新列表中对应 provider 的 url 和 key
+                this.providersList = this.providersList.map(p => {
+                    if (p.name === validation.name) {
+                        return {
+                            ...p,
+                            url: validation.url,
+                            key: params.key ? maskKeyLocal(params.key) : p.key,
+                            hasKey: params.key ? true : p.hasKey
+                        };
+                    }
+                    return p;
+                });
+
                 this.closeEditModal();
                 this.showMessage('操作成功', 'success');
-                await this.loadAll();
             } catch (e) {
                 this.showMessage('更新失败', 'error');
             }
@@ -366,13 +415,26 @@ export function createProvidersMethods(options = {}) {
                 return this.showMessage('请输入模型', 'error');
             }
             try {
-                const res = await api('add-model', { model: this.newModelName.trim() });
+                const modelName = this.newModelName.trim();
+                const res = await api('add-model', { model: modelName });
                 if (res.error) {
                     this.showMessage(res.error, 'error');
                 } else {
+                    // 本地更新：在当前 provider 的 models 中追加
+                    this.providersList = this.providersList.map(p => {
+                        if (p.name === this.currentProvider) {
+                            const exists = p.models.some(m => m.id === modelName);
+                            if (!exists) {
+                                return {
+                                    ...p,
+                                    models: [...p.models, { id: modelName, name: modelName, cost: null, contextWindow: undefined, maxTokens: undefined }]
+                                };
+                            }
+                        }
+                        return p;
+                    });
                     this.showMessage('操作成功', 'success');
                     this.closeModelModal();
-                    await this.loadAll();
                 }
             } catch (_) {
                 this.showMessage('新增模型失败', 'error');
@@ -385,8 +447,17 @@ export function createProvidersMethods(options = {}) {
                 if (res.error) {
                     this.showMessage(res.error, 'error');
                 } else {
+                    // 本地更新：从当前 provider 的 models 中移除
+                    this.providersList = this.providersList.map(p => {
+                        if (p.name === this.currentProvider) {
+                            return {
+                                ...p,
+                                models: p.models.filter(m => m.id !== model)
+                            };
+                        }
+                        return p;
+                    });
                     this.showMessage('操作成功', 'success');
-                    await this.loadAll();
                 }
             } catch (_) {
                 this.showMessage('删除模型失败', 'error');


### PR DESCRIPTION
## Summary

Replace `await this.loadAll()` with local state updates for provider CRUD operations, avoiding unnecessary full-reload API calls.

## Changes

| Method | Strategy |
|--------|----------|
| `addProvider` | Build object + push to `providersList` |
| `deleteProvider` | Filter removal + update currentProvider/currentModel |
| `updateProvider` | Map update url/key/hasKey |
| `addModel` | Push to current provider's models |
| `removeModel` | Filter from current provider's models |

- Added `maskKeyLocal` helper matching backend `maskKey` logic
- `resetConfig` keeps `loadAll()` (full reset still needs reload)

## Files

- `web-ui/modules/app.methods.providers.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of system messages and developer instructions in AI responses—developer-role content is now properly merged into a single system message without duplication.
  * Provider and model operations (add, edit, delete, update) now reflect changes instantly in the UI with local updates instead of requiring a full data reload, providing faster and smoother interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SakuraByteCore/codexmate/pull/158)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->