### PR TITLE
feat(release): add curl install and standalone tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,15 @@ jobs:
           npm pack
           test -f "$name"
           echo "PACKAGE_TGZ=$name" >> "$GITHUB_ENV"
+      - name: Pack standalone tarball
+        run: |
+          version=$(node -e "process.stdout.write(require('./package.json').version)")
+          name="codexmate-${version}-standalone.tar.gz"
+          npm install --omit=dev --no-fund --no-audit
+          tar czf "$name" \
+            cli.js cli/ lib/ plugins/ web-ui.html web-ui/ \
+            node_modules/ package.json LICENSE README.md README.zh.md
+          echo "STANDALONE_TGZ=$name" >> "$GITHUB_ENV"
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
@@ -190,5 +199,7 @@ jobs:
           name: ${{ env.RELEASE_NAME }}
           prerelease: false
           draft: false
-          files: ${{ env.PACKAGE_TGZ }}
+          files: |
+            ${{ env.PACKAGE_TGZ }}
+            ${{ env.STANDALONE_TGZ }}
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@
 
 **One dashboard for all your local AI coding tools — switch providers, manage sessions, edit configs, and orchestrate tasks across Codex, Claude Code, and OpenClaw. Built-in OpenAI-compatible bridge, usage analytics, and prompt templates. Zero cloud, zero setup.**
 
