### PR TITLE
feat(web-ui): add template editor to claude config panel

### DIFF
--- a/tests/unit/web-ui-behavior-parity.test.mjs
+++ b/tests/unit/web-ui-behavior-parity.test.mjs
@@ -575,6 +575,7 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'setConfigTemplateDiffConfirmEnabled',
         'extractClaudeResumeKeyFromFilePath',
         'openClaudeConfigTemplateEditor',
+        'applyClaudeLocalBridge',
         'loadPluginsOverview',
         'selectPlugin',
         'createPromptTemplate',

--- a/tests/unit/web-ui-behavior-parity.test.mjs
+++ b/tests/unit/web-ui-behavior-parity.test.mjs
@@ -411,6 +411,7 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
     ];
     allowedExtraCurrentKeys.push(
         'lang',
+        'configTemplateContext',
         'configTemplateDiffVisible',
         'configTemplateDiffLoading',
         'configTemplateDiffError',
@@ -424,6 +425,8 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'healthCheckBatchDone',
         'healthCheckBatchFailed',
         'showHealthCheckModal',
+        'showCodexBridgePoolModal',
+        'showClaudeBridgePoolModal',
         'pluginsActiveId',
         'pluginsLoading',
         'pluginsError',

--- a/tests/unit/web-ui-behavior-parity.test.mjs
+++ b/tests/unit/web-ui-behavior-parity.test.mjs
@@ -574,6 +574,7 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'normalizeConfigTemplateDiffConfirmEnabled',
         'setConfigTemplateDiffConfirmEnabled',
         'extractClaudeResumeKeyFromFilePath',
+        'openClaudeConfigTemplateEditor',
         'loadPluginsOverview',
         'selectPlugin',
         'createPromptTemplate',

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -98,6 +98,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 confirmDialogResolver: null,
                 configTemplateContent: '',
                 configTemplateApplying: false,
+                configTemplateContext: 'codex',
                 configTemplateDiffVisible: false,
                 configTemplateDiffLoading: false,
                 configTemplateDiffError: '',

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -71,6 +71,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 showAgentsModal: false,
                 showSkillsModal: false,
                 showHealthCheckModal: false,
+                showCodexBridgePoolModal: false,
+                showClaudeBridgePoolModal: false,
                 // Plugins
                 pluginsActiveId: 'prompt-templates',
                 pluginsLoading: false,

--- a/web-ui/logic.claude.mjs
+++ b/web-ui/logic.claude.mjs
@@ -111,6 +111,10 @@ export function matchClaudeConfigFromSettings(claudeConfigs = {}, env = {}) {
     if (!normalizedSettings.baseUrl || !normalizedSettings.model || !hasClaudeCredential(normalizedSettings)) {
         return '';
     }
+    // 检测本地桥接 URL
+    if (typeof normalizedSettings.baseUrl === 'string' && normalizedSettings.baseUrl.includes('/bridge/claude-local/')) {
+        return 'claude-local';
+    }
     const comparableSettingsUrl = normalizeClaudeComparableUrl(normalizedSettings.baseUrl);
     const entries = Object.entries(claudeConfigs || {});
     for (const [name, config] of entries) {

--- a/web-ui/modules/app.methods.claude-config.mjs
+++ b/web-ui/modules/app.methods.claude-config.mjs
@@ -264,6 +264,21 @@ export function createClaudeConfigMethods(options = {}) {
 
         claudeLocalBridgeConfigured() {
             return this.claudeLocalBridgeCandidateProviders().some(p => p.hasKey);
+        },
+
+        async openClaudeConfigTemplateEditor() {
+            try {
+                const res = await api('get-claude-settings-raw');
+                if (res.error) {
+                    this.showMessage(res.error, 'error');
+                    return;
+                }
+                this.configTemplateContent = res.content || '{}';
+                this.configTemplateContext = 'claude';
+                this.showConfigTemplateModal = true;
+            } catch (e) {
+                this.showMessage('加载 Claude settings 失败', 'error');
+            }
         }
     };
 }

--- a/web-ui/modules/app.methods.claude-config.mjs
+++ b/web-ui/modules/app.methods.claude-config.mjs
@@ -266,6 +266,28 @@ export function createClaudeConfigMethods(options = {}) {
             return this.claudeLocalBridgeCandidateProviders().some(p => p.hasKey);
         },
 
+        async applyClaudeLocalBridge() {
+            this.currentClaudeConfig = 'claude-local';
+            try { localStorage.setItem('currentClaudeConfig', 'claude-local'); } catch (_) {}
+            this.refreshClaudeModelContext();
+
+            const candidates = this.claudeLocalBridgeCandidateProviders();
+            if (candidates.length === 0) {
+                return this.showMessage('请先添加并配置至少一个 Claude 提供商', 'error');
+            }
+
+            try {
+                const res = await api('claude-local-bridge-toggle', { enable: true });
+                if (res.error) {
+                    this.showMessage(res.error || '启用本地负载均衡失败', 'error');
+                    return;
+                }
+                this.showMessage('Claude 本地负载均衡已启用', 'success');
+            } catch (e) {
+                this.showMessage('启用本地负载均衡失败', 'error');
+            }
+        },
+
         async openClaudeConfigTemplateEditor() {
             try {
                 const res = await api('get-claude-settings-raw');

--- a/web-ui/modules/app.methods.codex-config.mjs
+++ b/web-ui/modules/app.methods.codex-config.mjs
@@ -558,6 +558,7 @@ export function createCodexConfigMethods(options = {}) {
                     template = `${template.trimEnd()}\n\n${appendBlock}\n`;
                 }
                 this.configTemplateContent = template;
+                this.configTemplateContext = 'codex';
                 this.showConfigTemplateModal = true;
             } catch (e) {
                 this.showMessage('加载模板失败', 'error');
@@ -807,9 +808,16 @@ export function createCodexConfigMethods(options = {}) {
             const performApply = async () => {
                 this.configTemplateApplying = true;
                 try {
-                    const res = await api('apply-config-template', {
-                        template: this.configTemplateContent
-                    });
+                    let res;
+                    if (this.configTemplateContext === 'claude') {
+                        res = await api('apply-claude-settings-raw', {
+                            content: this.configTemplateContent
+                        });
+                    } else {
+                        res = await api('apply-config-template', {
+                            template: this.configTemplateContent
+                        });
+                    }
                     if (res.error) {
                         this.showMessage(res.error, 'error');
                         return;

--- a/web-ui/partials/index/modals-basic.html
+++ b/web-ui/partials/index/modals-basic.html
@@ -171,3 +171,53 @@
                 </div>
             </div>
         </div>
+
+        <!-- Codex 轮询池控制模态框 -->
+        <div v-if="showCodexBridgePoolModal" class="modal-overlay" @click.self="showCodexBridgePoolModal = false">
+            <div class="modal modal-bridge-pool" role="dialog" aria-modal="true" aria-labelledby="codex-bridge-pool-modal-title">
+                <div class="modal-title" id="codex-bridge-pool-modal-title">
+                    <svg class="modal-title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
+                    轮询池设置
+                </div>
+                <div class="bridge-pool-modal-hint">勾选参与负载均衡的提供商</div>
+                <div v-if="localBridgeCandidateProviders().length === 0" class="bridge-pool-empty">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="16" height="16"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
+                    <span>暂无可用上游 provider，请先添加直连 provider</span>
+                </div>
+                <div v-else class="bridge-pool-list">
+                    <label v-for="cp in localBridgeCandidateProviders()" :key="cp.name" class="bridge-pool-item">
+                        <span class="bridge-pool-item-name">{{ cp.name }}</span>
+                        <span class="bridge-pool-item-status" :class="{ active: !isLocalBridgeExcluded(cp.name) }">{{ isLocalBridgeExcluded(cp.name) ? '未启用' : '已启用' }}</span>
+                        <input type="checkbox" :checked="!isLocalBridgeExcluded(cp.name)" @change="toggleLocalBridgeExcluded(cp.name)" />
+                    </label>
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-confirm" @click="showCodexBridgePoolModal = false">{{ t('common.close') }}</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Claude 轮询池控制模态框 -->
+        <div v-if="showClaudeBridgePoolModal" class="modal-overlay" @click.self="showClaudeBridgePoolModal = false">
+            <div class="modal modal-bridge-pool" role="dialog" aria-modal="true" aria-labelledby="claude-bridge-pool-modal-title">
+                <div class="modal-title" id="claude-bridge-pool-modal-title">
+                    <svg class="modal-title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
+                    {{ t('claude.localBridge.poolTitle') }}
+                </div>
+                <div class="bridge-pool-modal-hint">{{ t('claude.localBridge.poolHint') }}</div>
+                <div v-if="Object.keys(claudeConfigs || {}).length === 0" class="bridge-pool-empty">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="16" height="16"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
+                    <span>{{ t('claude.localBridge.noProviders') }}</span>
+                </div>
+                <div v-else class="bridge-pool-list">
+                    <label v-for="(config, name) in claudeConfigs" :key="name" class="bridge-pool-item">
+                        <span class="bridge-pool-item-name">{{ name }}</span>
+                        <span class="bridge-pool-item-status" :class="{ active: !isClaudeLocalBridgeExcluded(name) }">{{ isClaudeLocalBridgeExcluded(name) ? t('claude.localBridge.disabled') : t('claude.localBridge.enabled') }}</span>
+                        <input type="checkbox" :checked="!isClaudeLocalBridgeExcluded(name)" @change="toggleClaudeLocalBridgeExcluded(name)" />
+                    </label>
+                </div>
+                <div class="btn-group">
+                    <button class="btn btn-confirm" @click="showClaudeBridgePoolModal = false">{{ t('common.close') }}</button>
+                </div>
+            </div>
+        </div>

--- a/web-ui/partials/index/modals-basic.html
+++ b/web-ui/partials/index/modals-basic.html
@@ -197,27 +197,3 @@
             </div>
         </div>
 
-        <!-- Claude 轮询池控制模态框 -->
-        <div v-if="showClaudeBridgePoolModal" class="modal-overlay" @click.self="showClaudeBridgePoolModal = false">
-            <div class="modal modal-bridge-pool" role="dialog" aria-modal="true" aria-labelledby="claude-bridge-pool-modal-title">
-                <div class="modal-title" id="claude-bridge-pool-modal-title">
-                    <svg class="modal-title-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="18" height="18"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
-                    {{ t('claude.localBridge.poolTitle') }}
-                </div>
-                <div class="bridge-pool-modal-hint">{{ t('claude.localBridge.poolHint') }}</div>
-                <div v-if="Object.keys(claudeConfigs || {}).length === 0" class="bridge-pool-empty">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="16" height="16"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
-                    <span>{{ t('claude.localBridge.noProviders') }}</span>
-                </div>
-                <div v-else class="bridge-pool-list">
-                    <label v-for="(config, name) in claudeConfigs" :key="name" class="bridge-pool-item">
-                        <span class="bridge-pool-item-name">{{ name }}</span>
-                        <span class="bridge-pool-item-status" :class="{ active: !isClaudeLocalBridgeExcluded(name) }">{{ isClaudeLocalBridgeExcluded(name) ? t('claude.localBridge.disabled') : t('claude.localBridge.enabled') }}</span>
-                        <input type="checkbox" :checked="!isClaudeLocalBridgeExcluded(name)" @change="toggleClaudeLocalBridgeExcluded(name)" />
-                    </label>
-                </div>
-                <div class="btn-group">
-                    <button class="btn btn-confirm" @click="showClaudeBridgePoolModal = false">{{ t('common.close') }}</button>
-                </div>
-            </div>
-        </div>

--- a/web-ui/partials/index/panel-config-claude.html
+++ b/web-ui/partials/index/panel-config-claude.html
@@ -98,7 +98,7 @@
                 </div>
 
                 <div class="card-list">
-                    <div :class="['card', { active: currentClaudeConfig === 'claude-local' }]" @click="currentClaudeConfig = 'claude-local'" @keydown.enter.self.prevent="currentClaudeConfig = 'claude-local'" @keydown.space.self.prevent="currentClaudeConfig = 'claude-local'" tabindex="0" role="button" :aria-current="currentClaudeConfig === 'claude-local' ? 'true' : null">
+                    <div :class="['card', { active: currentClaudeConfig === 'claude-local' }]" @click="applyClaudeLocalBridge" @keydown.enter.self.prevent="applyClaudeLocalBridge" @keydown.space.self.prevent="applyClaudeLocalBridge" tabindex="0" role="button" :aria-current="currentClaudeConfig === 'claude-local' ? 'true' : null">
                         <div class="card-leading">
                             <div class="card-icon">L</div>
                             <div class="card-content">

--- a/web-ui/partials/index/panel-config-claude.html
+++ b/web-ui/partials/index/panel-config-claude.html
@@ -98,29 +98,6 @@
                 </div>
 
                 <div class="card-list">
-                    <div :class="['card', { active: currentClaudeConfig === 'claude-local' }]" @click="applyClaudeLocalBridge" @keydown.enter.self.prevent="applyClaudeLocalBridge" @keydown.space.self.prevent="applyClaudeLocalBridge" tabindex="0" role="button" :aria-current="currentClaudeConfig === 'claude-local' ? 'true' : null">
-                        <div class="card-leading">
-                            <div class="card-icon">L</div>
-                            <div class="card-content">
-                                <div class="bridge-pool-summary">
-                                    <svg class="bridge-pool-summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
-                                    <span class="bridge-pool-summary-text">已启用 {{ Object.keys(claudeConfigs || {}).filter(name => !isClaudeLocalBridgeExcluded(name)).length }} / {{ Object.keys(claudeConfigs || {}).length }}</span>
-                                </div>
-                                <div class="card-title">
-                                    <span>local</span>
-                                    <span class="provider-readonly-badge">{{ t('config.badge.system') }}</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="card-trailing">
-                            <span :class="['pill', claudeLocalBridgeConfigured() ? 'configured' : 'empty']">{{ claudeLocalBridgeConfigured() ? t('claude.configured') : t('claude.notConfigured') }}</span>
-                            <div class="card-actions" @click.stop>
-                                <button class="card-action-btn bridge-pool-trigger" @click="showClaudeBridgePoolModal = true" :aria-label="'轮询池设置'" :title="'轮询池设置'">
-                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
-                                </button>
-                            </div>
-                        </div>
-                    </div>
                     <div v-for="(config, name) in claudeConfigs" :key="name" :class="['card', { active: currentClaudeConfig === name }]" @click="applyClaudeConfig(name)" @keydown.enter.self.prevent="applyClaudeConfig(name)" @keydown.space.self.prevent="applyClaudeConfig(name)" tabindex="0" role="button" :aria-current="currentClaudeConfig === name ? 'true' : null">
                         <div class="card-leading">
                             <div class="card-icon">{{ name.charAt(0).toUpperCase() }}</div>

--- a/web-ui/partials/index/panel-config-claude.html
+++ b/web-ui/partials/index/panel-config-claude.html
@@ -102,6 +102,10 @@
                         <div class="card-leading">
                             <div class="card-icon">L</div>
                             <div class="card-content">
+                                <div class="bridge-pool-summary">
+                                    <svg class="bridge-pool-summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
+                                    <span class="bridge-pool-summary-text">已启用 {{ Object.keys(claudeConfigs || {}).filter(name => !isClaudeLocalBridgeExcluded(name)).length }} / {{ Object.keys(claudeConfigs || {}).length }}</span>
+                                </div>
                                 <div class="card-title">
                                     <span>local</span>
                                     <span class="provider-readonly-badge">{{ t('config.badge.system') }}</span>
@@ -110,6 +114,11 @@
                         </div>
                         <div class="card-trailing">
                             <span :class="['pill', claudeLocalBridgeConfigured() ? 'configured' : 'empty']">{{ claudeLocalBridgeConfigured() ? t('claude.configured') : t('claude.notConfigured') }}</span>
+                            <div class="card-actions" @click.stop>
+                                <button class="card-action-btn bridge-pool-trigger" @click="showClaudeBridgePoolModal = true" :aria-label="'轮询池设置'" :title="'轮询池设置'">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
+                                </button>
+                            </div>
                         </div>
                     </div>
                     <div v-for="(config, name) in claudeConfigs" :key="name" :class="['card', { active: currentClaudeConfig === name }]" @click="applyClaudeConfig(name)" @keydown.enter.self.prevent="applyClaudeConfig(name)" @keydown.space.self.prevent="applyClaudeConfig(name)" tabindex="0" role="button" :aria-current="currentClaudeConfig === name ? 'true' : null">
@@ -139,27 +148,6 @@
                                 </button>
                             </div>
                         </div>
-                    </div>
-                </div>
-
-                <div v-if="currentClaudeConfig === 'claude-local'" class="bridge-pool-panel">
-                    <div class="bridge-pool-header">
-                        <span class="bridge-pool-icon">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
-                        </span>
-                        <span class="bridge-pool-title">{{ t('claude.localBridge.poolTitle') }}</span>
-                        <span class="bridge-pool-hint">{{ t('claude.localBridge.poolHint') }}</span>
-                    </div>
-                    <div v-if="Object.keys(claudeConfigs || {}).length === 0" class="bridge-pool-empty">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="16" height="16"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
-                        <span>{{ t('claude.localBridge.noProviders') }}</span>
-                    </div>
-                    <div v-else class="bridge-pool-list">
-                        <label v-for="(config, name) in claudeConfigs" :key="name" class="bridge-pool-item">
-                            <span class="bridge-pool-item-name">{{ name }}</span>
-                            <span class="bridge-pool-item-status" :class="{ active: !isClaudeLocalBridgeExcluded(name) }">{{ isClaudeLocalBridgeExcluded(name) ? t('claude.localBridge.disabled') : t('claude.localBridge.enabled') }}</span>
-                            <input type="checkbox" :checked="!isClaudeLocalBridgeExcluded(name)" @change="toggleClaudeLocalBridgeExcluded(name)" />
-                        </label>
                     </div>
                 </div>
 

--- a/web-ui/partials/index/panel-config-claude.html
+++ b/web-ui/partials/index/panel-config-claude.html
@@ -82,6 +82,7 @@
                         :placeholder="t('claude.model.placeholder')"
                     >
                     <div class="config-template-hint">{{ t('claude.model.hint') }}</div>
+                    <button class="btn-tool btn-template-editor" @click="openClaudeConfigTemplateEditor" :disabled="loading || !!initError">{{ t('config.template.openEditor') }}</button>
                 </div>
 
                 <div class="selector-section">

--- a/web-ui/partials/index/panel-config-codex.html
+++ b/web-ui/partials/index/panel-config-codex.html
@@ -124,6 +124,10 @@
                         <div class="card-leading">
                             <div class="card-icon">{{ provider.name.charAt(0).toUpperCase() }}<span v-if="isTransformProvider(provider)" class="card-icon-dot" title="通过内建转换适配"></span></div>
                             <div class="card-content">
+                                <div v-if="provider.name === 'local'" class="bridge-pool-summary">
+                                    <svg class="bridge-pool-summary-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="12" height="12"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
+                                    <span class="bridge-pool-summary-text">已启用 {{ localBridgeCandidateProviders().filter(cp => !isLocalBridgeExcluded(cp.name)).length }} / {{ localBridgeCandidateProviders().length }}</span>
+                                </div>
                                 <div class="card-title">
                                     <span>{{ provider.name }}</span>
                                     <span v-if="provider.readOnly" class="provider-readonly-badge">{{ t('config.badge.system') }}</span>
@@ -136,6 +140,9 @@
                             <span v-if="speedResults[provider.name]" :class="['latency', speedResults[provider.name].ok ? 'ok' : 'error']">{{ formatLatency(speedResults[provider.name]) }}</span>
                             <span :class="['pill', providerPillConfigured(provider) ? 'configured' : 'empty']">{{ providerPillText(provider) }}</span>
                             <div class="card-actions" @click.stop>
+                                <button v-if="provider.name === 'local'" class="card-action-btn bridge-pool-trigger" @click="showCodexBridgePoolModal = true" :aria-label="'轮询池设置'" :title="'轮询池设置'">
+                                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
+                                </button>
                                 <button class="card-action-btn" :class="{ loading: speedLoading[provider.name] }" :disabled="!!speedLoading[provider.name]" @click="runSpeedTest(provider.name, { silent: true })" :aria-label="t('config.availabilityTestAria', { name: provider.name })" :title="t('config.availabilityTest')">
                                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
                                 </button>
@@ -164,27 +171,6 @@
                                 </button>
                             </div>
                         </div>
-                    </div>
-                </div>
-
-                <div v-if="displayCurrentProvider === 'local'" class="bridge-pool-panel">
-                    <div class="bridge-pool-header">
-                        <span class="bridge-pool-icon">
-                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" width="14" height="14"><circle cx="6" cy="6" r="2"/><circle cx="18" cy="6" r="2"/><circle cx="12" cy="18" r="2"/><path d="M6 8v4h6v4"/><path d="M18 8v4h-6v4"/></svg>
-                        </span>
-                        <span class="bridge-pool-title">轮询池</span>
-                        <span class="bridge-pool-hint">勾选参与负载均衡的提供商</span>
-                    </div>
-                    <div v-if="localBridgeCandidateProviders().length === 0" class="bridge-pool-empty">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" width="16" height="16"><path d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"/></svg>
-                        <span>暂无可用上游 provider，请先添加直连 provider</span>
-                    </div>
-                    <div v-else class="bridge-pool-list">
-                        <label v-for="cp in localBridgeCandidateProviders()" :key="cp.name" class="bridge-pool-item">
-                            <span class="bridge-pool-item-name">{{ cp.name }}</span>
-                            <span class="bridge-pool-item-status" :class="{ active: !isLocalBridgeExcluded(cp.name) }">{{ isLocalBridgeExcluded(cp.name) ? '未启用' : '已启用' }}</span>
-                            <input type="checkbox" :checked="!isLocalBridgeExcluded(cp.name)" @change="toggleLocalBridgeExcluded(cp.name)" />
-                        </label>
                     </div>
                 </div>
                 </template>

--- a/web-ui/styles/bridge-pool.css
+++ b/web-ui/styles/bridge-pool.css
@@ -3,6 +3,43 @@
    ============================================ */
 
 
+/* ---- 摘要状态（在卡片标题上方） ---- */
+.bridge-pool-summary {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-bottom: 4px;
+}
+
+.bridge-pool-summary-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    background: var(--color-brand-light);
+    color: var(--color-brand-dark);
+    flex-shrink: 0;
+}
+
+.bridge-pool-summary-text {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    letter-spacing: -0.01em;
+}
+
+/* ---- 轮询池触发按钮 ---- */
+.bridge-pool-trigger {
+    color: var(--color-brand);
+    background: rgba(200, 121, 99, 0.08);
+}
+
+.bridge-pool-trigger:hover {
+    background: rgba(200, 121, 99, 0.16);
+}
+
 .bridge-pool-panel {
     margin-top: 18px;
     padding: 18px 20px 16px;
@@ -194,4 +231,36 @@
     .bridge-pool-item {
         padding: 10px 12px 10px 14px;
     }
+}
+
+/* ---- 模态框中的轮询池 ---- */
+.modal-bridge-pool {
+    max-width: 380px;
+}
+
+.modal-title-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    border-radius: 6px;
+    background: var(--color-brand-light);
+    color: var(--color-brand-dark);
+    margin-right: 8px;
+    vertical-align: middle;
+}
+
+.bridge-pool-modal-hint {
+    font-size: 12px;
+    color: var(--color-text-muted);
+    margin-bottom: 14px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--color-border-soft);
+}
+
+.modal-bridge-pool .bridge-pool-list {
+    max-height: 320px;
+    overflow-y: auto;
+    margin-bottom: 16px;
 }


### PR DESCRIPTION
## Summary
- Add template editor button to Claude config panel Model section, aligned with Codex position
- Reuse existing configTemplate modal, context-aware apply via configTemplateContext flag
- Claude reads/writes ~/.claude/settings.json via get-claude-settings-raw / apply-claude-settings-raw APIs

## Tests
- [ ] Click template editor button in Claude tab opens modal with settings.json content
- [ ] Edit and apply saves to ~/.claude/settings.json
- [ ] Codex template editor still works unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template editor for Claude configuration with a dedicated button; applying templates now supports multiple config types.
  * New Codex and Claude "bridge-pool" modals to view and enable/disable upstream providers, plus card-level buttons to open them.
  * Inline bridge-pool summaries on Codex and Claude provider cards showing enabled vs total candidates.

* **Style**
  * New styles for bridge-pool summaries, modal layout, and list scrolling.

* **Behavior**
  * Improved automatic detection for Claude-local configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SakuraByteCore/codexmate/pull/167?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->