### PR TITLE
feat: Web UI port auto-selection + v0.0.41

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ npm install -g codexmate
 codexmate run
 ```
 
+If the default Web UI port `3737` is unavailable, Codex Mate automatically tries the next ports (`3738`, `3739`, ...). To force a fixed port, set `CODEXMATE_PORT`:
+
+```bash
+CODEXMATE_PORT=8080 codexmate run
+```
+
+Windows PowerShell:
+
+```powershell
+$env:CODEXMATE_PORT=8080; codexmate run
+```
+
 ### Install via curl (Standalone)
 
 ```bash

--- a/README.zh.md
+++ b/README.zh.md
@@ -87,6 +87,18 @@ npm install -g codexmate
 codexmate run
 ```
 
+如果默认 Web UI 端口 `3737` 不可用，Codex Mate 会自动尝试后续端口（`3738`、`3739` ...）。如需固定端口，可以指定 `CODEXMATE_PORT`：
+
+```bash
+CODEXMATE_PORT=8080 codexmate run
+```
+
+Windows PowerShell：
+
+```powershell
+$env:CODEXMATE_PORT=8080; codexmate run
+```
+
 ### 通过 curl 安装 (独立包)
 
 ```bash

--- a/cli.js
+++ b/cli.js
@@ -359,6 +359,91 @@ function resolveWebPort() {
     return parsed;
 }
 
+function isWebPortExplicit() {
+    return typeof process.env.CODEXMATE_PORT === 'string' && process.env.CODEXMATE_PORT.trim().length > 0;
+}
+
+async function resolveAvailableWebPort(port, host, options = {}) {
+    const explicitPort = !!options.explicitPort;
+    const maxAttemptsRaw = Number.isFinite(options.maxAttempts) ? options.maxAttempts : parseInt(options.maxAttempts, 10);
+    const maxAttempts = Number.isFinite(maxAttemptsRaw) && maxAttemptsRaw > 0 ? Math.floor(maxAttemptsRaw) : 20;
+    const netModule = options.net || net;
+    const requestedPort = parseInt(String(port), 10);
+    if (!Number.isFinite(requestedPort) || requestedPort <= 0 || explicitPort) {
+        return {
+            port,
+            requestedPort: port,
+            explicitPort,
+            changed: false,
+            attempts: []
+        };
+    }
+
+    const attempts = [];
+    const checkPort = (candidatePort) => new Promise((resolve) => {
+        const tester = netModule.createServer();
+        let settled = false;
+        const finish = (result) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+        };
+        tester.once('error', (error) => {
+            finish({
+                available: false,
+                code: error && error.code ? String(error.code) : '',
+                message: error && error.message ? String(error.message) : ''
+            });
+        });
+        tester.once('listening', () => {
+            tester.close(() => finish({ available: true, code: '', message: '' }));
+        });
+        try {
+            tester.listen(candidatePort, host);
+        } catch (error) {
+            finish({
+                available: false,
+                code: error && error.code ? String(error.code) : '',
+                message: error && error.message ? String(error.message) : String(error)
+            });
+        }
+    });
+
+    const lastPort = Math.min(65535, requestedPort + maxAttempts - 1);
+    for (let candidatePort = requestedPort; candidatePort <= lastPort; candidatePort += 1) {
+        const result = await checkPort(candidatePort);
+        attempts.push({ port: candidatePort, available: !!result.available, code: result.code || '' });
+        if (result.available) {
+            return {
+                port: candidatePort,
+                requestedPort,
+                explicitPort: false,
+                changed: candidatePort !== requestedPort,
+                attempts
+            };
+        }
+        if (result.code !== 'EADDRINUSE' && result.code !== 'EACCES') {
+            return {
+                port: requestedPort,
+                requestedPort,
+                explicitPort: false,
+                changed: false,
+                attempts,
+                error: result.message || result.code || 'port probe failed'
+            };
+        }
+    }
+
+    return {
+        port: requestedPort,
+        requestedPort,
+        explicitPort: false,
+        changed: false,
+        attempts,
+        error: `no available port found from ${requestedPort} to ${lastPort}`
+    };
+}
+
 // #region releaseRunPortIfNeeded
 function releaseRunPortIfNeeded(port, host, deps = {}) {
     const numericPort = parseInt(String(port), 10);
@@ -11792,10 +11877,22 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
         socket.on('close', () => connections.delete(socket));
     });
 
