### PR TITLE
fix: allow global CLAUDE.md diff preview

### DIFF
--- a/cli/agents-files.js
+++ b/cli/agents-files.js
@@ -244,9 +244,6 @@ function createAgentsFileController(deps = {}) {
         if (context === 'claude-md') {
             readResult = readClaudeMdFile({ metaOnly });
         } else if (context === 'claude-project') {
-            if (!params.baseDir || !String(params.baseDir).trim()) {
-                return { error: 'project path is required for claude-project context' };
-            }
             readResult = readClaudeMdFile({ ...params, metaOnly });
         } else if (context === 'openclaw') {
             readResult = readOpenclawAgentsFile({ metaOnly });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexmate",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexmate",
-      "version": "0.0.50",
+      "version": "0.0.51",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexmate",
-  "version": "0.0.50",
+  "version": "0.0.51",
   "description": "Codex/Claude Code/OpenClaw 配置、会话与任务编排 CLI + Web 工具",
   "main": "cli.js",
   "bin": {

--- a/tests/e2e/test-config.js
+++ b/tests/e2e/test-config.js
@@ -12,7 +12,8 @@ module.exports = async function testConfig(ctx) {
         mockProviderUrl,
         noModelsUrl,
         htmlModelsUrl,
-        authFailUrl
+        authFailUrl,
+        claudeProjectDir
     } = ctx;
 
     // ========== Status API Tests ==========
@@ -297,6 +298,7 @@ preferred_auth_method = "shadow-key"
 
     const apiPathsClaude = await api('list-session-paths', { source: 'claude', limit: 10, forceRefresh: true });
     assert(Array.isArray(apiPathsClaude.paths), 'api session paths(claude) missing');
+    assert(apiPathsClaude.paths.includes(claudeProjectDir), 'api session paths(claude) missing project path');
 
     const apiPathsAll = await api('list-session-paths', { source: 'all', limit: 10, forceRefresh: true });
     assert(Array.isArray(apiPathsAll.paths), 'api session paths(all) missing');

--- a/tests/e2e/test-sessions.js
+++ b/tests/e2e/test-sessions.js
@@ -602,6 +602,7 @@ module.exports = async function testSessions(ctx) {
 
     const pathsClaude = await api('list-session-paths', { source: 'claude', limit: 100, forceRefresh: true });
     assert(Array.isArray(pathsClaude.paths), 'list-session-paths(claude) missing');
+    assert(pathsClaude.paths.includes(ctx.claudeProjectDir), 'list-session-paths(claude) missing project path');
 
     const pathsAll = await api('list-session-paths', { source: 'all', limit: 100, forceRefresh: true });
     assert(Array.isArray(pathsAll.paths), 'list-session-paths(all) missing');

--- a/tests/e2e/test-setup.js
+++ b/tests/e2e/test-setup.js
@@ -230,6 +230,7 @@ module.exports = async function testSetup(ctx) {
         lateKeywordSessionId,
         lateKeywordSessionPath,
         lateKeywordMessage,
+        claudeProjectDir,
         claudeSessionId,
         claudeSessionPath,
         geminiSessionId,

--- a/tests/unit/agents-files-project.test.mjs
+++ b/tests/unit/agents-files-project.test.mjs
@@ -210,13 +210,16 @@ test('buildAgentsDiff with claude-project context dispatches correctly', () => {
     assert.strictEqual(result.exists, true);
 });
 
-test('buildAgentsDiff with claude-project but missing baseDir returns error', () => {
-    const { ctrl } = createTestController();
+test('buildAgentsDiff with claude-project but missing baseDir previews global CLAUDE.md', () => {
+    const { tmpDir, ctrl } = createTestController();
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), 'global old', 'utf-8');
     const result = ctrl.buildAgentsDiff({
         context: 'claude-project',
-        content: 'test',
+        content: 'global new',
         lineEnding: '\n'
     });
-    assert.ok(result.error);
-    assert.match(result.error, /project path is required/);
+    assert.strictEqual(result.error, undefined);
+    assert.strictEqual(result.context, 'claude-project');
+    assert.strictEqual(result.path, path.join(tmpDir, 'CLAUDE.md'));
+    assert.strictEqual(result.exists, true);
 });

--- a/tests/unit/agents-modal-guards.test.mjs
+++ b/tests/unit/agents-modal-guards.test.mjs
@@ -580,6 +580,96 @@ test('applyAgentsContent rejects invalid workspace filenames before save api', a
     }]);
 });
 
+test('prepareAgentsDiff supports global CLAUDE.md from claude-project tab without baseDir', async () => {
+    const previewCalls = [];
+    const methods = createAgentsMethods({
+        api: async () => ({ success: true }),
+        apiWithMeta: async (action, params) => {
+            previewCalls.push({ action, params });
+            return {
+                diff: {
+                    lines: [{ type: 'add', value: 'after' }],
+                    stats: { added: 1, removed: 0, unchanged: 0 },
+                    hasChanges: true
+                }
+            };
+        }
+    });
+    const context = {
+        ...methods,
+        agentsContext: 'claude-project',
+        projectClaudeMdPath: '',
+        agentsContent: 'after',
+        agentsOriginalContent: 'before',
+        agentsLineEnding: '\n'
+    };
+
+    await methods.prepareAgentsDiff.call(context);
+
+    assert.deepStrictEqual(previewCalls, [{
+        action: 'preview-agents-diff',
+        params: {
+            content: 'after',
+            lineEnding: '\n',
+            context: 'claude-project',
+            baseContent: 'before'
+        }
+    }]);
+    assert.strictEqual(context.agentsDiffError, '');
+    assert.strictEqual(context.agentsDiffHasChangesValue, true);
+});
+
+test('applyAgentsContent saves global CLAUDE.md from claude-project tab without baseDir', async () => {
+    const apiCalls = [];
+    const methods = createAgentsMethods({
+        api: async (action, params) => {
+            apiCalls.push({ action, params });
+            return { success: true };
+        }
+    });
+    const context = {
+        ...createI18nMethods(),
+        ...methods,
+        agentsContext: 'claude-project',
+        projectClaudeMdPath: '',
+        agentsDiffVisible: true,
+        agentsDiffLoading: false,
+        agentsDiffError: '',
+        agentsDiffHasChanges: true,
+        agentsDiffHasChangesValue: true,
+        agentsDiffFingerprint: 'same',
+        agentsContent: 'after',
+        agentsOriginalContent: 'before',
+        agentsLineEnding: '\n',
+        mainTab: 'sessions',
+        shownMessages: [],
+        showMessage(message, type) {
+            this.shownMessages.push({ message, type });
+        },
+        buildAgentsDiffFingerprint() {
+            return 'same';
+        },
+        closeAgentsModal(options) {
+            this.closeOptions = options;
+        }
+    };
+
+    await methods.applyAgentsContent.call(context);
+
+    assert.deepStrictEqual(apiCalls, [{
+        action: 'apply-claude-md-file',
+        params: {
+            content: 'after',
+            lineEnding: '\n'
+        }
+    }]);
+    assert.deepStrictEqual(context.shownMessages, [{
+        message: '项目 CLAUDE.md 已保存',
+        type: 'success'
+    }]);
+    assert.deepStrictEqual(context.closeOptions, { force: true });
+});
+
 test('applyAgentsContent ignores duplicate save attempts while a save is already running', async () => {
     const resolvers = [];
     const apiCalls = [];

--- a/tests/unit/agents-modal-guards.test.mjs
+++ b/tests/unit/agents-modal-guards.test.mjs
@@ -619,6 +619,69 @@ test('prepareAgentsDiff supports global CLAUDE.md from claude-project tab withou
     assert.strictEqual(context.agentsDiffHasChangesValue, true);
 });
 
+test('loadPromptsContent auto-loads project path options for claude-project tab', async () => {
+    const apiCalls = [];
+    let pathLoadCalls = 0;
+    const methods = createAgentsMethods({
+        api: async (action, params) => {
+            apiCalls.push({ action, params });
+            return {
+                content: 'global claude',
+                path: '/home/user/.claude/CLAUDE.md',
+                exists: true,
+                lineEnding: '\n'
+            };
+        }
+    });
+    const context = {
+        ...methods,
+        promptsSubTab: 'claude-project',
+        mainTab: 'prompts',
+        projectClaudeMdPath: '',
+        projectPathOptions: [],
+        projectPathOptionsLoading: false,
+        resetAgentsDiffState() {},
+        showMessage() {},
+        loadProjectPathOptions() {
+            pathLoadCalls += 1;
+        }
+    };
+
+    await methods.loadPromptsContent.call(context);
+
+    assert.strictEqual(pathLoadCalls, 1);
+    assert.deepStrictEqual(apiCalls, [{
+        action: 'get-claude-md-file',
+        params: {}
+    }]);
+    assert.strictEqual(context.agentsContent, 'global claude');
+    assert.strictEqual(context.agentsContext, 'claude-project');
+});
+
+test('loadPromptsContent does not duplicate project path loading while already loading', async () => {
+    let pathLoadCalls = 0;
+    const methods = createAgentsMethods({
+        api: async () => ({ content: '', path: '', exists: false, lineEnding: '\n' })
+    });
+    const context = {
+        ...methods,
+        promptsSubTab: 'claude-project',
+        mainTab: 'prompts',
+        projectClaudeMdPath: '',
+        projectPathOptions: [],
+        projectPathOptionsLoading: true,
+        resetAgentsDiffState() {},
+        showMessage() {},
+        loadProjectPathOptions() {
+            pathLoadCalls += 1;
+        }
+    };
+
+    await methods.loadPromptsContent.call(context);
+
+    assert.strictEqual(pathLoadCalls, 0);
+});
+
 test('applyAgentsContent saves global CLAUDE.md from claude-project tab without baseDir', async () => {
     const apiCalls = [];
     const methods = createAgentsMethods({

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -752,6 +752,9 @@ document.addEventListener('DOMContentLoaded', () => {
         watch: {
             mainTab(newTab) {
                 if (newTab === 'prompts' && typeof this.loadPromptsContent === 'function') {
+                    if (this.promptsSubTab === 'claude-project' && !this.projectPathOptions.length && !this.projectPathOptionsLoading && typeof this.loadProjectPathOptions === 'function') {
+                        this.loadProjectPathOptions();
+                    }
                     this.loadPromptsContent();
                 }
             },

--- a/web-ui/modules/app.methods.agents.mjs
+++ b/web-ui/modules/app.methods.agents.mjs
@@ -727,6 +727,9 @@ export function createAgentsMethods(options = {}) {
                 const rpcParams = {};
                 if (subTab === 'claude-project') {
                     action = 'get-claude-md-file';
+                    if (!this.projectPathOptions.length && !this.projectPathOptionsLoading && typeof this.loadProjectPathOptions === 'function') {
+                        this.loadProjectPathOptions();
+                    }
                     const projectPath = (this.projectClaudeMdPath || '').trim();
                     if (projectPath) {
                         rpcParams.baseDir = projectPath;


### PR DESCRIPTION
## Summary
- allow `claude-project` diff preview to fall back to global `~/.claude/CLAUDE.md` when no project path is selected
- keep project-path previews unchanged when `baseDir` is provided
- add backend and UI regression tests for global CLAUDE.md preview/save without `baseDir`

## Testing
- `npm run test:unit` (658 unit tests passed; existing `search_sessions.py --limit -1` usage noise printed after the runner but exit code was 0)
- `npm run lint` (220 files passed)
- `npm run test:e2e` (exit code 0)
- `npm test` (unit + e2e passed; same existing `search_sessions.py --limit -1` usage noise, exit code 0)
- `npm run test:ci` (install + lint + unit + e2e passed; same existing usage noise, exit code 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using a global `CLAUDE.md` in the agents modal when no project path is provided, including previewing and saving changes.
* **Improvements**
  * The CLAUDE project prompts tab now loads required project path options on demand (only when needed) before fetching `CLAUDE.md`.
* **Bug Fixes**
  * Adjusted `claude-project` diff behavior to avoid incorrectly requiring a project path.
* **Tests**
  * Updated unit and end-to-end coverage to reflect the global `CLAUDE.md` flow and `claudeProjectDir` session paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->