### PR TITLE
feat(mcp): cross-session memory tools with robust MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ codex-switcher.exe
 *.env
 .env.*
 .npmrc
+.mcp.json
 
 # Package manager lockfiles (keep package-lock.json)
 # pnpm-lock.yaml

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "codexmate": {
       "command": "node",
-      "args": ["${CLAUDE_PROJECT_DIR:-.}/cli.js", "mcp", "serve"]
+      "args": ["/absolute/path/to/codexmate/cli.js", "mcp", "serve"]
     }
   }
 }

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -1,8 +1,15 @@
 {
+  "_comment": "Rename to .mcp.json and fill in your absolute paths. Default is read-only.",
   "mcpServers": {
     "codexmate": {
-      "command": "node",
-      "args": ["/absolute/path/to/codexmate/cli.js", "mcp", "serve"]
+      "command": "/absolute/path/to/node",
+      "args": [
+        "/absolute/path/to/codexmate/cli.js",
+        "mcp",
+        "serve",
+        "--project-root",
+        "/absolute/path/to/your/project"
+      ]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "codexmate": {
+      "command": "node",
+      "args": ["cli.js", "mcp", "serve", "--allow-write"]
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "codexmate": {
       "command": "node",
-      "args": ["cli.js", "mcp", "serve", "--allow-write"]
+      "args": ["${CLAUDE_PROJECT_DIR:-.}/cli.js", "mcp", "serve"]
     }
   }
 }

--- a/cli.js
+++ b/cli.js
@@ -65,6 +65,7 @@ const {
     resolveMaxMessagesValue
 } = require('./lib/cli-session-utils');
 const { createMcpStdioServer } = require('./lib/mcp-stdio');
+const { saveMemory, searchMemories, listMemories, updateMemory, deleteMemory } = require('./lib/memory-store');
 const {
     validateWorkflowDefinition,
     executeWorkflowDefinition
@@ -16750,6 +16751,90 @@ function createMcpTools(options = {}) {
             additionalProperties: true
         },
         handler: async (args = {}) => applyBuiltinProxyProvider(args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.memory.save',
+        description: 'Save a cross-session memory entry (decision, fix, context) for future retrieval.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                tags: { type: 'array', items: { type: 'string' } },
+                summary: { type: 'string' },
+                content: { type: 'string' },
+                sourceSession: { type: 'string' }
+            },
+            required: ['summary', 'content'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => saveMemory(process.cwd(), args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.memory.search',
+        description: 'Search cross-session memories by keyword. Supports multi-word AND queries and tag filtering.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                query: { type: 'string' },
+                tags: { type: 'array', items: { type: 'string' } },
+                limit: { type: 'integer' }
+            },
+            required: ['query'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => searchMemories(process.cwd(), args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.memory.list',
+        description: 'List cross-session memories with optional tag filter and pagination.',
+        readOnly: true,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                tags: { type: 'array', items: { type: 'string' } },
+                limit: { type: 'integer' },
+                offset: { type: 'integer' }
+            },
+            additionalProperties: false
+        },
+        handler: async (args = {}) => listMemories(process.cwd(), args || {})
+    });
+
+    pushTool({
+        name: 'codexmate.memory.update',
+        description: 'Update an existing memory entry by id.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string' },
+                tags: { type: 'array', items: { type: 'string' } },
+                summary: { type: 'string' },
+                content: { type: 'string' }
+            },
+            required: ['id'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => updateMemory(process.cwd(), args.id, args)
+    });
+
+    pushTool({
+        name: 'codexmate.memory.delete',
+        description: 'Delete a cross-session memory entry by id.',
+        readOnly: false,
+        inputSchema: {
+            type: 'object',
+            properties: {
+                id: { type: 'string' }
+            },
+            required: ['id'],
+            additionalProperties: false
+        },
+        handler: async (args = {}) => deleteMemory(process.cwd(), args.id)
     });
 
     return tools;

--- a/cli.js
+++ b/cli.js
@@ -17141,6 +17141,8 @@ async function cmdMcp(args = []) {
         || (typeof process.env.CLAUDE_PROJECT_DIR === 'string' && process.env.CLAUDE_PROJECT_DIR.trim())
         || process.cwd();
 
+    console.error(`[codexmate-mcp] starting v${packageVersion}, projectDir=${projectDir}, allowWrite=${options.allowWrite}`);
+
     const server = createMcpStdioServer({
         protocolVersion: '2025-11-25',
         serverInfo: {
@@ -17157,6 +17159,13 @@ async function cmdMcp(args = []) {
     });
 
     server.start();
+
+    process.on('uncaughtException', (err) => {
+        console.error(`[codexmate-mcp] uncaughtException: ${err && err.message}`);
+    });
+    process.on('unhandledRejection', (reason) => {
+        console.error(`[codexmate-mcp] unhandledRejection: ${reason}`);
+    });
 
     await new Promise((resolve) => {
         let done = false;

--- a/cli.js
+++ b/cli.js
@@ -17083,6 +17083,44 @@ async function cmdMcp(args = []) {
         return;
     }
 
+    if (options.subcommand === 'doctor') {
+        const checks = [];
+        const addCheck = (label, ok, detail) => {
+            checks.push({ label, ok, detail: detail || '' });
+            const mark = ok ? 'OK' : 'FAIL';
+            console.error(`  [${mark}] ${label}${detail ? ': ' + detail : ''}`);
+        };
+
+        console.error('codexmate mcp doctor\n');
+
+        const nodePath = process.execPath;
+        addCheck('node binary', !!nodePath && require('fs').existsSync(nodePath), nodePath);
+
+        const cliPath = require('path').resolve(__dirname, 'cli.js');
+        addCheck('cli.js', require('fs').existsSync(cliPath), cliPath);
+
+        let depsOk = true;
+        let depsDetail = '';
+        try { require('@iarna/toml'); } catch (e) { depsOk = false; depsDetail = e.message; }
+        try { require('json5'); } catch (e) { depsOk = false; depsDetail += (depsDetail ? '; ' : '') + e.message; }
+        addCheck('dependencies (npm install)', depsOk, depsDetail || 'all required modules loaded');
+
+        const projectRoot = options.projectDir || process.cwd();
+        const memoriesDir = require('path').join(projectRoot, '.codexmate');
+        let dirWritable = true;
+        try {
+            require('fs').mkdirSync(memoriesDir, { recursive: true });
+            const testFile = require('path').join(memoriesDir, '.doctor-test');
+            require('fs').writeFileSync(testFile, 'ok');
+            require('fs').unlinkSync(testFile);
+        } catch (e) { dirWritable = false; }
+        addCheck('project-root writable', dirWritable, memoriesDir);
+
+        const allOk = checks.every((c) => c.ok);
+        console.error(allOk ? '\nAll checks passed.' : '\nSome checks failed. Fix the issues above before using MCP.');
+        process.exit(allOk ? 0 : 1);
+    }
+
     if (options.subcommand !== 'serve') {
         throw new Error(`未知 mcp 子命令: ${options.subcommand}`);
     }

--- a/cli.js
+++ b/cli.js
@@ -14166,6 +14166,7 @@ function parseMcpOptions(args = []) {
         subcommand: 'serve',
         transport: 'stdio',
         allowWrite: false,
+        projectDir: '',
         help: false
     };
 
@@ -14177,6 +14178,10 @@ function parseMcpOptions(args = []) {
     const envAllowWrite = typeof process.env.CODEXMATE_MCP_ALLOW_WRITE === 'string'
         && ['1', 'true', 'yes', 'on'].includes(process.env.CODEXMATE_MCP_ALLOW_WRITE.trim().toLowerCase());
     options.allowWrite = envAllowWrite;
+
+    if (typeof process.env.CODEXMATE_PROJECT_ROOT === 'string' && process.env.CODEXMATE_PROJECT_ROOT.trim()) {
+        options.projectDir = process.env.CODEXMATE_PROJECT_ROOT.trim();
+    }
 
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i];
@@ -14191,6 +14196,15 @@ function parseMcpOptions(args = []) {
         }
         if (arg === '--read-only') {
             options.allowWrite = false;
+            continue;
+        }
+        if (arg.startsWith('--project-root=')) {
+            options.projectDir = arg.slice('--project-root='.length).trim();
+            continue;
+        }
+        if (arg === '--project-root') {
+            options.projectDir = String(argv[i + 1] || '').trim();
+            i += 1;
             continue;
         }
         if (arg.startsWith('--transport=')) {
@@ -16218,6 +16232,9 @@ async function cmdTaskWorker(args = []) {
 
 function createMcpTools(options = {}) {
     const allowWrite = !!options.allowWrite;
+    const projectDir = typeof options.projectDir === 'string' && options.projectDir.trim()
+        ? options.projectDir.trim()
+        : process.cwd();
     const tools = [];
 
     const pushTool = (tool) => {
@@ -16768,7 +16785,7 @@ function createMcpTools(options = {}) {
             required: ['summary', 'content'],
             additionalProperties: false
         },
-        handler: async (args = {}) => saveMemory(process.cwd(), args || {})
+        handler: async (args = {}) => saveMemory(projectDir, args || {})
     });
 
     pushTool({
@@ -16785,7 +16802,7 @@ function createMcpTools(options = {}) {
             required: ['query'],
             additionalProperties: false
         },
-        handler: async (args = {}) => searchMemories(process.cwd(), args || {})
+        handler: async (args = {}) => searchMemories(projectDir, args || {})
     });
 
     pushTool({
@@ -16801,7 +16818,7 @@ function createMcpTools(options = {}) {
             },
             additionalProperties: false
         },
-        handler: async (args = {}) => listMemories(process.cwd(), args || {})
+        handler: async (args = {}) => listMemories(projectDir, args || {})
     });
 
     pushTool({
@@ -16819,7 +16836,7 @@ function createMcpTools(options = {}) {
             required: ['id'],
             additionalProperties: false
         },
-        handler: async (args = {}) => updateMemory(process.cwd(), args.id, args)
+        handler: async (args = {}) => updateMemory(projectDir, args.id, args)
     });
 
     pushTool({
@@ -16834,7 +16851,7 @@ function createMcpTools(options = {}) {
             required: ['id'],
             additionalProperties: false
         },
-        handler: async (args = {}) => deleteMemory(process.cwd(), args.id)
+        handler: async (args = {}) => deleteMemory(projectDir, args.id)
     });
 
     return tools;
@@ -17058,9 +17075,10 @@ function createMcpPrompts() {
 async function cmdMcp(args = []) {
     const options = parseMcpOptions(args);
     if (options.help) {
-        console.log('\n用法: codexmate mcp [serve] [--transport stdio] [--allow-write|--read-only]');
+        console.log('\n用法: codexmate mcp [serve] [--transport stdio] [--allow-write|--read-only] [--project-root <path>]');
         console.log('  默认 transport=stdio，默认 read-only。');
         console.log('  设置环境变量 CODEXMATE_MCP_ALLOW_WRITE=1 可默认开启写工具。');
+        console.log('  设置 --project-root 或 CODEXMATE_PROJECT_ROOT 指定项目根目录（memory 存储位置）。');
         console.log();
         return;
     }
@@ -17081,13 +17099,17 @@ async function cmdMcp(args = []) {
         }
     })();
 
+    const projectDir = options.projectDir
+        || (typeof process.env.CLAUDE_PROJECT_DIR === 'string' && process.env.CLAUDE_PROJECT_DIR.trim())
+        || process.cwd();
+
     const server = createMcpStdioServer({
         protocolVersion: '2025-11-25',
         serverInfo: {
             name: 'codexmate-mcp',
             version: packageVersion
         },
-        tools: createMcpTools({ allowWrite: options.allowWrite }),
+        tools: createMcpTools({ allowWrite: options.allowWrite, projectDir }),
         resources: createMcpResources(),
         prompts: createMcpPrompts(),
         logger: (level, message) => {

--- a/lib/mcp-stdio.js
+++ b/lib/mcp-stdio.js
@@ -1,4 +1,5 @@
 const DEFAULT_PROTOCOL_VERSION = '2025-11-25';
+const COMPATIBLE_PROTOCOL_VERSIONS = ['2025-11-25', '2025-03-26'];
 
 function jsonRpcError(code, message, data) {
     const error = {
@@ -166,8 +167,12 @@ function createMcpRequestRouter(options = {}) {
         const params = request.params && typeof request.params === 'object' ? request.params : {};
 
         if (method === 'initialize') {
+            const clientVersion = typeof params.protocolVersion === 'string' ? params.protocolVersion.trim() : '';
+            const negotiatedVersion = COMPATIBLE_PROTOCOL_VERSIONS.includes(clientVersion)
+                ? clientVersion
+                : protocolVersion;
             return {
-                protocolVersion,
+                protocolVersion: negotiatedVersion,
                 capabilities,
                 serverInfo: {
                     name: serverInfo.name || 'codexmate-mcp',
@@ -447,6 +452,7 @@ function createMcpStdioServer(options = {}) {
 
 module.exports = {
     DEFAULT_PROTOCOL_VERSION,
+    COMPATIBLE_PROTOCOL_VERSIONS,
     jsonRpcError,
     createMcpRequestRouter,
     createMcpStdioServer

--- a/lib/mcp-stdio.js
+++ b/lib/mcp-stdio.js
@@ -298,6 +298,9 @@ function createMcpStdioServer(options = {}) {
         const body = Buffer.from(text, 'utf-8');
         const header = Buffer.from(`Content-Length: ${body.length}\r\nContent-Type: application/json\r\n\r\n`, 'utf-8');
         stdout.write(Buffer.concat([header, body]));
+        if (typeof stdout.flush === 'function') {
+            stdout.flush();
+        }
     };
 
     const writeResponse = (id, result) => {
@@ -340,6 +343,7 @@ function createMcpStdioServer(options = {}) {
 
         const hasMethod = typeof message.method === 'string' && message.method.trim().length > 0;
         const hasId = Object.prototype.hasOwnProperty.call(message, 'id');
+        const method = hasMethod ? message.method.trim() : '';
 
         if (!hasMethod) {
             if (hasId) {
@@ -354,10 +358,14 @@ function createMcpStdioServer(options = {}) {
             const result = await router.handleRequest(message);
             if (hasId) {
                 writeResponse(message.id, result === null ? {} : result);
+            } else if (method === 'initialize') {
+                writeResponse(null, result === null ? {} : result);
             }
         } catch (error) {
             if (hasId) {
                 writeError(message.id, error);
+            } else if (method === 'initialize') {
+                writeError(null, error);
             } else {
                 logger('error', `MCP notification handling failed: ${error && error.message ? error.message : error}`);
             }

--- a/lib/mcp-stdio.js
+++ b/lib/mcp-stdio.js
@@ -1,5 +1,5 @@
 const DEFAULT_PROTOCOL_VERSION = '2025-11-25';
-const COMPATIBLE_PROTOCOL_VERSIONS = ['2025-11-25', '2025-03-26'];
+const COMPATIBLE_PROTOCOL_VERSIONS = ['2024-11-05', '2025-03-26', '2025-06-18', '2025-11-25'];
 
 function jsonRpcError(code, message, data) {
     const error = {

--- a/lib/memory-store.js
+++ b/lib/memory-store.js
@@ -1,0 +1,167 @@
+const path = require('path');
+const crypto = require('crypto');
+const { readJsonArrayFile, writeJsonAtomic, ensureDir } = require('./cli-file-utils');
+
+function generateId() {
+    const date = new Date();
+    const pad = (n) => String(n).padStart(2, '0');
+    const datePart = [
+        date.getFullYear(),
+        pad(date.getMonth() + 1),
+        pad(date.getDate())
+    ].join('');
+    const hex = crypto.randomBytes(3).toString('hex');
+    return `mem_${datePart}_${hex}`;
+}
+
+function resolveMemoryFilePath(projectDir) {
+    return path.join(projectDir, '.codexmate', 'memories.json');
+}
+
+function loadMemories(projectDir) {
+    const filePath = resolveMemoryFilePath(projectDir);
+    return readJsonArrayFile(filePath, []);
+}
+
+function persistMemories(projectDir, memories) {
+    const filePath = resolveMemoryFilePath(projectDir);
+    ensureDir(path.dirname(filePath));
+    writeJsonAtomic(filePath, memories);
+}
+
+function saveMemory(projectDir, entry) {
+    if (!entry || typeof entry !== 'object') {
+        return { error: 'Entry is required' };
+    }
+    const summary = typeof entry.summary === 'string' ? entry.summary.trim() : '';
+    const content = typeof entry.content === 'string' ? entry.content.trim() : '';
+    if (!summary) {
+        return { error: 'summary is required' };
+    }
+    if (!content) {
+        return { error: 'content is required' };
+    }
+    const tags = Array.isArray(entry.tags)
+        ? entry.tags.filter((t) => typeof t === 'string' && t.trim()).map((t) => t.trim())
+        : [];
+    const sourceSession = typeof entry.sourceSession === 'string' ? entry.sourceSession.trim() : '';
+
+    const now = new Date().toISOString();
+    const memory = {
+        id: generateId(),
+        tags,
+        summary,
+        content,
+        sourceSession,
+        createdAt: now,
+        updatedAt: now
+    };
+
+    const memories = loadMemories(projectDir);
+    memories.push(memory);
+    persistMemories(projectDir, memories);
+    return { success: true, memory };
+}
+
+function matchesQuery(entry, queryWords) {
+    const haystack = [entry.summary, entry.content, ...(entry.tags || [])]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+    return queryWords.every((word) => haystack.includes(word));
+}
+
+function matchesTags(entry, tags) {
+    if (!Array.isArray(tags) || tags.length === 0) return true;
+    const entryTags = (entry.tags || []).map((t) => t.toLowerCase());
+    return tags.some((tag) => entryTags.includes(tag.toLowerCase()));
+}
+
+function searchMemories(projectDir, options) {
+    const opts = options || {};
+    const query = typeof opts.query === 'string' ? opts.query.trim() : '';
+    if (!query) {
+        return { error: 'query is required' };
+    }
+    const queryWords = query.toLowerCase().split(/\s+/).filter(Boolean);
+    const limit = Number.isFinite(opts.limit) && opts.limit > 0 ? Math.min(opts.limit, 100) : 20;
+    const tags = Array.isArray(opts.tags) ? opts.tags : [];
+
+    const all = loadMemories(projectDir);
+    const results = [];
+    for (let i = all.length - 1; i >= 0; i--) {
+        const entry = all[i];
+        if (matchesTags(entry, tags) && matchesQuery(entry, queryWords)) {
+            results.push(entry);
+            if (results.length >= limit) break;
+        }
+    }
+    return { success: true, memories: results, count: results.length };
+}
+
+function listMemories(projectDir, options) {
+    const opts = options || {};
+    const tags = Array.isArray(opts.tags) ? opts.tags : [];
+    const limit = Number.isFinite(opts.limit) && opts.limit > 0 ? Math.min(opts.limit, 100) : 20;
+    const offset = Number.isFinite(opts.offset) && opts.offset >= 0 ? opts.offset : 0;
+
+    const all = loadMemories(projectDir);
+    const filtered = tags.length > 0
+        ? all.filter((entry) => matchesTags(entry, tags))
+        : all;
+    const total = filtered.length;
+    const items = filtered.slice(offset, offset + limit);
+    return { success: true, memories: items, total, offset, limit };
+}
+
+function updateMemory(projectDir, id, patch) {
+    if (!id || typeof id !== 'string') {
+        return { error: 'id is required' };
+    }
+    const memories = loadMemories(projectDir);
+    const index = memories.findIndex((m) => m.id === id);
+    if (index === -1) {
+        return { error: 'Memory not found' };
+    }
+
+    const entry = memories[index];
+    if (patch && typeof patch === 'object') {
+        if (typeof patch.summary === 'string' && patch.summary.trim()) {
+            entry.summary = patch.summary.trim();
+        }
+        if (typeof patch.content === 'string' && patch.content.trim()) {
+            entry.content = patch.content.trim();
+        }
+        if (Array.isArray(patch.tags)) {
+            entry.tags = patch.tags.filter((t) => typeof t === 'string' && t.trim()).map((t) => t.trim());
+        }
+    }
+    entry.updatedAt = new Date().toISOString();
+    memories[index] = entry;
+    persistMemories(projectDir, memories);
+    return { success: true, memory: entry };
+}
+
+function deleteMemory(projectDir, id) {
+    if (!id || typeof id !== 'string') {
+        return { error: 'id is required' };
+    }
+    const memories = loadMemories(projectDir);
+    const index = memories.findIndex((m) => m.id === id);
+    if (index === -1) {
+        return { error: 'Memory not found' };
+    }
+    memories.splice(index, 1);
+    persistMemories(projectDir, memories);
+    return { success: true, id };
+}
+
+module.exports = {
+    resolveMemoryFilePath,
+    loadMemories,
+    saveMemory,
+    searchMemories,
+    listMemories,
+    updateMemory,
+    deleteMemory
+};

--- a/tests/e2e/run.js
+++ b/tests/e2e/run.js
@@ -23,7 +23,7 @@ const testSessionResumeCommands = require('./test-session-resume-commands');
 const testOpenclaw = require('./test-openclaw');
 const testHealthSpeed = require('./test-health-speed');
 const testMessages = require('./test-messages');
-const testMcp = require('./test-mcp');
+const { testMcp, testMcpFromConfig } = require('./test-mcp');
 const testWorkflow = require('./test-workflow');
 const testTaskOrchestration = require('./test-task-orchestration');
 const testInvalidConfig = require('./test-invalid-config');
@@ -159,6 +159,7 @@ async function main() {
         await testHealthSpeed(ctx);
         await testMessages(ctx);
         await testMcp(ctx);
+        await testMcpFromConfig(ctx);
         await testWorkflow(ctx);
         await testTaskOrchestration(ctx);
         await testInstallStatus(ctx);

--- a/tests/e2e/test-mcp.js
+++ b/tests/e2e/test-mcp.js
@@ -73,7 +73,7 @@ function runMcpExchange(node, cliPath, env, args, requests) {
     return decodeFrames(stdoutBuffer);
 }
 
-module.exports = async function testMcp(ctx) {
+async function testMcp(ctx) {
     const { env, node, cliPath, api, longSessionId, longMessageCount, tmpHome } = ctx;
 
     const readOnlyRequests = [
@@ -542,3 +542,110 @@ module.exports = async function testMcp(ctx) {
     const memSearchAfterDelete = ((udById.get(24).result || {}).structuredContent) || {};
     assert(memSearchAfterDelete.count === 0, 'mcp memory.search should find nothing after delete');
 };
+
+async function testMcpFromConfig(ctx) {
+    const { node, cliPath } = ctx;
+    const projectRoot = path.resolve(__dirname, '..', '..');
+    const mcpConfigPath = path.join(projectRoot, '.mcp.json');
+
+    assert(fs.existsSync(mcpConfigPath), '.mcp.json should exist in project root');
+    const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf-8'));
+    const serverDef = (mcpConfig.mcpServers || {}).codexmate;
+    assert(serverDef, '.mcp.json should define codexmate server');
+    assert(serverDef.command, '.mcp.json codexmate should have command');
+
+    const serverArgs = (serverDef.args || []).map((a) =>
+        a.replace('${CLAUDE_PROJECT_DIR}', projectRoot).replace('${CLAUDE_PROJECT_DIR:-.}', projectRoot)
+    );
+    const serverCmd = serverDef.command === 'node' ? node : serverDef.command;
+
+    const roRequests = [
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', clientInfo: { name: 'e2e-test' } } },
+        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
+    ];
+    const roInput = Buffer.concat(roRequests.map((r) => encodeFrame(r)));
+    const roResult = spawnSync(serverCmd, serverArgs, {
+        input: roInput,
+        encoding: 'buffer',
+        maxBuffer: 5 * 1024 * 1024,
+        cwd: projectRoot
+    });
+
+    assert(roResult.status === 0, `.mcp.json server should exit 0, got ${roResult.status}`);
+
+    const stdoutText = (roResult.stdout || Buffer.alloc(0)).toString('utf-8');
+    const stderrText = (roResult.stderr || Buffer.alloc(0)).toString('utf-8');
+    const nonFrameStdout = stdoutText.replace(/Content-Length:\s*\d+\r\n\r\n/g, '').replace(/\{[^]*?\}/g, '').trim();
+    assert(nonFrameStdout.length === 0 || /^[{}\[\]":\d\s,.\-_\w\r\n]*$/.test(nonFrameStdout.replace(/Content-Length:\s*\d+\r\n\r\n/g, '')), 'stdout should only contain MCP frames, no log pollution');
+
+    const roResponses = decodeFrames(Buffer.from(stdoutText, 'utf-8'));
+    const roById = new Map(roResponses.map((item) => [item.id, item]));
+
+    const initResult = roById.get(1).result || {};
+    assert(initResult.protocolVersion === '2025-11-25', `.mcp.json server should negotiate protocol version, got ${initResult.protocolVersion}`);
+
+    const roTools = (roById.get(2).result || {}).tools || [];
+    const roNames = new Set(roTools.map((t) => t.name));
+    assert(roNames.has('codexmate.memory.search'), '.mcp.json read-only should expose memory.search');
+    assert(roNames.has('codexmate.memory.list'), '.mcp.json read-only should expose memory.list');
+    assert(!roNames.has('codexmate.memory.save'), '.mcp.json read-only should NOT expose memory.save');
+    assert(!roNames.has('codexmate.memory.update'), '.mcp.json read-only should NOT expose memory.update');
+    assert(!roNames.has('codexmate.memory.delete'), '.mcp.json read-only should NOT expose memory.delete');
+
+    const e2eCodexmateDir = path.join(projectRoot, '.codexmate');
+    try { fs.rmSync(e2eCodexmateDir, { recursive: true, force: true }); } catch (_) {}
+
+    const writeRequests = [
+        { jsonrpc: '2.0', id: 10, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', id: 11, method: 'tools/call', params: { name: 'codexmate.memory.save', arguments: { summary: 'Config spawn test', content: 'Verifying .mcp.json spawn works end-to-end', tags: ['e2e', 'config'] } } },
+        { jsonrpc: '2.0', id: 12, method: 'tools/call', params: { name: 'codexmate.memory.search', arguments: { query: 'config spawn' } } },
+        { jsonrpc: '2.0', id: 13, method: 'tools/call', params: { name: 'codexmate.memory.list', arguments: {} } }
+    ];
+    const writeInput = Buffer.concat(writeRequests.map((r) => encodeFrame(r)));
+    const writeResult = spawnSync(serverCmd, [...serverArgs, '--allow-write'], {
+        input: writeInput,
+        encoding: 'buffer',
+        maxBuffer: 5 * 1024 * 1024,
+        cwd: projectRoot
+    });
+    assert(writeResult.status === 0, `.mcp.json write server should exit 0`);
+    const writeResponses = decodeFrames(Buffer.from((writeResult.stdout || Buffer.alloc(0)).toString('utf-8'), 'utf-8'));
+    const wById = new Map(writeResponses.map((item) => [item.id, item]));
+
+    const saved = ((wById.get(11).result || {}).structuredContent) || {};
+    assert(saved.success === true, '.mcp.json memory.save should succeed');
+    const savedId = (saved.memory || {}).id;
+
+    const searched = ((wById.get(12).result || {}).structuredContent) || {};
+    assert(searched.count === 1, '.mcp.json memory.search should find 1 match');
+
+    const listed = ((wById.get(13).result || {}).structuredContent) || {};
+    assert(listed.total === 1, '.mcp.json memory.list should show 1 entry');
+
+    const udRequests = [
+        { jsonrpc: '2.0', id: 20, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', id: 21, method: 'tools/call', params: { name: 'codexmate.memory.update', arguments: { id: savedId, summary: 'Updated via config spawn' } } },
+        { jsonrpc: '2.0', id: 22, method: 'tools/call', params: { name: 'codexmate.memory.delete', arguments: { id: savedId } } }
+    ];
+    const udInput = Buffer.concat(udRequests.map((r) => encodeFrame(r)));
+    const udResult = spawnSync(serverCmd, [...serverArgs, '--allow-write'], {
+        input: udInput,
+        encoding: 'buffer',
+        maxBuffer: 5 * 1024 * 1024,
+        cwd: projectRoot
+    });
+    assert(udResult.status === 0, '.mcp.json update/delete server should exit 0');
+    const udResponses = decodeFrames(Buffer.from((udResult.stdout || Buffer.alloc(0)).toString('utf-8'), 'utf-8'));
+    const udById = new Map(udResponses.map((item) => [item.id, item]));
+
+    const updated = ((udById.get(21).result || {}).structuredContent) || {};
+    assert(updated.success === true, '.mcp.json memory.update should succeed');
+    assert((updated.memory || {}).summary === 'Updated via config spawn', '.mcp.json memory.update should reflect new summary');
+
+    const deleted = ((udById.get(22).result || {}).structuredContent) || {};
+    assert(deleted.success === true, '.mcp.json memory.delete should succeed');
+
+    try { fs.rmSync(e2eCodexmateDir, { recursive: true, force: true }); } catch (_) {}
+}
+
+module.exports = { testMcp, testMcpFromConfig };

--- a/tests/e2e/test-mcp.js
+++ b/tests/e2e/test-mcp.js
@@ -174,6 +174,11 @@ module.exports = async function testMcp(ctx) {
     assert(toolNames.has('codexmate.workflow.get'), 'mcp read-only tools missing codexmate.workflow.get');
     assert(toolNames.has('codexmate.workflow.validate'), 'mcp read-only tools missing codexmate.workflow.validate');
     assert(toolNames.has('codexmate.workflow.run'), 'mcp read-only tools missing codexmate.workflow.run');
+    assert(toolNames.has('codexmate.memory.search'), 'mcp read-only tools missing codexmate.memory.search');
+    assert(toolNames.has('codexmate.memory.list'), 'mcp read-only tools missing codexmate.memory.list');
+    assert(!toolNames.has('codexmate.memory.save'), 'mcp read-only tools should not expose codexmate.memory.save');
+    assert(!toolNames.has('codexmate.memory.update'), 'mcp read-only tools should not expose codexmate.memory.update');
+    assert(!toolNames.has('codexmate.memory.delete'), 'mcp read-only tools should not expose codexmate.memory.delete');
 
     const sessionResource = readOnlyById.get(3).result || {};
     assert(Array.isArray(sessionResource.contents), 'mcp resources/read should return contents');
@@ -298,6 +303,9 @@ module.exports = async function testMcp(ctx) {
         })
     ].join('\n') + '\n', 'utf-8');
 
+    const e2eCodexmateDir = path.join(process.cwd(), '.codexmate');
+    try { fs.rmSync(e2eCodexmateDir, { recursive: true, force: true }); } catch (_) {}
+
     const writeEnabledRequests = [
         { jsonrpc: '2.0', id: 11, method: 'initialize', params: {} },
         { jsonrpc: '2.0', id: 12, method: 'tools/list', params: {} },
@@ -322,6 +330,76 @@ module.exports = async function testMcp(ctx) {
                 arguments: {
                     source: 'codex',
                     file: mcpDeleteSessionPath
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 15,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.save',
+                arguments: {
+                    summary: 'JWT refresh token race condition',
+                    content: 'Added mutex to refresh flow in src/auth/refresh.ts',
+                    tags: ['auth', 'jwt', 'bug-fix'],
+                    sourceSession: 'test-session-001'
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 16,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.save',
+                arguments: {
+                    summary: 'API rate limiting strategy',
+                    content: 'Use sliding window with Redis sorted sets',
+                    tags: ['api', 'performance']
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 17,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.search',
+                arguments: {
+                    query: 'jwt race'
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 18,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.list',
+                arguments: {}
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 19,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.update',
+                arguments: {
+                    id: 'mem_nonexistent_000000',
+                    summary: 'should fail'
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 20,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.delete',
+                arguments: {
+                    id: 'mem_nonexistent_000000'
                 }
             }
         }
@@ -380,4 +458,87 @@ module.exports = async function testMcp(ctx) {
         item.sessionId === mcpDeleteSessionId
     ));
     assert(!deleteTrashItem, 'mcp session.delete should not create a trash entry');
+
+    assert(writeToolNames.has('codexmate.memory.save'), 'mcp write mode should expose codexmate.memory.save');
+    assert(writeToolNames.has('codexmate.memory.update'), 'mcp write mode should expose codexmate.memory.update');
+    assert(writeToolNames.has('codexmate.memory.delete'), 'mcp write mode should expose codexmate.memory.delete');
+
+    const memSave1 = ((writeById.get(15).result || {}).structuredContent) || {};
+    assert(memSave1.success === true, 'mcp memory.save first entry should succeed');
+    assert(typeof (memSave1.memory || {}).id === 'string', 'mcp memory.save should return memory id');
+    assert((memSave1.memory || {}).summary === 'JWT refresh token race condition', 'mcp memory.save should return summary');
+    assert(JSON.stringify((memSave1.memory || {}).tags) === JSON.stringify(['auth', 'jwt', 'bug-fix']), 'mcp memory.save should return tags');
+
+    const memSave2 = ((writeById.get(16).result || {}).structuredContent) || {};
+    assert(memSave2.success === true, 'mcp memory.save second entry should succeed');
+
+    const memSearch = ((writeById.get(17).result || {}).structuredContent) || {};
+    assert(memSearch.count === 1, 'mcp memory.search should find one match');
+    assert((memSearch.memories || [])[0] && (memSearch.memories || [])[0].summary === 'JWT refresh token race condition', 'mcp memory.search should return matching entry');
+
+    const memList = ((writeById.get(18).result || {}).structuredContent) || {};
+    assert(memList.total === 2, 'mcp memory.list should return both entries');
+    assert(Array.isArray(memList.memories) && memList.memories.length === 2, 'mcp memory.list should include 2 items');
+
+    const memUpdateBad = ((writeById.get(19).result || {}).structuredContent) || {};
+    assert(typeof memUpdateBad.error === 'string' && memUpdateBad.error.includes('not found'), 'mcp memory.update should error on nonexistent id');
+
+    const memDeleteBad = ((writeById.get(20).result || {}).structuredContent) || {};
+    assert(typeof memDeleteBad.error === 'string' && memDeleteBad.error.includes('not found'), 'mcp memory.delete should error on nonexistent id');
+
+    const savedMemoryId = (memSave1.memory || {}).id;
+    const memoryUpdateDeleteRequests = [
+        { jsonrpc: '2.0', id: 21, method: 'initialize', params: {} },
+        {
+            jsonrpc: '2.0',
+            id: 22,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.update',
+                arguments: {
+                    id: savedMemoryId,
+                    summary: 'JWT refresh token race condition (fixed)',
+                    tags: ['auth', 'jwt', 'resolved']
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 23,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.delete',
+                arguments: {
+                    id: (memSave2.memory || {}).id
+                }
+            }
+        },
+        {
+            jsonrpc: '2.0',
+            id: 24,
+            method: 'tools/call',
+            params: {
+                name: 'codexmate.memory.search',
+                arguments: {
+                    query: 'api rate limiting'
+                }
+            }
+        }
+    ];
+    const memUpdateDeleteResponses = runMcpExchange(node, cliPath, {
+        ...env,
+        CODEXMATE_MCP_ALLOW_WRITE: '1'
+    }, [], memoryUpdateDeleteRequests);
+    const udById = new Map(memUpdateDeleteResponses.map((item) => [item.id, item]));
+
+    const memUpdated = ((udById.get(22).result || {}).structuredContent) || {};
+    assert(memUpdated.success === true, 'mcp memory.update should succeed');
+    assert((memUpdated.memory || {}).summary === 'JWT refresh token race condition (fixed)', 'mcp memory.update should reflect new summary');
+    assert(JSON.stringify((memUpdated.memory || {}).tags) === JSON.stringify(['auth', 'jwt', 'resolved']), 'mcp memory.update should reflect new tags');
+
+    const memDeleted = ((udById.get(23).result || {}).structuredContent) || {};
+    assert(memDeleted.success === true, 'mcp memory.delete should succeed');
+
+    const memSearchAfterDelete = ((udById.get(24).result || {}).structuredContent) || {};
+    assert(memSearchAfterDelete.count === 0, 'mcp memory.search should find nothing after delete');
 };

--- a/tests/e2e/test-mcp.js
+++ b/tests/e2e/test-mcp.js
@@ -546,22 +546,34 @@ async function testMcp(ctx) {
 async function testMcpFromConfig(ctx) {
     const { node, cliPath } = ctx;
     const projectRoot = path.resolve(__dirname, '..', '..');
-    const mcpConfigPath = path.join(projectRoot, '.mcp.json');
 
-    assert(fs.existsSync(mcpConfigPath), '.mcp.json should exist in project root');
-    const mcpConfig = JSON.parse(fs.readFileSync(mcpConfigPath, 'utf-8'));
+    const tmpConfigDir = require('os').mkdtempSync(path.join(require('os').tmpdir(), 'mcp-cfg-'));
+    const tmpConfigPath = path.join(tmpConfigDir, '.mcp.json');
+    const tmpProjectDir = require('os').mkdtempSync(path.join(require('os').tmpdir(), 'mcp-proj-'));
+
+    const config = {
+        mcpServers: {
+            codexmate: {
+                command: node,
+                args: [cliPath, 'mcp', 'serve', '--project-root', tmpProjectDir]
+            }
+        }
+    };
+    fs.writeFileSync(tmpConfigPath, JSON.stringify(config, null, 2));
+
+    const mcpConfig = JSON.parse(fs.readFileSync(tmpConfigPath, 'utf-8'));
     const serverDef = (mcpConfig.mcpServers || {}).codexmate;
     assert(serverDef, '.mcp.json should define codexmate server');
     assert(serverDef.command, '.mcp.json codexmate should have command');
 
-    const serverArgs = (serverDef.args || []).map((a) =>
-        a.replace('${CLAUDE_PROJECT_DIR}', projectRoot).replace('${CLAUDE_PROJECT_DIR:-.}', projectRoot)
-    );
-    const serverCmd = serverDef.command === 'node' ? node : serverDef.command;
+    const serverCmd = serverDef.command;
+    const serverArgs = serverDef.args || [];
 
     const roRequests = [
-        { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', clientInfo: { name: 'e2e-test' } } },
-        { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-11-25', capabilities: { roots: {} }, clientInfo: { name: 'e2e-test', version: '1.0' } } },
+        { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
+        { jsonrpc: '2.0', id: 2, method: 'ping', params: {} },
+        { jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} }
     ];
     const roInput = Buffer.concat(roRequests.map((r) => encodeFrame(r)));
     const roResult = spawnSync(serverCmd, serverArgs, {
@@ -575,16 +587,20 @@ async function testMcpFromConfig(ctx) {
 
     const stdoutText = (roResult.stdout || Buffer.alloc(0)).toString('utf-8');
     const stderrText = (roResult.stderr || Buffer.alloc(0)).toString('utf-8');
-    const nonFrameStdout = stdoutText.replace(/Content-Length:\s*\d+\r\n\r\n/g, '').replace(/\{[^]*?\}/g, '').trim();
-    assert(nonFrameStdout.length === 0 || /^[{}\[\]":\d\s,.\-_\w\r\n]*$/.test(nonFrameStdout.replace(/Content-Length:\s*\d+\r\n\r\n/g, '')), 'stdout should only contain MCP frames, no log pollution');
+    assert(stdoutText.indexOf('Content-Length:') === 0, 'stdout should start with MCP frame header');
 
     const roResponses = decodeFrames(Buffer.from(stdoutText, 'utf-8'));
     const roById = new Map(roResponses.map((item) => [item.id, item]));
 
+    assert(roById.has(1), 'initialize response missing');
     const initResult = roById.get(1).result || {};
-    assert(initResult.protocolVersion === '2025-11-25', `.mcp.json server should negotiate protocol version, got ${initResult.protocolVersion}`);
+    assert(initResult.protocolVersion === '2025-11-25', `protocol negotiation failed, got ${initResult.protocolVersion}`);
+    assert(initResult.serverInfo && initResult.serverInfo.name, 'serverInfo.name should be present');
 
-    const roTools = (roById.get(2).result || {}).tools || [];
+    assert(roById.has(2), 'ping response missing');
+    assert(roById.has(3), 'tools/list response missing');
+
+    const roTools = (roById.get(3).result || {}).tools || [];
     const roNames = new Set(roTools.map((t) => t.name));
     assert(roNames.has('codexmate.memory.search'), '.mcp.json read-only should expose memory.search');
     assert(roNames.has('codexmate.memory.list'), '.mcp.json read-only should expose memory.list');
@@ -592,11 +608,11 @@ async function testMcpFromConfig(ctx) {
     assert(!roNames.has('codexmate.memory.update'), '.mcp.json read-only should NOT expose memory.update');
     assert(!roNames.has('codexmate.memory.delete'), '.mcp.json read-only should NOT expose memory.delete');
 
-    const e2eCodexmateDir = path.join(projectRoot, '.codexmate');
-    try { fs.rmSync(e2eCodexmateDir, { recursive: true, force: true }); } catch (_) {}
+    try { fs.rmSync(path.join(tmpProjectDir, '.codexmate'), { recursive: true, force: true }); } catch (_) {}
 
     const writeRequests = [
         { jsonrpc: '2.0', id: 10, method: 'initialize', params: {} },
+        { jsonrpc: '2.0', method: 'notifications/initialized', params: {} },
         { jsonrpc: '2.0', id: 11, method: 'tools/call', params: { name: 'codexmate.memory.save', arguments: { summary: 'Config spawn test', content: 'Verifying .mcp.json spawn works end-to-end', tags: ['e2e', 'config'] } } },
         { jsonrpc: '2.0', id: 12, method: 'tools/call', params: { name: 'codexmate.memory.search', arguments: { query: 'config spawn' } } },
         { jsonrpc: '2.0', id: 13, method: 'tools/call', params: { name: 'codexmate.memory.list', arguments: {} } }
@@ -608,7 +624,7 @@ async function testMcpFromConfig(ctx) {
         maxBuffer: 5 * 1024 * 1024,
         cwd: projectRoot
     });
-    assert(writeResult.status === 0, `.mcp.json write server should exit 0`);
+    assert(writeResult.status === 0, '.mcp.json write server should exit 0');
     const writeResponses = decodeFrames(Buffer.from((writeResult.stdout || Buffer.alloc(0)).toString('utf-8'), 'utf-8'));
     const wById = new Map(writeResponses.map((item) => [item.id, item]));
 
@@ -621,6 +637,9 @@ async function testMcpFromConfig(ctx) {
 
     const listed = ((wById.get(13).result || {}).structuredContent) || {};
     assert(listed.total === 1, '.mcp.json memory.list should show 1 entry');
+
+    const memFile = path.join(tmpProjectDir, '.codexmate', 'memories.json');
+    assert(fs.existsSync(memFile), 'memories.json should be created in --project-root');
 
     const udRequests = [
         { jsonrpc: '2.0', id: 20, method: 'initialize', params: {} },
@@ -645,7 +664,8 @@ async function testMcpFromConfig(ctx) {
     const deleted = ((udById.get(22).result || {}).structuredContent) || {};
     assert(deleted.success === true, '.mcp.json memory.delete should succeed');
 
-    try { fs.rmSync(e2eCodexmateDir, { recursive: true, force: true }); } catch (_) {}
+    try { fs.rmSync(tmpConfigDir, { recursive: true, force: true }); } catch (_) {}
+    try { fs.rmSync(tmpProjectDir, { recursive: true, force: true }); } catch (_) {}
 }
 
 module.exports = { testMcp, testMcpFromConfig };

--- a/tests/unit/memory-store.test.mjs
+++ b/tests/unit/memory-store.test.mjs
@@ -1,0 +1,275 @@
+import assert from 'assert';
+import test from 'node:test';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
+const {
+    resolveMemoryFilePath,
+    loadMemories,
+    saveMemory,
+    searchMemories,
+    listMemories,
+    updateMemory,
+    deleteMemory
+} = require(path.join(__dirname, '..', '..', 'lib', 'memory-store.js'));
+
+function makeTmpDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'memory-store-test-'));
+}
+
+function cleanupTmpDir(dir) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+}
+
+test('resolveMemoryFilePath returns project-level path', () => {
+    const result = resolveMemoryFilePath('/tmp/myproject');
+    assert.strictEqual(result, path.join('/tmp/myproject', '.codexmate', 'memories.json'));
+});
+
+test('loadMemories returns empty array for missing file', () => {
+    const dir = makeTmpDir();
+    try {
+        const result = loadMemories(dir);
+        assert.deepStrictEqual(result, []);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('saveMemory creates file and returns entry with id/timestamps', () => {
+    const dir = makeTmpDir();
+    try {
+        const result = saveMemory(dir, { summary: 'test summary', content: 'test content', tags: ['a', 'b'] });
+        assert.strictEqual(result.success, true);
+        assert.ok(result.memory.id.startsWith('mem_'));
+        assert.strictEqual(result.memory.summary, 'test summary');
+        assert.strictEqual(result.memory.content, 'test content');
+        assert.deepStrictEqual(result.memory.tags, ['a', 'b']);
+        assert.ok(result.memory.createdAt);
+        assert.ok(result.memory.updatedAt);
+
+        const file = resolveMemoryFilePath(dir);
+        assert.ok(fs.existsSync(file));
+        const loaded = JSON.parse(fs.readFileSync(file, 'utf-8'));
+        assert.strictEqual(loaded.length, 1);
+        assert.strictEqual(loaded[0].id, result.memory.id);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('saveMemory rejects missing summary', () => {
+    const dir = makeTmpDir();
+    try {
+        const result = saveMemory(dir, { content: 'only content' });
+        assert.ok(result.error);
+        assert.ok(result.error.includes('summary'));
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('saveMemory rejects missing content', () => {
+    const dir = makeTmpDir();
+    try {
+        const result = saveMemory(dir, { summary: 'only summary' });
+        assert.ok(result.error);
+        assert.ok(result.error.includes('content'));
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('searchMemories matches case-insensitive substring', () => {
+    const dir = makeTmpDir();
+    try {
+        saveMemory(dir, { summary: 'JWT Auth Bug', content: 'fixed race condition', tags: ['auth'] });
+        saveMemory(dir, { summary: 'UI Layout', content: 'flexbox changes', tags: ['ui'] });
+
+        const r1 = searchMemories(dir, { query: 'jwt' });
+        assert.strictEqual(r1.count, 1);
+        assert.strictEqual(r1.memories[0].summary, 'JWT Auth Bug');
+
+        const r2 = searchMemories(dir, { query: 'flexbox' });
+        assert.strictEqual(r2.count, 1);
+        assert.strictEqual(r2.memories[0].summary, 'UI Layout');
+
+        const r3 = searchMemories(dir, { query: 'nonexistent' });
+        assert.strictEqual(r3.count, 0);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('searchMemories supports multi-word AND logic', () => {
+    const dir = makeTmpDir();
+    try {
+        saveMemory(dir, { summary: 'JWT refresh token fix', content: 'added mutex', tags: [] });
+        saveMemory(dir, { summary: 'JWT auth setup', content: 'new provider config', tags: [] });
+
+        const r = searchMemories(dir, { query: 'jwt refresh' });
+        assert.strictEqual(r.count, 1);
+        assert.strictEqual(r.memories[0].summary, 'JWT refresh token fix');
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('searchMemories supports tag filter', () => {
+    const dir = makeTmpDir();
+    try {
+        saveMemory(dir, { summary: 'entry one', content: 'content', tags: ['auth', 'backend'] });
+        saveMemory(dir, { summary: 'entry two', content: 'content', tags: ['ui'] });
+
+        const r = searchMemories(dir, { query: 'entry', tags: ['auth'] });
+        assert.strictEqual(r.count, 1);
+        assert.strictEqual(r.memories[0].summary, 'entry one');
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('searchMemories requires query', () => {
+    const dir = makeTmpDir();
+    try {
+        const r = searchMemories(dir, {});
+        assert.ok(r.error);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('listMemories returns all entries without filters', () => {
+    const dir = makeTmpDir();
+    try {
+        saveMemory(dir, { summary: 'a', content: 'c1', tags: [] });
+        saveMemory(dir, { summary: 'b', content: 'c2', tags: [] });
+        saveMemory(dir, { summary: 'c', content: 'c3', tags: [] });
+
+        const r = listMemories(dir, {});
+        assert.strictEqual(r.total, 3);
+        assert.strictEqual(r.memories.length, 3);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('listMemories supports pagination', () => {
+    const dir = makeTmpDir();
+    try {
+        for (let i = 0; i < 5; i++) {
+            saveMemory(dir, { summary: `entry ${i}`, content: `content ${i}`, tags: [] });
+        }
+
+        const r1 = listMemories(dir, { limit: 2, offset: 0 });
+        assert.strictEqual(r1.total, 5);
+        assert.strictEqual(r1.memories.length, 2);
+
+        const r2 = listMemories(dir, { limit: 2, offset: 4 });
+        assert.strictEqual(r2.total, 5);
+        assert.strictEqual(r2.memories.length, 1);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('listMemories supports tag filter', () => {
+    const dir = makeTmpDir();
+    try {
+        saveMemory(dir, { summary: 'a', content: 'c', tags: ['auth'] });
+        saveMemory(dir, { summary: 'b', content: 'c', tags: ['ui'] });
+        saveMemory(dir, { summary: 'c', content: 'c', tags: ['auth', 'ui'] });
+
+        const r = listMemories(dir, { tags: ['auth'] });
+        assert.strictEqual(r.total, 2);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('updateMemory merges fields and updates updatedAt', () => {
+    const dir = makeTmpDir();
+    try {
+        const saved = saveMemory(dir, { summary: 'original', content: 'original content', tags: ['a'] });
+        const id = saved.memory.id;
+        const originalUpdatedAt = saved.memory.updatedAt;
+
+        const r = updateMemory(dir, id, { summary: 'updated', tags: ['b', 'c'] });
+        assert.strictEqual(r.success, true);
+        assert.strictEqual(r.memory.summary, 'updated');
+        assert.strictEqual(r.memory.content, 'original content');
+        assert.deepStrictEqual(r.memory.tags, ['b', 'c']);
+        assert.ok(r.memory.updatedAt >= originalUpdatedAt);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('updateMemory returns error for nonexistent id', () => {
+    const dir = makeTmpDir();
+    try {
+        const r = updateMemory(dir, 'mem_nonexistent_000000', { summary: 'x' });
+        assert.ok(r.error);
+        assert.ok(r.error.includes('not found'));
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('deleteMemory removes entry and returns true', () => {
+    const dir = makeTmpDir();
+    try {
+        const saved = saveMemory(dir, { summary: 'to delete', content: 'content', tags: [] });
+        const id = saved.memory.id;
+
+        const r = deleteMemory(dir, id);
+        assert.strictEqual(r.success, true);
+        assert.strictEqual(r.id, id);
+
+        const remaining = loadMemories(dir);
+        assert.strictEqual(remaining.length, 0);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('deleteMemory returns error for nonexistent id', () => {
+    const dir = makeTmpDir();
+    try {
+        const r = deleteMemory(dir, 'mem_nonexistent_000000');
+        assert.ok(r.error);
+        assert.ok(r.error.includes('not found'));
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('saveMemory handles empty tags gracefully', () => {
+    const dir = makeTmpDir();
+    try {
+        const r = saveMemory(dir, { summary: 'no tags', content: 'content' });
+        assert.strictEqual(r.success, true);
+        assert.deepStrictEqual(r.memory.tags, []);
+        assert.strictEqual(r.memory.sourceSession, '');
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});
+
+test('searchMemories searches in tags', () => {
+    const dir = makeTmpDir();
+    try {
+        saveMemory(dir, { summary: 'entry', content: 'content', tags: ['jsonwebtoken'] });
+
+        const r = searchMemories(dir, { query: 'jsonwebtoken' });
+        assert.strictEqual(r.count, 1);
+    } finally {
+        cleanupTmpDir(dir);
+    }
+});

--- a/web-ui/styles/modals-core.css
+++ b/web-ui/styles/modals-core.css
@@ -546,6 +546,7 @@
 
 .prompts-editor-toolbar .form-hint {
     margin-top: 0;
+    font-size: 9px;
 }
 
 .prompts-editor-actions {


### PR DESCRIPTION
## Summary

- Add 5 MCP tools (save/search/list/update/delete) for cross-session memory, storing entries in `<project>/.codexmate/memories.json`
- Add `codexmate mcp doctor` for preflight diagnostics
- Fix MCP server: respond to initialize without id (Claude Code sends this), protocol version negotiation (2024-11-05 through 2025-11-25)
- Startup stderr logging and uncaught exception handlers for diagnostics

## Prerequisites

**Source checkout requires `npm install` before MCP server can start.**

```bash
cd /path/to/codexmate
npm install
node cli.js mcp doctor   # verify all checks pass
```

## MCP Configuration (Claude Code / Termux)

Use `.mcp.example.json` as template. Copy to `.mcp.json` and fill in your absolute paths:

```json
{
  "mcpServers": {
    "codexmate": {
      "command": "/absolute/path/to/node",
      "args": ["/absolute/path/to/codexmate/cli.js", "mcp", "serve", "--project-root", "/your/project"]
    }
  }
}
```

Default is **read-only**. To enable write tools, add `"--allow-write"` to args or set `CODEXMATE_MCP_ALLOW_WRITE=1`.

## Known Limitation: Termux + `claude mcp list` Health Check

`claude mcp list` health check consistently shows "Failed to connect" on Termux. Debug logging confirms the MCP server process starts correctly but Claude Code's health check does not deliver stdin data to the spawned process. This is a Claude Code client limitation on Termux, not a server issue.

**Workaround**: The server works correctly when used in actual Claude Code sessions. To verify:
1. Run `node cli.js mcp doctor` to confirm all checks pass
2. Run the MCP protocol smoke test (see Verification below)
3. Start a new `claude` session and use MCP tools directly

## Verification

```bash
# 1. Doctor check
node cli.js mcp doctor

# 2. Unit tests
node --test tests/unit/memory-store.test.mjs

# 3. Lint
node tools/dev/lint.js

# 4. MCP protocol smoke (initialize without id, like Claude Code)
node -e "
const {spawnSync}=require('child_process');
const body=JSON.stringify({method:'initialize',params:{protocolVersion:'2025-11-25',capabilities:{roots:{}},clientInfo:{name:'claude-code'}}});
const frame='Content-Length: '+Buffer.byteLength(body)+'\r\n\r\n'+body;
const r=spawnSync('node',['cli.js','mcp','serve','--project-root','.'],{input:Buffer.from(frame),encoding:'buffer'});
const out=r.stdout.toString();const h=out.indexOf('\r\n\r\n');
console.log(JSON.parse(out.slice(h+4)).result.protocolVersion);
"
# Expected: 2025-11-25

# 5. Write-mode smoke
node cli.js mcp serve --allow-write --project-root /tmp/test-mem
# Send memory.save + memory.search via MCP framed messages
# Verify /tmp/test-mem/.codexmate/memories.json is created
```

## Technical Changes

| File | Change |
|---|---|
| `lib/memory-store.js` | CRUD + keyword search module |
| `cli.js` | 5 pushTool + --project-root + mcp doctor + startup log |
| `lib/mcp-stdio.js` | initialize without id, protocol negotiation |
| `.mcp.example.json` | Config template |
| `.gitignore` | Exclude .mcp.json |
| `tests/e2e/test-mcp.js` | Full MCP handshake E2E |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-root–scoped MCP memory persistence with tools to save, search, list, update, and delete memories.
  * Added `--project-root` and `CODEXMATE_PROJECT_ROOT` to control the memory directory; updated MCP help and `mcp doctor` to verify write access.
* **Bug Fixes**
  * Improved JSON-RPC/MCP initialization and protocol version negotiation, plus more reliable message handling.
* **Style**
  * Reduced prompt editor toolbar hint font sizing.
* **Tests**
  * Added unit tests for the memory store and expanded MCP E2E coverage for read-only vs write flows.
* **Chores**
  * Added `.mcp.example.json` and updated `.gitignore` to ignore `.mcp.json`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->