### PR TITLE
fix(web-ui): correct importSingleSkill parameter name

### DIFF
--- a/web-ui/modules/skills.methods.mjs
+++ b/web-ui/modules/skills.methods.mjs
@@ -491,7 +491,7 @@ export function createSkillsMethods({ api }) {
             try {
                 const res = await api('import-skills', {
                     targetApp: this.skillsTargetApp,
-                    imports: [skill]
+                    items: [skill]
                 });
                 if (res && res.error) {
                     this.showMessage(res.error, 'error');


### PR DESCRIPTION
## Summary
Fix parameter name mismatch in `importSingleSkill` that caused "请先选择要导入的 skill" error when clicking the + button in market tab.

## Technical changes
- `web-ui/modules/skills.methods.mjs`: Changed `imports: [skill]` to `items: [skill]` to match backend API expectation in `cli/skills.js:533`

## Verification
- Unit tests: 530 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected skill import request format to ensure proper backend communication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SakuraByteCore/codexmate/pull/177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->