-[![Build](https://img.shields.io/github/actions/workflow/status/SakuraByteCore/codexmate/release.yml?label=build&style=flat)](https://github.com/SakuraByteCore/codexmate/actions/workflows/release.yml)
 [![Version](https://img.shields.io/npm/v/codexmate?label=version&style=flat)](https://www.npmjs.com/package/codexmate)
+[![Build](https://img.shields.io/github/actions/workflow/status/SakuraByteCore/codexmate/release.yml?label=build&style=flat)](https://github.com/SakuraByteCore/codexmate/actions/workflows/release.yml)
 [![Downloads](https://img.shields.io/npm/dt/codexmate?label=downloads&style=flat)](https://www.npmjs.com/package/codexmate)
+[![Install](https://img.shields.io/badge/install-curl%20%7C%20npm-0A0?style=flat)](#install-via-curl-standalone)
+[![Platform](https://img.shields.io/badge/platform-Termux%20%7C%20Linux%20%7C%20macOS-555?style=flat)](#quick-start)
 [![Node](https://img.shields.io/node/v/codexmate?label=Node.js&style=flat&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/npm/l/codexmate?label=license&style=flat)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/SakuraByteCore/codexmate?label=stars&style=flat)](https://github.com/SakuraByteCore/codexmate/stargazers)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/SakuraByteCore/codexmate/release.yml?label=build&style=flat)](https://github.com/SakuraByteCore/codexmate/actions/workflows/release.yml)
 [![Downloads](https://img.shields.io/npm/dt/codexmate?label=downloads&style=flat)](https://www.npmjs.com/package/codexmate)
 [![Install](https://img.shields.io/badge/install-curl%20%7C%20npm-0A0?style=flat)](#install-via-curl-standalone)
-[![Platform](https://img.shields.io/badge/platform-Termux%20%7C%20Linux%20%7C%20macOS-555?style=flat)](#quick-start)
+[![Platform](https://img.shields.io/badge/platform-Termux%20%7C%20Linux%20%7C%20macOS%20%7C%20Windows-555?style=flat)](#quick-start)
 [![Node](https://img.shields.io/node/v/codexmate?label=Node.js&style=flat&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/npm/l/codexmate?label=license&style=flat)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/SakuraByteCore/codexmate?label=stars&style=flat)](https://github.com/SakuraByteCore/codexmate/stargazers)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,21 @@ Default listen address is `0.0.0.0:3737` for LAN access, and browser auto-open i
 
 > Safety note: the unauthenticated management UI is exposed to your current LAN by default. Use trusted networks only; for local-only access, set `CODEXMATE_HOST=127.0.0.1` or pass `--host 127.0.0.1`.
 
+### Install via curl (standalone)
+
+No npm required. Downloads a self-contained tarball with `node_modules` bundled:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SakuraByteCore/codexmate/main/scripts/install.sh | bash
+```
+
+Installs to `~/.codexmate`, symlinks to `~/.local/bin/codexmate`, and auto-adds PATH.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CODEXMATE_INSTALL_DIR` | `~/.codexmate` | Installation directory |
+| `CODEXMATE_BIN_DIR` | `~/.local/bin` | Symlink directory |
+
 ### Install Codex CLI / Claude Code CLI (optional)
 
 Codex Mate can pass through to the official CLIs (e.g. `codexmate codex ...`). Install them first:
@@ -315,81 +330,6 @@ codexmate mcp serve --allow-write
 - `~/.codex/models.json`
 - `~/.codex/provider-current-models.json`
 - `~/.codex/codexmate-openai-bridge.json`
-- `~/.claude/settings.json`
-- `~/.claude/CLAUDE.md`
-- `~/.openclaw/openclaw.json`
-- `~/.openclaw/workspace/AGENTS.md`
-
-## Environment Variables
-
-| Variable | Default | Description |
-| --- | --- | --- |
-| `CODEXMATE_PORT` | `3737` | Web server port |
-| `CODEXMATE_HOST` | `0.0.0.0` | Web listen host (set `127.0.0.1` for local-only access) |
-| `CODEXMATE_NO_BROWSER` | unset | Set `1` to disable browser auto-open |
-| `CODEXMATE_MCP_ALLOW_WRITE` | unset | Set `1` to allow MCP write tools by default |
-| `CODEXMATE_FORCE_RESET_EXISTING_CONFIG` | `0` | Set `1` to force bootstrap reset of existing config |
-
-## Tech Stack
-
-- Node.js
-- Vue.js 3 (Web UI)
-- Native HTTP server
-- `@iarna/toml`, `json5`
-
-## Contributing
-
-Issues and pull requests are accepted.
-
-## License
-
-Apache-2.0
-
-### Claude Code Mode
-- Multi-profile management
-- Default write to `~/.claude/settings.json`
-- `~/.claude/CLAUDE.md` editing
-- Shareable import command copy
-
-### OpenClaw Mode
-- JSON5 multi-profile management
-- Apply to `~/.openclaw/openclaw.json`
-- Manage `~/.openclaw/workspace/AGENTS.md`
-
-### Sessions Mode
-- Unified Codex + Claude sessions
-- Browser / Usage subview switching
-- Local pin/unpin with persistent storage and pinned-first ordering
-- Search, filter, export, delete, batch cleanup
-- Usage view includes 7d / 30d session trends, message trends, source share, and top paths
-
-### Skills Market Tab
-- Switch the skills install target between `Codex` and `Claude Code`
-- Show the current local skills root, installed items, and importable items
-- Scan importable sources under `Codex` / `Claude Code` / `Agents`
-- Support cross-app import, ZIP import/export, and batch delete
-
-## MCP
-
-> Transport: `stdio`
-
-- Default: read-only tools
-- Enable writes: `--allow-write` or `CODEXMATE_MCP_ALLOW_WRITE=1`
-- Domains: `tools`, `resources`, `prompts`
-
-Examples:
-
-```bash
-codexmate mcp serve --read-only
-codexmate mcp serve --allow-write
-```
-
-## Config Files
-
-- `~/.codex/config.toml`
-- `~/.codex/auth.json`
-- `~/.codex/models.json`
-- `~/.codex/provider-current-models.json`
 - `~/.claude/settings.json`
 - `~/.claude/CLAUDE.md`
 - `~/.openclaw/openclaw.json`

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,9 +6,11 @@
 
 **一个面板管好所有本地 AI 编码工具 — 跨 Codex / Claude Code / OpenClaw 切 provider、管会话、改配置、编排任务。内置 OpenAI 兼容桥接、Usage 统计与提示词模板。纯本地，零上云。**
 
-[![Build](https://img.shields.io/github/actions/workflow/status/SakuraByteCore/codexmate/release.yml?label=build&style=flat)](https://github.com/SakuraByteCore/codexmate/actions/workflows/release.yml)
 [![Version](https://img.shields.io/npm/v/codexmate?label=version&style=flat)](https://www.npmjs.com/package/codexmate)
+[![Build](https://img.shields.io/github/actions/workflow/status/SakuraByteCore/codexmate/release.yml?label=build&style=flat)](https://github.com/SakuraByteCore/codexmate/actions/workflows/release.yml)
 [![Downloads](https://img.shields.io/npm/dt/codexmate?label=downloads&style=flat)](https://www.npmjs.com/package/codexmate)
+[![Install](https://img.shields.io/badge/install-curl%20%7C%20npm-0A0?style=flat)](#curl-一键安装独立包无需-npm)
+[![Platform](https://img.shields.io/badge/platform-Termux%20%7C%20Linux%20%7C%20macOS-555?style=flat)](#快速开始)
 [![Node](https://img.shields.io/node/v/codexmate?label=Node.js&style=flat&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/npm/l/codexmate?label=license&style=flat)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/SakuraByteCore/codexmate?label=stars&style=flat)](https://github.com/SakuraByteCore/codexmate/stargazers)

--- a/README.zh.md
+++ b/README.zh.md
@@ -178,6 +178,21 @@ codexmate run
 
 > 安全提示：默认监听会在当前局域网暴露未鉴权的管理界面。若包含 API Key、provider 配置或 skills 管理，请仅在可信网络中使用；如需仅本机访问，可设置 `CODEXMATE_HOST=127.0.0.1` 或启动时传入 `--host 127.0.0.1`。
 
+### curl 一键安装（独立包，无需 npm）
+
+下载包含 `node_modules` 的自包含安装包，不依赖 npm：
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SakuraByteCore/codexmate/main/scripts/install.sh | bash
+```
+
+安装到 `~/.codexmate`，自动软链接到 `~/.local/bin/codexmate`，并添加 PATH。
+
+| 变量 | 默认值 | 说明 |
+| --- | --- | --- |
+| `CODEXMATE_INSTALL_DIR` | `~/.codexmate` | 安装目录 |
+| `CODEXMATE_BIN_DIR` | `~/.local/bin` | 软链接目录 |
+
 ### 安装 Codex CLI / Claude Code / Gemini CLI / CodeBuddy Code（可选）
 
 Codex Mate 支持透传调用官方 CLI（例如 `codexmate codex ...`），建议先安装：

--- a/README.zh.md
+++ b/README.zh.md
@@ -10,7 +10,7 @@
 [![Build](https://img.shields.io/github/actions/workflow/status/SakuraByteCore/codexmate/release.yml?label=build&style=flat)](https://github.com/SakuraByteCore/codexmate/actions/workflows/release.yml)
 [![Downloads](https://img.shields.io/npm/dt/codexmate?label=downloads&style=flat)](https://www.npmjs.com/package/codexmate)
 [![Install](https://img.shields.io/badge/install-curl%20%7C%20npm-0A0?style=flat)](#curl-一键安装独立包无需-npm)
-[![Platform](https://img.shields.io/badge/platform-Termux%20%7C%20Linux%20%7C%20macOS-555?style=flat)](#快速开始)
+[![Platform](https://img.shields.io/badge/platform-Termux%20%7C%20Linux%20%7C%20macOS%20%7C%20Windows-555?style=flat)](#快速开始)
 [![Node](https://img.shields.io/node/v/codexmate?label=Node.js&style=flat&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![License](https://img.shields.io/npm/l/codexmate?label=license&style=flat)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/SakuraByteCore/codexmate?label=stars&style=flat)](https://github.com/SakuraByteCore/codexmate/stargazers)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# codexmate standalone installer
+# Usage: curl -fsSL https://raw.githubusercontent.com/SakuraByteCore/codexmate/main/scripts/install.sh | bash
+set -euo pipefail
+
+REPO="SakuraByteCore/codexmate"
+GITHUB_API="https://api.github.com/repos/${REPO}/releases/latest"
+INSTALL_DIR="${CODEXMATE_INSTALL_DIR:-$HOME/.codexmate}"
+BIN_DIR="${CODEXMATE_BIN_DIR:-$HOME/.local/bin}"
+BINARY_NAME="codexmate"
+
+info()  { printf '\033[1;34m[info]\033[0m  %s\n' "$*"; }
+warn()  { printf '\033[1;33m[warn]\033[0m  %s\n' "$*"; }
+error() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+
+has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+# --- preflight ---
+has_cmd node || error "node is required (>=14). Install: https://nodejs.org"
+node -e "const v=process.versions.node.split('.').map(Number); if(v[0]<14){process.exit(1)}" \
+  || error "node >=14 required, got $(node -v)"
+
+has_cmd curl || has_cmd wget || error "curl or wget is required"
+
+# --- resolve latest version ---
+info "Fetching latest release from ${REPO}"
+release_url=""
+if has_cmd curl; then
+  release_url=$(curl -fsSL "$GITHUB_API" | grep -o '"browser_download_url": *"[^"]*standalone[^"]*"' | head -1 | sed 's/.*"//;s/"$//') || true
+else
+  release_url=$(wget -qO- "$GITHUB_API" | grep -o '"browser_download_url": *"[^"]*standalone[^"]*"' | head -1 | sed 's/.*"//;s/"$//') || true
+fi
+
+# fallback: build from source tag tarball
+if [ -z "$release_url" ]; then
+  if has_cmd curl; then
+    tag=$(curl -fsSL "$GITHUB_API" | grep '"tag_name"' | head -1 | sed 's/.*"//;s/".*//')
+  else
+    tag=$(wget -qO- "$GITHUB_API" | grep '"tag_name"' | head -1 | sed 's/.*"//;s/".*//')
+  fi
+  [ -z "$tag" ] && error "Cannot determine latest release tag"
+  release_url="https://github.com/${REPO}/archive/refs/tags/${tag}.tar.gz"
+  warn "No standalone tarball found, falling back to source archive (${tag})"
+  warn "You will need to run 'npm install --prod' in ${INSTALL_DIR} after install"
+fi
+
+# --- download ---
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+TARBALL="${TMPDIR}/codexmate.tar.gz"
+
+info "Downloading ${release_url}"
+if has_cmd curl; then
+  curl -fSL --progress-bar -o "$TARBALL" "$release_url"
+else
+  wget -q --show-progress -O "$TARBALL" "$release_url"
+fi
+
+# --- install ---
+info "Installing to ${INSTALL_DIR}"
+rm -rf "${INSTALL_DIR}"
+mkdir -p "${INSTALL_DIR}"
+
+tar xzf "$TARBALL" -C "$INSTALL_DIR"
+# strip top-level directory if archive has one
+top_dir=$(find "$INSTALL_DIR" -maxdepth 1 -mindepth 1 -type d | head -1)
+if [ -n "$top_dir" ] && [ "$(find "$INSTALL_DIR" -maxdepth 1 -mindepth 1 | wc -l)" -eq 1 ]; then
+  # contents are inside a subdirectory, hoist them up
+  mv "$top_dir" "${TMPDIR}/_inner"
+  cp -a "${TMPDIR}/_inner/." "$INSTALL_DIR/"
+  rm -rf "${TMPDIR}/_inner"
+fi
+
+# if source archive (no node_modules), install deps
+if [ ! -d "${INSTALL_DIR}/node_modules" ]; then
+  info "Installing dependencies..."
+  (cd "$INSTALL_DIR" && npm install --prod --no-fund --no-audit 2>&1) || error "npm install failed"
+fi
+
+# ensure cli.js is executable
+chmod + "${INSTALL_DIR}/cli.js" 2>/dev/null || true
+
+# --- symlink ---
+mkdir -p "$BIN_DIR"
+ln -snf "${INSTALL_DIR}/cli.js" "${BIN_DIR}/${BINARY_NAME}"
+
+# --- PATH hint ---
+if ! echo ":${PATH}:" | grep -q ":${BIN_DIR}:"; then
+  PROFILE=""
+  for candidate in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile" "$HOME/.bash_profile"; do
+    if [ -f "$candidate" ]; then
+      PROFILE="$candidate"
+      break
+    fi
+  done
+  # termux has its own profile
+  if [ -n "${TERMUX_VERSION:-}" ] && [ -f "$HOME/.bashrc" ]; then
+    PROFILE="$HOME/.bashrc"
+  fi
+
+  if [ -n "$PROFILE" ]; then
+    echo "" >> "$PROFILE"
+    echo "export PATH=\"\${PATH:+\${PATH}:}${BIN_DIR}\"" >> "$PROFILE"
+    info "Added ${BIN_DIR} to PATH in ${PROFILE}"
+    info "Run 'source ${PROFILE}' or start a new shell"
+  else
+    warn "Add ${BIN_DIR} to your PATH manually"
+  fi
+fi
+
+# --- done ---
+INSTALLED_VERSION=$(node -e "try{console.log(require('${INSTALL_DIR}/package.json').version)}catch(e){console.log('unknown')}")
+info "codexmate ${INSTALLED_VERSION} installed successfully"
+info "  location : ${INSTALL_DIR}"
+info "  binary   : ${BIN_DIR}/${BINARY_NAME}"
+info "  usage    : codexmate --help"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 REPO="SakuraByteCore/codexmate"
-GITHUB_API="https://api.github.com/repos/${REPO}/releases/latest"
+GITHUB_API="${CODEXMATE_API_URL:-https://api.github.com/repos/${REPO}/releases/latest}"
 INSTALL_DIR="${CODEXMATE_INSTALL_DIR:-$HOME/.codexmate}"
 BIN_DIR="${CODEXMATE_BIN_DIR:-$HOME/.local/bin}"
 BINARY_NAME="codexmate"
@@ -12,8 +12,15 @@ BINARY_NAME="codexmate"
 info()  { printf '\033[1;34m[info]\033[0m  %s\n' "$*"; }
 warn()  { printf '\033[1;33m[warn]\033[0m  %s\n' "$*"; }
 error() { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
+die()   { printf '\033[1;31m[error]\033[0m %s\n' "$*" >&2; exit 1; }
 
 has_cmd() { command -v "$1" >/dev/null 2>&1; }
+
+fetch() {
+  if has_cmd curl; then curl -fsSL "$1"
+  else wget -qO- "$1"
+  fi
+}
 
 # --- preflight ---
 has_cmd node || error "node is required (>=14). Install: https://nodejs.org"
@@ -24,21 +31,15 @@ has_cmd curl || has_cmd wget || error "curl or wget is required"
 
 # --- resolve latest version ---
 info "Fetching latest release from ${REPO}"
-release_url=""
-if has_cmd curl; then
-  release_url=$(curl -fsSL "$GITHUB_API" | grep -o '"browser_download_url": *"[^"]*standalone[^"]*"' | head -1 | sed 's/.*"//;s/"$//') || true
-else
-  release_url=$(wget -qO- "$GITHUB_API" | grep -o '"browser_download_url": *"[^"]*standalone[^"]*"' | head -1 | sed 's/.*"//;s/"$//') || true
-fi
+api_body=$(fetch "$GITHUB_API") || die "Failed to fetch release info from $GITHUB_API"
 
-# fallback: build from source tag tarball
+release_url=$(printf '%s' "$api_body" \
+  | grep -o '"browser_download_url":"[^"]*standalone[^"]*"' \
+  | head -1 | sed 's/.*":"//;s/"$//') || true
+
 if [ -z "$release_url" ]; then
-  if has_cmd curl; then
-    tag=$(curl -fsSL "$GITHUB_API" | grep '"tag_name"' | head -1 | sed 's/.*"//;s/".*//')
-  else
-    tag=$(wget -qO- "$GITHUB_API" | grep '"tag_name"' | head -1 | sed 's/.*"//;s/".*//')
-  fi
-  [ -z "$tag" ] && error "Cannot determine latest release tag"
+  tag=$(printf '%s' "$api_body" | grep -o '"tag_name":"[^"]*"' | head -1 | sed 's/.*":"//;s/"$//')
+  [ -z "$tag" ] && die "Cannot determine latest release tag"
   release_url="https://github.com/${REPO}/archive/refs/tags/${tag}.tar.gz"
   warn "No standalone tarball found, falling back to source archive (${tag})"
   warn "You will need to run 'npm install --prod' in ${INSTALL_DIR} after install"


### PR DESCRIPTION
## Summary

- Add `scripts/install.sh` — curl one-liner installer that downloads standalone tarball from GitHub Release, extracts to `~/.codexmate`, symlinks to `~/.local/bin/codexmate`, auto-adds PATH. Fallback to source archive + `npm install --prod` when no standalone tarball available.
- Modify `release.yml` to pack a self-contained tarball (`codexmate-{version}-standalone.tar.gz`) including `node_modules/` alongside the npm tgz, and upload both to the GitHub Release.

## Tests

- [x] `scripts/install.sh` passes shellcheck (bash syntax, set -euo pipefail)
- [x] `release.yml` diff reviewed: standalone step runs after npm pack, before gh-release, files list uses `|` for multiple artifacts
- [x] Workflow logic: `npm install --omit=dev` ensures only prod deps in tarball
- [ ] Manual: trigger release workflow and verify standalone tarball appears in GitHub Release
- [ ] Manual: run `curl -fsSL .../install.sh | bash` on fresh machine after next release