### PR TITLE
fix(release): generate accurate rounded release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
             cli.js cli/ lib/ plugins/ web-ui.html web-ui/ \
             node_modules/ package.json LICENSE README.md README.zh.md
           echo "STANDALONE_TGZ=$name" >> "$GITHUB_ENV"
-      - name: Print release changelog
+      - name: Generate release notes from actual commit range
         env:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
           TAG_EXISTS: ${{ steps.resolve.outputs.tag_exists }}

--- a/tests/unit/release-changelog.test.mjs
+++ b/tests/unit/release-changelog.test.mjs
@@ -9,6 +9,8 @@ const {
     parseLogLine,
     groupCommits,
     listContributors,
+    contributorProfile,
+    formatContributorCard,
     compareUrl,
     formatChangelog
 } = require('../../tools/release/changelog.js');
@@ -45,15 +47,27 @@ test('release changelog groups PR commits and direct commits for action logs', (
         commits
     });
 
-    assert.match(changelog, /## codexmate v0\.0\.39/);
-    assert.match(changelog, /Changes since v0\.0\.38/);
-    assert.match(changelog, /PRs:/);
+    assert.doesNotMatch(changelog, /## codexmate v0\.0\.39/);
+    assert.doesNotMatch(changelog, /Changes since v0\.0\.38/);
+    assert.match(changelog, /### PRs/);
     assert.match(changelog, /#180 fix\(proxy\): bypass responses probe for streaming codex tasks \(f5700cf\)/);
-    assert.match(changelog, /Commits without PR:/);
+    assert.match(changelog, /### Commits without PR/);
     assert.match(changelog, /abc1234 chore: update generated assets/);
     assert.match(changelog, /https:\/\/github\.com\/SakuraByteCore\/codexmate\/compare\/v0\.0\.38\.\.\.v0\.0\.39/);
-    assert.match(changelog, /### Contributors\n- awsl233777/);
-    assert.ok(changelog.trimEnd().endsWith('- awsl233777'));
+    assert.match(changelog, /### Contributors\n<a href="https:\/\/github\.com\/awsl233777" title="Awsl">/);
+    assert.match(changelog, /<img src="https:\/\/github\.com\/awsl233777\.png\?size=96" width="64" height="64" alt="Awsl" \/>/);
+    assert.doesNotMatch(changelog, /<sub><b>Awsl<\/b><\/sub>/);
+    assert.ok(changelog.trimEnd().endsWith('</a>'));
+});
+
+test('release changelog maps contributor display names to GitHub avatar cards', () => {
+    assert.deepStrictEqual(contributorProfile('Awsl'), { login: 'awsl233777', displayName: 'Awsl' });
+    assert.deepStrictEqual(contributorProfile('ymkiux'), { login: 'ymkiux', displayName: 'ymkiux' });
+
+    const card = formatContributorCard('ymkiux');
+    assert.match(card, /href="https:\/\/github\.com\/ymkiux"/);
+    assert.match(card, /src="https:\/\/github\.com\/ymkiux\.png\?size=96"/);
+    assert.doesNotMatch(card, /<sub><b>ymkiux<\/b><\/sub>/);
 });
 
 test('release changelog reports initial release when no previous tag exists', () => {
@@ -65,7 +79,7 @@ test('release changelog reports initial release when no previous tag exists', ()
         commits: []
     });
 
-    assert.match(changelog, /## codexmate v0\.0\.1/);
+    assert.doesNotMatch(changelog, /## codexmate v0\.0\.1/);
     assert.match(changelog, /No previous semver tag was found/);
     assert.match(changelog, /### Contributors\n- Unknown contributor/);
     assert.equal(compareUrl('SakuraByteCore/codexmate', '', 'v0.0.1', 'HEAD'), '');

--- a/tests/unit/release-changelog.test.mjs
+++ b/tests/unit/release-changelog.test.mjs
@@ -11,6 +11,7 @@ const {
     listContributors,
     contributorProfile,
     formatContributorCard,
+    formatChangeSummary,
     compareUrl,
     formatChangelog
 } = require('../../tools/release/changelog.js');
@@ -49,15 +50,31 @@ test('release changelog groups PR commits and direct commits for action logs', (
 
     assert.doesNotMatch(changelog, /## codexmate v0\.0\.39/);
     assert.doesNotMatch(changelog, /Changes since v0\.0\.38/);
+    assert.match(changelog, /### Changes/);
+    assert.match(changelog, /- proxy: bypass responses probe for streaming codex tasks \(#180\)/);
+    assert.match(changelog, /- update generated assets/);
     assert.match(changelog, /### PRs/);
     assert.match(changelog, /#180 fix\(proxy\): bypass responses probe for streaming codex tasks \(f5700cf\)/);
     assert.match(changelog, /### Commits without PR/);
     assert.match(changelog, /abc1234 chore: update generated assets/);
     assert.match(changelog, /https:\/\/github\.com\/SakuraByteCore\/codexmate\/compare\/v0\.0\.38\.\.\.v0\.0\.39/);
     assert.match(changelog, /### Contributors\n<a href="https:\/\/github\.com\/awsl233777" title="Awsl">/);
-    assert.match(changelog, /<img src="https:\/\/github\.com\/awsl233777\.png\?size=96" width="64" height="64" alt="Awsl" \/>/);
+    assert.match(changelog, /<img src="https:\/\/wsrv\.nl\/\?url=https%3A%2F%2Fgithub\.com%2Fawsl233777\.png%3Fsize%3D96&w=96&h=96&fit=cover&mask=circle" width="64" height="64" alt="Awsl" \/>/);
     assert.doesNotMatch(changelog, /<sub><b>Awsl<\/b><\/sub>/);
     assert.ok(changelog.trimEnd().endsWith('</a>'));
+});
+
+test('release changelog summarizes actual commit changes without release housekeeping', () => {
+    const commits = [
+        parseLogLine('628d451\u001ffeat: add Claude proxy target APIs with Ollama support (#171)\u001fAwsl'),
+        parseLogLine('5b92004\u001ffeat(web-ui): add Prompts tab for inline AGENTS.md and CLAUDE.md editing\u001fymkiux'),
+        parseLogLine('1587cce\u001fchore: bump version to 0.0.45\u001fymkiux')
+    ];
+
+    assert.deepStrictEqual(formatChangeSummary(commits), [
+        '- add Claude proxy target APIs with Ollama support (#171)',
+        '- web-ui: add Prompts tab for inline AGENTS.md and CLAUDE.md editing'
+    ]);
 });
 
 test('release changelog maps contributor display names to GitHub avatar cards', () => {
@@ -66,7 +83,7 @@ test('release changelog maps contributor display names to GitHub avatar cards', 
 
     const card = formatContributorCard('ymkiux');
     assert.match(card, /href="https:\/\/github\.com\/ymkiux"/);
-    assert.match(card, /src="https:\/\/github\.com\/ymkiux\.png\?size=96"/);
+    assert.match(card, /src="https:\/\/wsrv\.nl\/\?url=https%3A%2F%2Fgithub\.com%2Fymkiux\.png%3Fsize%3D96&w=96&h=96&fit=cover&mask=circle"/);
     assert.doesNotMatch(card, /<sub><b>ymkiux<\/b><\/sub>/);
 });
 

--- a/tests/unit/release-changelog.test.mjs
+++ b/tests/unit/release-changelog.test.mjs
@@ -36,8 +36,7 @@ test('release changelog groups PR commits and direct commits for action logs', (
     ];
     const grouped = groupCommits(commits);
 
-    assert.deepStrictEqual(grouped.prs.map((commit) => commit.pr), [180]);
-    assert.deepStrictEqual(grouped.directCommits.map((commit) => commit.hash), ['abc1234']);
+    assert.deepStrictEqual(grouped.directCommits.map((commit) => commit.hash), ['f5700cf', 'abc1234']);
     assert.deepStrictEqual(listContributors(commits), ['awsl233777']);
 
     const changelog = formatChangelog({
@@ -53,9 +52,9 @@ test('release changelog groups PR commits and direct commits for action logs', (
     assert.match(changelog, /### Changes/);
     assert.match(changelog, /- proxy: bypass responses probe for streaming codex tasks \(#180\)/);
     assert.match(changelog, /- update generated assets/);
-    assert.match(changelog, /### PRs/);
-    assert.match(changelog, /#180 fix\(proxy\): bypass responses probe for streaming codex tasks \(f5700cf\)/);
+    assert.doesNotMatch(changelog, /### PRs/);
     assert.match(changelog, /### Commits without PR/);
+    assert.match(changelog, /f5700cf fix\(proxy\): bypass responses probe for streaming codex tasks \(#180\)/);
     assert.match(changelog, /abc1234 chore: update generated assets/);
     assert.match(changelog, /https:\/\/github\.com\/SakuraByteCore\/codexmate\/compare\/v0\.0\.38\.\.\.v0\.0\.39/);
     assert.match(changelog, /### Contributors\n<a href="https:\/\/github\.com\/awsl233777" title="Awsl">/);
@@ -106,6 +105,7 @@ test('release workflow uses generated changelog as release body', () => {
     const workflow = fs.readFileSync('.github/workflows/release.yml', 'utf8');
 
     assert.match(workflow, /RELEASE_CHANGELOG_FILE:\s*release-changelog\.md/);
+    assert.match(workflow, /Generate release notes from actual commit range/);
     assert.match(workflow, /node tools\/release\/changelog\.js/);
     assert.match(workflow, /test -s "\$\{RELEASE_CHANGELOG_FILE\}"/);
     assert.match(workflow, /body_path:\s*\$\{\{ env\.RELEASE_CHANGELOG_FILE \}\}/);

--- a/tools/release/changelog.js
+++ b/tools/release/changelog.js
@@ -88,20 +88,7 @@ function readCommits(previousTag, currentRef) {
 }
 
 function groupCommits(commits) {
-    const prs = [];
-    const seenPrs = new Set();
-    const directCommits = [];
-    for (const commit of commits) {
-        if (commit.pr) {
-            if (!seenPrs.has(commit.pr)) {
-                seenPrs.add(commit.pr);
-                prs.push(commit);
-            }
-        } else {
-            directCommits.push(commit);
-        }
-    }
-    return { prs, directCommits };
+    return { directCommits: commits };
 }
 
 function formatContributorName(author) {
@@ -203,7 +190,7 @@ function formatChangelog({ repository = '', previousTag = '', currentTag = '', c
         return `${lines.join('\n')}\n`;
     }
 
-    const { prs, directCommits } = groupCommits(commits);
+    const { directCommits } = groupCommits(commits);
     if (!commits.length) {
         lines.push('No commits found in this range.');
     } else {
@@ -211,14 +198,6 @@ function formatChangelog({ repository = '', previousTag = '', currentTag = '', c
         if (changeSummary.length) {
             lines.push('### Changes');
             lines.push(...changeSummary);
-            lines.push('');
-        }
-
-        if (prs.length) {
-            lines.push('### PRs');
-            for (const commit of prs) {
-                lines.push(`- #${commit.pr} ${stripPullRequestSuffix(commit.subject)} (${commit.hash})`);
-            }
             lines.push('');
         }
 

--- a/tools/release/changelog.js
+++ b/tools/release/changelog.js
@@ -109,6 +109,38 @@ function formatContributorName(author) {
     return value || 'Unknown contributor';
 }
 
+const CONTRIBUTOR_PROFILES = new Map([
+    ['awsl', { login: 'awsl233777', displayName: 'Awsl' }],
+    ['awsl233777', { login: 'awsl233777', displayName: 'Awsl' }]
+]);
+
+function escapeHtml(value) {
+    return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function contributorProfile(author) {
+    const displayName = formatContributorName(author);
+    const mapped = CONTRIBUTOR_PROFILES.get(displayName.toLowerCase());
+    if (mapped) return mapped;
+    return { login: displayName, displayName };
+}
+
+function formatContributorCard(author) {
+    const { login, displayName } = contributorProfile(author);
+    const safeLogin = encodeURIComponent(login);
+    const safeDisplayName = escapeHtml(displayName);
+    return [
+        `<a href="https://github.com/${safeLogin}" title="${safeDisplayName}">`,
+        `  <img src="https://github.com/${safeLogin}.png?size=96" width="64" height="64" alt="${safeDisplayName}" />`,
+        `</a>`
+    ].join('\n');
+}
+
 function listContributors(commits) {
     const seen = new Set();
     const contributors = [];
@@ -129,14 +161,9 @@ function compareUrl(repository, previousTag, currentTag, currentRef) {
 }
 
 function formatChangelog({ repository = '', previousTag = '', currentTag = '', currentRef = 'HEAD', commits = [] }) {
-    const currentLabel = currentTag || currentRef || 'HEAD';
     const lines = [];
-    const releaseName = repository ? repository.split('/').pop() : 'Release';
-    lines.push(`## ${releaseName} ${currentLabel}`);
-    lines.push('');
 
     if (!previousTag) {
-        lines.push(`### Changes`);
         lines.push('No previous semver tag was found. Treating this as the initial release.');
         lines.push('');
         lines.push('### Contributors');
@@ -144,15 +171,12 @@ function formatChangelog({ repository = '', previousTag = '', currentTag = '', c
         return `${lines.join('\n')}\n`;
     }
 
-    lines.push(`### Changes since ${previousTag}`);
-    lines.push('');
-
     const { prs, directCommits } = groupCommits(commits);
     if (!commits.length) {
         lines.push('No commits found in this range.');
     } else {
         if (prs.length) {
-            lines.push('PRs:');
+            lines.push('### PRs');
             for (const commit of prs) {
                 lines.push(`- #${commit.pr} ${commit.subject.replace(/\s*\(#\d+\)\s*$/, '')} (${commit.hash})`);
             }
@@ -160,7 +184,7 @@ function formatChangelog({ repository = '', previousTag = '', currentTag = '', c
         }
 
         if (directCommits.length) {
-            lines.push('Commits without PR:');
+            lines.push('### Commits without PR');
             for (const commit of directCommits) {
                 lines.push(`- ${commit.hash} ${commit.subject}${commit.author ? ` — ${commit.author}` : ''}`);
             }
@@ -179,9 +203,7 @@ function formatChangelog({ repository = '', previousTag = '', currentTag = '', c
     if (!contributors.length) {
         lines.push('- Unknown contributor');
     } else {
-        for (const contributor of contributors) {
-            lines.push(`- ${contributor}`);
-        }
+        lines.push(contributors.map(formatContributorCard).join('\n&nbsp;&nbsp;\n'));
     }
     return `${lines.join('\n').replace(/\n{3,}/g, '\n\n')}\n`;
 }
@@ -233,6 +255,8 @@ module.exports = {
     parseLogLine,
     groupCommits,
     listContributors,
+    contributorProfile,
+    formatContributorCard,
     compareUrl,
     formatChangelog,
     main

--- a/tools/release/changelog.js
+++ b/tools/release/changelog.js
@@ -134,9 +134,11 @@ function formatContributorCard(author) {
     const { login, displayName } = contributorProfile(author);
     const safeLogin = encodeURIComponent(login);
     const safeDisplayName = escapeHtml(displayName);
+    const githubAvatarUrl = `https://github.com/${safeLogin}.png?size=96`;
+    const roundedAvatarUrl = `https://wsrv.nl/?url=${encodeURIComponent(githubAvatarUrl)}&w=96&h=96&fit=cover&mask=circle`;
     return [
         `<a href="https://github.com/${safeLogin}" title="${safeDisplayName}">`,
-        `  <img src="https://github.com/${safeLogin}.png?size=96" width="64" height="64" alt="${safeDisplayName}" />`,
+        `  <img src="${roundedAvatarUrl}" width="64" height="64" alt="${safeDisplayName}" />`,
         `</a>`
     ].join('\n');
 }
@@ -160,6 +162,36 @@ function compareUrl(repository, previousTag, currentTag, currentRef) {
     return `https://github.com/${repository}/compare/${previousTag}...${right}`;
 }
 
+function stripPullRequestSuffix(subject) {
+    return String(subject || '').replace(/\s*\(#\d+\)\s*$/, '').trim();
+}
+
+function formatChangeSummaryLine(commit) {
+    const subject = stripPullRequestSuffix(commit?.subject || '');
+    if (!subject) return '';
+    if (/^chore:\s*bump version\b/i.test(subject)) return '';
+
+    const conventional = subject.match(/^(\w+)(?:\(([^)]+)\))?:\s*(.+)$/);
+    const summary = conventional
+        ? `${conventional[2] ? `${conventional[2]}: ` : ''}${conventional[3]}`
+        : subject;
+    return `- ${summary}${commit.pr ? ` (#${commit.pr})` : ''}`;
+}
+
+function formatChangeSummary(commits) {
+    const lines = [];
+    const seen = new Set();
+    for (const commit of commits) {
+        const line = formatChangeSummaryLine(commit);
+        if (!line) continue;
+        const key = line.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        lines.push(line);
+    }
+    return lines;
+}
+
 function formatChangelog({ repository = '', previousTag = '', currentTag = '', currentRef = 'HEAD', commits = [] }) {
     const lines = [];
 
@@ -175,10 +207,17 @@ function formatChangelog({ repository = '', previousTag = '', currentTag = '', c
     if (!commits.length) {
         lines.push('No commits found in this range.');
     } else {
+        const changeSummary = formatChangeSummary([...commits].reverse());
+        if (changeSummary.length) {
+            lines.push('### Changes');
+            lines.push(...changeSummary);
+            lines.push('');
+        }
+
         if (prs.length) {
             lines.push('### PRs');
             for (const commit of prs) {
-                lines.push(`- #${commit.pr} ${commit.subject.replace(/\s*\(#\d+\)\s*$/, '')} (${commit.hash})`);
+                lines.push(`- #${commit.pr} ${stripPullRequestSuffix(commit.subject)} (${commit.hash})`);
             }
             lines.push('');
         }
@@ -257,6 +296,9 @@ module.exports = {
     listContributors,
     contributorProfile,
     formatContributorCard,
+    stripPullRequestSuffix,
+    formatChangeSummaryLine,
+    formatChangeSummary,
     compareUrl,
     formatChangelog,
     main


### PR DESCRIPTION
## Summary
- generate release notes from the actual release commit range
- omit the separate `### PRs` section while keeping all compare commits traceable in `### Commits without PR`
- render Contributors as avatar-only rounded GitHub cards instead of plain text names
- map the Awsl display name to the `awsl233777` GitHub avatar/profile
- explicitly update the release workflow step to generate release notes from the actual commit range
- update release changelog unit coverage for the new format

## Validation
- `node tests/unit/run.mjs`
- `npm run lint`
- generated `v0.0.45` with `RELEASE_TAG=v0.0.45 GITHUB_REPOSITORY=SakuraByteCore/codexmate RELEASE_CHANGELOG_FILE=/tmp/codexmate-release-e2e.md node tools/release/changelog.js`
- compared generated audit details against GitHub `compare/v0.0.44...v0.0.45`: 11/11 compare commits present
- verified generated body has no `### PRs`, no old `codexmate v0.0.45` title, and no `Changes since v0.0.44`
- downloaded both rounded contributor avatar images and verified all PNG corner alpha values are transparent
- verified `.github/workflows/release.yml` contains `Generate release notes from actual commit range` and still calls `node tools/release/changelog.js`

## Notes
- Existing release `v0.0.45` was updated separately to the same generated format.
- Browser navigation to GitHub was blocked by local browser policy, so rendered verification used GitHub API body readback plus real image downloads instead of a browser screenshot.