+    const printPortOverrideHint = () => {
+        const examplePort = port === 8080 ? 8081 : 8080;
+        console.error(`  临时换端口（macOS/Linux）: CODEXMATE_PORT=${examplePort} codexmate run`);
+        console.error(`  临时换端口（Windows PowerShell）: $env:CODEXMATE_PORT=${examplePort}; codexmate run`);
+        console.error(`  临时换端口（Windows CMD）: set CODEXMATE_PORT=${examplePort} && codexmate run`);
+    };
+
     server.once('error', (err) => {
         if (err && err.code === 'EADDRINUSE') {
             console.error(`! 启动失败: 端口 ${port} 已被占用，可能有残留的 codexmate run 实例。`);
             console.error('  请先停止旧实例或更换端口后重试。');
+            printPortOverrideHint();
+        } else if (err && err.code === 'EACCES') {
+            console.error(`! 启动失败: 没有权限监听 ${host}:${port}。`);
+            console.error('  请检查系统/安全软件限制，或更换端口后重试。');
+            printPortOverrideHint();
         } else {
             console.error('! 启动 Web UI 失败:', err && err.message ? err.message : err);
         }
@@ -11916,7 +12013,7 @@ async function restartWebUiServerAfterFrontendChange({
 // #endregion restartWebUiServerAfterFrontendChange
 
 // 打开 Web UI
-function cmdStart(options = {}) {
+async function cmdStart(options = {}) {
     const webDir = path.join(__dirname, 'web-ui');
     const newHtmlPath = path.join(webDir, 'index.html');
     const legacyHtmlPath = path.join(__dirname, 'web-ui.html');
@@ -11927,9 +12024,29 @@ function cmdStart(options = {}) {
         process.exit(1);
     }
 
-    const port = resolveWebPort();
+    let port = resolveWebPort();
+    const explicitPort = isWebPortExplicit();
     const host = resolveWebHost(options);
     releaseRunPortIfNeeded(port, host);
+    const selectedPort = await resolveAvailableWebPort(port, host, { explicitPort });
+    if (selectedPort.error) {
+        console.error(`! 启动失败: ${selectedPort.error}`);
+        console.error(`  已尝试端口: ${selectedPort.attempts.map((attempt) => attempt.port).join(', ')}`);
+        console.error('  请设置 CODEXMATE_PORT 指定可用端口后重试。');
+        process.exit(1);
+    }
+    if (selectedPort.changed) {
+        const failed = selectedPort.attempts
+            .filter((attempt) => !attempt.available)
+            .map((attempt) => `${attempt.port}${attempt.code ? `(${attempt.code})` : ''}`)
+            .join(', ');
+        console.warn(`! 默认端口 ${selectedPort.requestedPort} 不可用，已自动切换到 ${selectedPort.port}。`);
+        if (failed) {
+            console.warn(`  跳过端口: ${failed}`);
+        }
+        console.warn('  如需固定端口，请设置 CODEXMATE_PORT 后重新启动。');
+    }
+    port = selectedPort.port;
 
     const isDev = process.env.NODE_ENV === 'development'
         || process.env.CODEXMATE_DEV === '1'
@@ -16301,7 +16418,7 @@ async function main() {
         case 'workflow': await cmdWorkflow(args.slice(1)); break;
         case 'task': await cmdTask(args.slice(1)); break;
         case 'analytics': await cmdAnalytics(args.slice(1)); break;
-        case 'run': cmdStart(parseStartOptions(args.slice(1))); break;
+        case 'run': await cmdStart(parseStartOptions(args.slice(1))); break;
         case 'update': await cmdToolUpdate(args.slice(1)); break;
         case 'start':
             console.error('错误: 命令已更名为 "run"，请使用: codexmate run');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexmate",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexmate",
-      "version": "0.0.40",
+      "version": "0.0.41",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexmate",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Codex/Claude Code/OpenClaw 配置、会话与任务编排 CLI + Web 工具",
   "main": "cli.js",
   "bin": {

--- a/site/index.md
+++ b/site/index.md
@@ -51,6 +51,18 @@ codexmate run
 codexmate run --no-browser
 ```
 
+如果默认端口 `3737` 不可用，Codex Mate 会自动尝试后续端口（`3738`、`3739` ...）。如需固定端口，可指定：
+
+```bash
+CODEXMATE_PORT=8080 codexmate run
+```
+
+Windows PowerShell：
+
+```powershell
+$env:CODEXMATE_PORT=8080; codexmate run
+```
+
 ## 命令速查
 
 - `codexmate status`

--- a/tests/unit/release-changelog.test.mjs
+++ b/tests/unit/release-changelog.test.mjs
@@ -19,7 +19,7 @@ test('release changelog selects the previous semver tag below the current releas
         'v0.0.38'
     );
     assert.equal(
-        selectPreviousSemverTag(['v0.0.39', 'v0.0.40'], 'v0.0.39'),
+        selectPreviousSemverTag(['v0.0.40', 'v0.0.41'], 'v0.0.40'),
         ''
     );
 });

--- a/tests/unit/web-run-host.test.mjs
+++ b/tests/unit/web-run-host.test.mjs
@@ -122,8 +122,13 @@ const resolveWebHostSource = extractFunctionBySignature(
 );
 const cmdStartSource = extractFunctionBySignature(
     cliContent,
-    'function cmdStart(options = {}) {',
+    'async function cmdStart(options = {}) {',
     'cmdStart'
+);
+const resolveAvailableWebPortSource = extractFunctionBySignature(
+    cliContent,
+    'async function resolveAvailableWebPort(port, host, options = {}) {',
+    'resolveAvailableWebPort'
 );
 const releaseRunPortIfNeededSource = extractFunctionBySignature(
     cliContent,
@@ -156,6 +161,83 @@ test('resolveWebHost still prefers environment host over default host', () => {
     });
 
     assert.strictEqual(withEnv({}), '192.168.1.10');
+});
+
+function createPortProbeNetMock(outcomes = {}) {
+    const checkedPorts = [];
+    return {
+        checkedPorts,
+        createServer() {
+            const handlers = {};
+            return {
+                once(event, handler) {
+                    handlers[event] = handler;
+                    return this;
+                },
+                listen(port) {
+                    checkedPorts.push(port);
+                    const outcome = outcomes[port] || 'available';
+                    setImmediate(() => {
+                        if (outcome === 'available') {
+                            if (handlers.listening) handlers.listening();
+                            return;
+                        }
+                        if (handlers.error) {
+                            handlers.error({ code: outcome, message: `${outcome} ${port}` });
+                        }
+                    });
+                },
+                close(callback) {
+                    if (typeof callback === 'function') {
+                        callback();
+                    }
+                }
+            };
+        }
+    };
+}
+
+test('resolveAvailableWebPort auto-increments only for the implicit default port', async () => {
+    const netMock = createPortProbeNetMock({
+        3737: 'EADDRINUSE',
+        3738: 'EACCES',
+        3739: 'available'
+    });
+    const resolveAvailableWebPort = instantiateFunction(resolveAvailableWebPortSource, 'resolveAvailableWebPort', {
+        net: netMock
+    });
+
+    const result = await resolveAvailableWebPort(3737, '127.0.0.1', { net: netMock });
+
+    assert.strictEqual(result.port, 3739);
+    assert.strictEqual(result.requestedPort, 3737);
+    assert.strictEqual(result.changed, true);
+    assert.deepStrictEqual(netMock.checkedPorts, [3737, 3738, 3739]);
+    assert.deepStrictEqual(result.attempts, [
+        { port: 3737, available: false, code: 'EADDRINUSE' },
+        { port: 3738, available: false, code: 'EACCES' },
+        { port: 3739, available: true, code: '' }
+    ]);
+});
+
+test('resolveAvailableWebPort does not probe or increment explicit ports', async () => {
+    const netMock = createPortProbeNetMock({
+        8080: 'EADDRINUSE'
+    });
+    const resolveAvailableWebPort = instantiateFunction(resolveAvailableWebPortSource, 'resolveAvailableWebPort', {
+        net: netMock
+    });
+
+    const result = await resolveAvailableWebPort(8080, '127.0.0.1', {
+        explicitPort: true,
+        net: netMock
+    });
+
+    assert.strictEqual(result.port, 8080);
+    assert.strictEqual(result.explicitPort, true);
+    assert.strictEqual(result.changed, false);
+    assert.deepStrictEqual(result.attempts, []);
+    assert.deepStrictEqual(netMock.checkedPorts, []);
 });
 
 test('web auto-open uses IPv6 loopback when binding to IPv6 any address', () => {
@@ -427,13 +509,16 @@ test('releaseRunPortIfNeeded only taskkills Windows listeners that match host an
 test('cmdStart releases the resolved port before creating the web server', () => {
     const resolveIndex = cmdStartSource.indexOf('resolveWebPort(');
     const releaseIndex = cmdStartSource.indexOf('releaseRunPortIfNeeded(port, host)');
+    const selectIndex = cmdStartSource.indexOf('resolveAvailableWebPort(port, host');
     const createIndex = cmdStartSource.indexOf('createWebServer(');
 
     assert(resolveIndex >= 0, 'cmdStart should resolve the web port');
     assert(releaseIndex >= 0, 'cmdStart should release the run port with host before startup');
+    assert(selectIndex >= 0, 'cmdStart should select an available port before startup');
     assert(createIndex >= 0, 'cmdStart should create the web server');
     assert(resolveIndex < releaseIndex, 'cmdStart should resolve the port before releasing it');
-    assert(releaseIndex < createIndex, 'cmdStart should release the port before creating the web server');
+    assert(releaseIndex < selectIndex, 'cmdStart should release the port before probing availability');
+    assert(selectIndex < createIndex, 'cmdStart should select the port before creating the web server');
 });
 
 const getCodexSkillsDirSource = extractFunctionBySignature(
@@ -812,6 +897,104 @@ test('createWebServer returns 500 when fallback bundled html generation throws',
     assertInternalServerErrorResponse(response);
     assert.deepStrictEqual(errors, [
         ['! Web UI 资源读取失败 [/]:', 'fallback html failed']
+    ]);
+});
+
+test('createWebServer prints port override guidance for EACCES listen errors', () => {
+    let errorHandler = null;
+    let exitCode = null;
+    const errors = [];
+    const createWebServer = instantiateFunction(createWebServerSource, 'createWebServer', {
+        http: {
+            createServer() {
+                return {
+                    listening: false,
+                    on() {},
+                    once(event, handler) {
+                        if (event === 'error') {
+                            errorHandler = handler;
+                        }
+                    },
+                    listen() {},
+                    close(callback) {
+                        if (typeof callback === 'function') {
+                            callback();
+                        }
+                    }
+                };
+            }
+        },
+        path,
+        __dirname: '/repo',
+        readBundledWebUiHtml() {
+            return '<!doctype html>';
+        },
+        PUBLIC_WEB_UI_DYNAMIC_ASSETS: new Map(),
+        PUBLIC_WEB_UI_STATIC_ASSETS: new Set(),
+        isPathInside() {
+            return true;
+        },
+        fs: {
+            existsSync() {
+                return false;
+            },
+            statSync() {
+                return {
+                    isFile() {
+                        return false;
+                    }
+                };
+            },
+            createReadStream() {
+                throw new Error('unexpected static asset read');
+            }
+        },
+        formatHostForUrl(value) {
+            return value;
+        },
+        DEFAULT_WEB_OPEN_HOST: '127.0.0.1',
+        isAnyAddressHost() {
+            return false;
+        },
+        process: {
+            env: {},
+            platform: 'linux',
+            exit(code) {
+                exitCode = code;
+            }
+        },
+        exec() {},
+        console: {
+            log() {},
+            warn() {},
+            error(...args) {
+                errors.push(args);
+            }
+        },
+        setTimeout,
+        Buffer,
+        startWinTray() {}
+    });
+
+    createWebServer({
+        htmlPath: '/repo/web-ui/index.html',
+        assetsDir: '/repo/res',
+        webDir: '/repo/web-ui',
+        host: '127.0.0.1',
+        port: 3737,
+        openBrowser: false
+    });
+
+    assert.strictEqual(typeof errorHandler, 'function');
+    errorHandler({ code: 'EACCES', message: 'listen EACCES: permission denied 127.0.0.1:3737' });
+
+    assert.strictEqual(exitCode, 1);
+    assert.deepStrictEqual(errors, [
+        ['! 启动失败: 没有权限监听 127.0.0.1:3737。'],
+        ['  请检查系统/安全软件限制，或更换端口后重试。'],
+        ['  临时换端口（macOS/Linux）: CODEXMATE_PORT=8080 codexmate run'],
+        ['  临时换端口（Windows PowerShell）: $env:CODEXMATE_PORT=8080; codexmate run'],
+        ['  临时换端口（Windows CMD）: set CODEXMATE_PORT=8080 && codexmate run']
     ]);
 });
 

--- a/tests/unit/web-run-host.test.mjs
+++ b/tests/unit/web-run-host.test.mjs
@@ -220,6 +220,34 @@ test('resolveAvailableWebPort auto-increments only for the implicit default port
     ]);
 });
 
+test('resolveAvailableWebPort reports a bounded error when no candidate port is available', async () => {
+    const netMock = createPortProbeNetMock({
+        3737: 'EADDRINUSE',
+        3738: 'EACCES',
+        3739: 'EADDRINUSE'
+    });
+    const resolveAvailableWebPort = instantiateFunction(resolveAvailableWebPortSource, 'resolveAvailableWebPort', {
+        net: netMock
+    });
+
+    const result = await resolveAvailableWebPort(3737, '127.0.0.1', {
+        maxAttempts: 3,
+        net: netMock
+    });
+
+    assert.strictEqual(result.port, 3737);
+    assert.strictEqual(result.requestedPort, 3737);
+    assert.strictEqual(result.changed, false);
+    assert.strictEqual(result.error, 'no available port found from 3737 to 3739');
+    assert.deepStrictEqual(netMock.checkedPorts, [3737, 3738, 3739]);
+    assert.strictEqual(result.attempts.length, 3);
+    assert.deepStrictEqual(result.attempts, [
+        { port: 3737, available: false, code: 'EADDRINUSE' },
+        { port: 3738, available: false, code: 'EACCES' },
+        { port: 3739, available: false, code: 'EADDRINUSE' }
+    ]);
+});
+
 test('resolveAvailableWebPort does not probe or increment explicit ports', async () => {
     const netMock = createPortProbeNetMock({
         8080: 'EADDRINUSE'


### PR DESCRIPTION
## Summary
- **v0.0.41 release**: Bump version from 0.0.40 to 0.0.41
- Auto-select the next available Web UI port when the default 3737 is unavailable
- Keep CODEXMATE_PORT strict when users explicitly set a fixed port
- Document fixed-port usage and add coverage for auto-increment and EACCES guidance

Fixes #183

## Technical changes
- Add port resolver that probes sequential ports when requested port is unavailable (unless explicitly set)
- Integrate port resolution into async cmdStart startup
- Add unit tests for port probing, bounded failure behavior, and EACCES handling
- Update documentation (README.md, README.zh.md, site/index.md) with CODEXMATE_PORT usage
- Bump version to v0.0.41

## Tests
- All 577 tests passed
- Added coverage for port exhaustion path

## Compatibility
- Fully backward compatible
- Default behavior: auto-probe ports 3737+ when unavailable
- Explicit CODEXMATE_PORT: strict mode, no probing