### PR TITLE
feat(ui): add timeline style toggle and refine session browser

### DIFF
--- a/tests/unit/session-tab-switch-performance.test.mjs
+++ b/tests/unit/session-tab-switch-performance.test.mjs
@@ -592,7 +592,7 @@ test('session template removes timeline switch button and binds refs by timeline
     assert.doesNotMatch(template, /@click="toggleSessionTimeline"/);
     assert.doesNotMatch(template, /开启时间轴|关闭时间轴/);
     assert.match(template, /:ref="getSessionMessageRefBinder\(getRecordRenderKey\(msg,\s*idx\)\)"/);
-    assert.match(template, /<aside v-if="sessionPreviewRenderEnabled && sessionTimelineNodes.length" class="session-timeline"/);
+    assert.match(template, /:class="(\['session-timeline', 'session-timeline-' \+ sessionTimelineStyle\]|session-timeline-\$\{sessionTimelineStyle\})"/);
 });
 
 test('loadActiveSessionDetail primes visible messages even when timeline is disabled', async () => {

--- a/tests/unit/web-ui-behavior-parity.test.mjs
+++ b/tests/unit/web-ui-behavior-parity.test.mjs
@@ -515,7 +515,8 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'opencodeApplyToCoreAgents',
         'opencodeAutoCompact',
         'opencodeMaxTokens',
-        'opencodeReasoningEffort'
+        'opencodeReasoningEffort',
+        'sessionTimelineStyle'
     );
     if (parityAgainstHead) {
         const allowedExtraKeySet = new Set(allowedExtraCurrentKeys);
@@ -583,6 +584,8 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'selectSessionsUsageDay',
         'clearSessionsUsageDay',
         'setSessionTrashEnabled',
+        'setSessionTimelineStyle',
+        'normalizeSessionTimelineStyle',
         'onSettingsTabKeydown',
         'setShareCommandPrefix',
         'setSessionListRef',
@@ -842,7 +845,8 @@ test('captured bundled app skeleton only exposes expected data key drift versus 
         'providersHealthSummary',
         'providersHealthTone',
         'sessionContextUtilization',
-        'isLocalProviderDisabled'
+        'isLocalProviderDisabled',
+        'sessionTimelineProgressPercent'
     ];
     const allowedMissingCurrentComputedKeys = [
         'hasLocalAndProxy',

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -231,6 +231,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 sessionTimelineLastAnchorY: 0,
                 sessionTimelineLastDirection: 0,
                 sessionTimelineEnabled: true,
+                sessionTimelineStyle: 'dots',
                 sessionMessageRefMap: Object.create(null),
                 sessionMessageRefBinderMap: Object.create(null),
                 sessionPreviewScrollEl: null,
@@ -576,6 +577,10 @@ document.addEventListener('DOMContentLoaded', () => {
             this.shareCommandPrefix = this.normalizeShareCommandPrefix(localStorage.getItem('codexmateShareCommandPrefix'));
             this.sessionTrashEnabled = this.normalizeSessionTrashEnabled(localStorage.getItem('codexmateSessionTrashEnabled'));
             this.sessionTrashRetentionDays = this.normalizeSessionTrashRetentionDays(localStorage.getItem('codexmateSessionTrashRetentionDays'));
+            try {
+                var savedTimelineStyle = localStorage.getItem('codexmateSessionTimelineStyle');
+                this.sessionTimelineStyle = savedTimelineStyle === 'bar' ? 'bar' : 'dots';
+            } catch (_) {}
             this.configTemplateDiffConfirmEnabled = loadConfigTemplateDiffConfirmEnabledFromStorage(localStorage);
             try {
                 var savedProjectPath = localStorage.getItem('codexmate_project_claude_md_path');

--- a/web-ui/modules/app.computed.session.mjs
+++ b/web-ui/modules/app.computed.session.mjs
@@ -261,6 +261,12 @@ export function createSessionComputed() {
             const matched = nodes.find(node => node.key === this.sessionTimelineActiveKey);
             return matched ? matched.title : '';
         },
+        sessionTimelineProgressPercent() {
+            if (!this.sessionTimelineActiveKey || !this.sessionTimelineNodes.length) return 0;
+            const index = this.sessionTimelineNodes.findIndex(node => node.key === this.sessionTimelineActiveKey);
+            if (index < 0) return 0;
+            return Math.round(((index + 1) / this.sessionTimelineNodes.length) * 100);
+        },
         sessionQueryPlaceholder() {
             if (this.isSessionQueryEnabled) {
                 return typeof this.t === 'function'

--- a/web-ui/modules/app.methods.session-actions.mjs
+++ b/web-ui/modules/app.methods.session-actions.mjs
@@ -265,6 +265,12 @@ export function createSessionActionMethods(options = {}) {
             return true;
         },
 
+        normalizeSessionTimelineStyle(value) {
+            const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+            if (normalized === 'bar') return 'bar';
+            return 'dots';
+        },
+
         normalizeConfigTemplateDiffConfirmEnabled(value) {
             return normalizeConfigTemplateDiffConfirmEnabled(value);
         },
@@ -274,6 +280,14 @@ export function createSessionActionMethods(options = {}) {
             this.sessionTrashEnabled = enabled;
             try {
                 localStorage.setItem('codexmateSessionTrashEnabled', enabled ? 'true' : 'false');
+            } catch (_) {}
+        },
+
+        setSessionTimelineStyle(style) {
+            const normalized = style === 'bar' ? 'bar' : 'dots';
+            this.sessionTimelineStyle = normalized;
+            try {
+                localStorage.setItem('codexmateSessionTimelineStyle', normalized);
             } catch (_) {}
         },
 

--- a/web-ui/modules/i18n/locales/en.mjs
+++ b/web-ui/modules/i18n/locales/en.mjs
@@ -1153,6 +1153,12 @@ const en = Object.freeze({
     'settings.templateConfirm.toggle': 'Preview diffs before apply (Confirm → Apply)',
     'settings.templateConfirm.hint': 'When enabled: show a diff preview first, then confirm writing.',
 
+    'settings.timeline.style.title': 'Timeline Style',
+    'settings.timeline.style.meta': 'Choose timeline navigation style in session preview',
+    'settings.timeline.style.dots': 'Dots',
+    'settings.timeline.style.bar': 'Bar',
+    'settings.timeline.style.hint': 'Dots for quick navigation, Bar for visual progress',
+
     'settings.reset.title': 'Config reset',
     'settings.reset.meta': 'Proceed with caution',
     'settings.reset.hint': 'Backs up config.toml, then writes default config.',

--- a/web-ui/modules/i18n/locales/ja.mjs
+++ b/web-ui/modules/i18n/locales/ja.mjs
@@ -1146,6 +1146,12 @@ const ja = Object.freeze({
     'settings.templateConfirm.toggle': 'テンプレート適用前に差分をプレビュー（2段階：確認 → 適用）',
     'settings.templateConfirm.hint': '有効時：先に差分プレビューを表示し、確認後に書き込みます。',
 
+    'settings.timeline.style.title': 'タイムラインスタイル',
+    'settings.timeline.style.meta': 'セッションプレビューのタイムラインナビゲーションスタイルを選択',
+    'settings.timeline.style.dots': 'ドット',
+    'settings.timeline.style.bar': 'バー',
+    'settings.timeline.style.hint': 'ドットは素早いナビゲーション、バーは進捗を直感的に表示',
+
     'settings.reset.title': '設定リセット',
     'settings.reset.meta': '注意して操作してください',
     'settings.reset.hint': '先に config.toml をバックアップし、デフォルト設定を書き込みます。',

--- a/web-ui/modules/i18n/locales/vi.mjs
+++ b/web-ui/modules/i18n/locales/vi.mjs
@@ -382,6 +382,13 @@ const vi = Object.freeze({
     // Sessions
     'sessions.preview.openLink': 'Mở liên kết',
 
+    // Settings
+    'settings.timeline.style.title': 'Kiểu dòng thời gian',
+    'settings.timeline.style.meta': 'Chọn kiểu điều hướng dòng thời gian trong xem trước phiên',
+    'settings.timeline.style.dots': 'Chấm',
+    'settings.timeline.style.bar': 'Thanh',
+    'settings.timeline.style.hint': 'Chấm để điều hướng nhanh, Thanh để hiển thị tiến trình trực quan',
+
     // Diff / Agents hints
     'diff.hint.busy': 'Đang tạo diff hoặc áp dụng. Thao tác tạm thời bị vô hiệu hóa.',
     'diff.hint.failedBack': 'Xem trước diff thất bại. Hãy quay lại chỉnh sửa và thử lại.',

--- a/web-ui/modules/i18n/locales/zh-tw.mjs
+++ b/web-ui/modules/i18n/locales/zh-tw.mjs
@@ -1156,6 +1156,12 @@ const zhTw = Object.freeze({
     'settings.templateConfirm.toggle': '應用模板前先預覽差異（兩步：確認 → 應用）',
     'settings.templateConfirm.hint': '開啟後：先展示差異預覽，再確認寫入。',
 
+    'settings.timeline.style.title': '時間線樣式',
+    'settings.timeline.style.meta': '選擇會話預覽中的時間線導航樣式',
+    'settings.timeline.style.dots': '點狀',
+    'settings.timeline.style.bar': '條狀',
+    'settings.timeline.style.hint': '點狀適合快速定位，條狀更直觀顯示進度',
+
     'settings.reset.title': '設定重置',
     'settings.reset.meta': '謹慎操作',
     'settings.reset.hint': '會先備份 config.toml，再寫入預設設定。',

--- a/web-ui/modules/i18n/locales/zh.mjs
+++ b/web-ui/modules/i18n/locales/zh.mjs
@@ -1156,6 +1156,12 @@ const zh = Object.freeze({
     'settings.templateConfirm.toggle': '应用模板前先预览差异（两步：确认 → 应用）',
     'settings.templateConfirm.hint': '开启后：先展示差异预览，再确认写入。',
 
+    'settings.timeline.style.title': '时间线样式',
+    'settings.timeline.style.meta': '选择会话预览中的时间线导航样式',
+    'settings.timeline.style.dots': '点状',
+    'settings.timeline.style.bar': '条状',
+    'settings.timeline.style.hint': '点状适合快速定位，条状更直观显示进度',
+
     'settings.reset.title': '配置重置',
     'settings.reset.meta': '谨慎操作',
     'settings.reset.hint': '会先备份 config.toml，再写入默认配置。',

--- a/web-ui/partials/index/panel-sessions.html
+++ b/web-ui/partials/index/panel-sessions.html
@@ -316,23 +316,50 @@
                                     </div>
                                 </div>
                             </div>
-                            <aside v-if="sessionPreviewRenderEnabled && sessionTimelineNodes.length" class="session-timeline" :aria-label="t('sessions.timeline.aria')">
-                                <div class="session-timeline-track"></div>
-                                <button
-                                    v-for="node in sessionTimelineNodes"
-                                    :key="'timeline-' + node.key"
-                                    v-memo="[sessionTimelineActiveKey === node.key, node.safePercent, node.title]"
-                                    type="button"
-                                    :class="['session-timeline-node', { active: sessionTimelineActiveKey === node.key }]"
-                                    :aria-current="sessionTimelineActiveKey === node.key ? 'true' : null"
-                                    :style="{ top: `${node.safePercent}%` }"
-                                    :title="node.title"
-                                    @click="jumpToSessionTimelineNode(node.key)">
-                                    <span class="sr-only">{{ node.title }}</span>
-                                </button>
-                                <div class="session-timeline-current" v-if="sessionTimelineActiveTitle">
-                                    {{ sessionTimelineActiveTitle }}
-                                </div>
+                            <aside v-if="sessionPreviewRenderEnabled && sessionTimelineNodes.length" :class="['session-timeline', 'session-timeline-' + sessionTimelineStyle]" :aria-label="t('sessions.timeline.aria')">
+                                <!-- 点状模式 -->
+                                <template v-if="sessionTimelineStyle === 'dots'">
+                                    <div class="session-timeline-track"></div>
+                                    <button
+                                        v-for="node in sessionTimelineNodes"
+                                        :key="'timeline-' + node.key"
+                                        v-memo="[sessionTimelineActiveKey === node.key, node.safePercent, node.title]"
+                                        type="button"
+                                        :class="['session-timeline-node', { active: sessionTimelineActiveKey === node.key }]"
+                                        :aria-current="sessionTimelineActiveKey === node.key ? 'true' : null"
+                                        :style="{ top: `${node.safePercent}%` }"
+                                        :title="node.title"
+                                        @click="jumpToSessionTimelineNode(node.key)">
+                                        <span class="sr-only">{{ node.title }}</span>
+                                    </button>
+                                    <div class="session-timeline-current" v-if="sessionTimelineActiveTitle">
+                                        {{ sessionTimelineActiveTitle }}
+                                    </div>
+                                </template>
+
+                                <!-- 条状模式 -->
+                                <template v-else>
+                                    <div class="session-timeline-bar-track">
+                                        <div class="session-timeline-bar-progress"
+                                             :style="{ height: sessionTimelineProgressPercent + '%' }">
+                                        </div>
+                                    </div>
+                                    <button
+                                        v-for="node in sessionTimelineNodes"
+                                        :key="'timeline-bar-' + node.key"
+                                        v-memo="[sessionTimelineActiveKey === node.key, node.safePercent, node.title]"
+                                        type="button"
+                                        :class="['session-timeline-bar-node', { active: sessionTimelineActiveKey === node.key }]"
+                                        :aria-current="sessionTimelineActiveKey === node.key ? 'true' : null"
+                                        :style="{ top: `${node.safePercent}%` }"
+                                        :title="node.title"
+                                        @click="jumpToSessionTimelineNode(node.key)">
+                                        <span class="sr-only">{{ node.title }}</span>
+                                    </button>
+                                    <div class="session-timeline-current" v-if="sessionTimelineActiveTitle">
+                                        {{ sessionTimelineActiveTitle }}
+                                    </div>
+                                </template>
                             </aside>
                         </template>
 

--- a/web-ui/partials/index/panel-settings.html
+++ b/web-ui/partials/index/panel-settings.html
@@ -114,6 +114,30 @@
                                     <span v-else>{{ t('settings.webhook.enable') }}</span>
                                 </button>
                             </section>
+
+                            <section class="settings-card" :aria-label="t('settings.timeline.style.title')">
+                                <div class="settings-card-main">
+                                    <div class="settings-card-content">
+                                        <div class="settings-card-title">{{ t('settings.timeline.style.title') }}</div>
+                                        <p class="settings-card-desc">{{ t('settings.timeline.style.meta') }}</p>
+                                        <div class="settings-toggle-group">
+                                            <button
+                                                type="button"
+                                                :class="['toggle-btn', { active: sessionTimelineStyle === 'dots' }]"
+                                                @click="setSessionTimelineStyle('dots')">
+                                                {{ t('settings.timeline.style.dots') }}
+                                            </button>
+                                            <button
+                                                type="button"
+                                                :class="['toggle-btn', { active: sessionTimelineStyle === 'bar' }]"
+                                                @click="setSessionTimelineStyle('bar')">
+                                                {{ t('settings.timeline.style.bar') }}
+                                            </button>
+                                        </div>
+                                        <p class="settings-card-hint">{{ t('settings.timeline.style.hint') }}</p>
+                                    </div>
+                                </div>
+                            </section>
                         </div>
                     </div>
 

--- a/web-ui/res/web-ui-render.precompiled.js
+++ b/web-ui/res/web-ui-render.precompiled.js
@@ -3320,34 +3320,70 @@ return function render(_ctx, _cache) {
                                   (_ctx.sessionPreviewRenderEnabled && _ctx.sessionTimelineNodes.length)
                                     ? (_openBlock(), _createElementBlock("aside", {
                                         key: 0,
-                                        class: "session-timeline",
+                                        class: _normalizeClass(['session-timeline', 'session-timeline-' + _ctx.sessionTimelineStyle]),
                                         "aria-label": _ctx.t('sessions.timeline.aria')
                                       }, [
-                                        _createElementVNode("div", { class: "session-timeline-track" }),
-                                        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.sessionTimelineNodes, (node, __, ___, _cached) => {
-                                          const _memo = ([_ctx.sessionTimelineActiveKey === node.key, node.safePercent, node.title])
-                                          if (_cached && _cached.key === 'timeline-' + node.key && _isMemoSame(_cached, _memo)) return _cached
-                                          const _item = (_openBlock(), _createElementBlock("button", {
-                                            key: 'timeline-' + node.key,
-                                            type: "button",
-                                            class: _normalizeClass(['session-timeline-node', { active: _ctx.sessionTimelineActiveKey === node.key }]),
-                                            "aria-current": _ctx.sessionTimelineActiveKey === node.key ? 'true' : null,
-                                            style: _normalizeStyle({ top: `${node.safePercent}%` }),
-                                            title: node.title,
-                                            onClick: $event => (_ctx.jumpToSessionTimelineNode(node.key))
-                                          }, [
-                                            _createElementVNode("span", { class: "sr-only" }, _toDisplayString(node.title), 1 /* TEXT */)
-                                          ], 14 /* CLASS, STYLE, PROPS */, ["aria-current", "title", "onClick"]))
-                                          _item.memo = _memo
-                                          return _item
-                                        }, _cache, 4), 128 /* KEYED_FRAGMENT */)),
-                                        (_ctx.sessionTimelineActiveTitle)
-                                          ? (_openBlock(), _createElementBlock("div", {
-                                              key: 0,
-                                              class: "session-timeline-current"
-                                            }, _toDisplayString(_ctx.sessionTimelineActiveTitle), 1 /* TEXT */))
-                                          : _createCommentVNode("v-if", true)
-                                      ], 8 /* PROPS */, ["aria-label"]))
+                                        _createCommentVNode(" 点状模式 "),
+                                        (_ctx.sessionTimelineStyle === 'dots')
+                                          ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+                                              _createElementVNode("div", { class: "session-timeline-track" }),
+                                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.sessionTimelineNodes, (node, __, ___, _cached) => {
+                                                const _memo = ([_ctx.sessionTimelineActiveKey === node.key, node.safePercent, node.title])
+                                                if (_cached && _cached.key === 'timeline-' + node.key && _isMemoSame(_cached, _memo)) return _cached
+                                                const _item = (_openBlock(), _createElementBlock("button", {
+                                                  key: 'timeline-' + node.key,
+                                                  type: "button",
+                                                  class: _normalizeClass(['session-timeline-node', { active: _ctx.sessionTimelineActiveKey === node.key }]),
+                                                  "aria-current": _ctx.sessionTimelineActiveKey === node.key ? 'true' : null,
+                                                  style: _normalizeStyle({ top: `${node.safePercent}%` }),
+                                                  title: node.title,
+                                                  onClick: $event => (_ctx.jumpToSessionTimelineNode(node.key))
+                                                }, [
+                                                  _createElementVNode("span", { class: "sr-only" }, _toDisplayString(node.title), 1 /* TEXT */)
+                                                ], 14 /* CLASS, STYLE, PROPS */, ["aria-current", "title", "onClick"]))
+                                                _item.memo = _memo
+                                                return _item
+                                              }, _cache, 4), 128 /* KEYED_FRAGMENT */)),
+                                              (_ctx.sessionTimelineActiveTitle)
+                                                ? (_openBlock(), _createElementBlock("div", {
+                                                    key: 0,
+                                                    class: "session-timeline-current"
+                                                  }, _toDisplayString(_ctx.sessionTimelineActiveTitle), 1 /* TEXT */))
+                                                : _createCommentVNode("v-if", true)
+                                            ], 64 /* STABLE_FRAGMENT */))
+                                          : (_openBlock(), _createElementBlock(_Fragment, { key: 1 }, [
+                                              _createCommentVNode(" 条状模式 "),
+                                              _createElementVNode("div", { class: "session-timeline-bar-track" }, [
+                                                _createElementVNode("div", {
+                                                  class: "session-timeline-bar-progress",
+                                                  style: _normalizeStyle({ height: _ctx.sessionTimelineProgressPercent + '%' })
+                                                }, null, 4 /* STYLE */)
+                                              ]),
+                                              (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.sessionTimelineNodes, (node, __, ___, _cached) => {
+                                                const _memo = ([_ctx.sessionTimelineActiveKey === node.key, node.safePercent, node.title])
+                                                if (_cached && _cached.key === 'timeline-bar-' + node.key && _isMemoSame(_cached, _memo)) return _cached
+                                                const _item = (_openBlock(), _createElementBlock("button", {
+                                                  key: 'timeline-bar-' + node.key,
+                                                  type: "button",
+                                                  class: _normalizeClass(['session-timeline-bar-node', { active: _ctx.sessionTimelineActiveKey === node.key }]),
+                                                  "aria-current": _ctx.sessionTimelineActiveKey === node.key ? 'true' : null,
+                                                  style: _normalizeStyle({ top: `${node.safePercent}%` }),
+                                                  title: node.title,
+                                                  onClick: $event => (_ctx.jumpToSessionTimelineNode(node.key))
+                                                }, [
+                                                  _createElementVNode("span", { class: "sr-only" }, _toDisplayString(node.title), 1 /* TEXT */)
+                                                ], 14 /* CLASS, STYLE, PROPS */, ["aria-current", "title", "onClick"]))
+                                                _item.memo = _memo
+                                                return _item
+                                              }, _cache, 6), 128 /* KEYED_FRAGMENT */)),
+                                              (_ctx.sessionTimelineActiveTitle)
+                                                ? (_openBlock(), _createElementBlock("div", {
+                                                    key: 0,
+                                                    class: "session-timeline-current"
+                                                  }, _toDisplayString(_ctx.sessionTimelineActiveTitle), 1 /* TEXT */))
+                                                : _createCommentVNode("v-if", true)
+                                            ], 64 /* STABLE_FRAGMENT */))
+                                      ], 10 /* CLASS, PROPS */, ["aria-label"]))
                                     : _createCommentVNode("v-if", true)
                                 ], 64 /* STABLE_FRAGMENT */))
                               : (_openBlock(), _createElementBlock("div", {
@@ -4843,6 +4879,30 @@ return function render(_ctx, _cache) {
                       ? (_openBlock(), _createElementBlock("span", { key: 0 }, _toDisplayString(_ctx.webhookConfig.url ? _ctx.t('settings.webhook.edit') : _ctx.t('settings.webhook.configure')), 1 /* TEXT */))
                       : (_openBlock(), _createElementBlock("span", { key: 1 }, _toDisplayString(_ctx.t('settings.webhook.enable')), 1 /* TEXT */))
                   ], 10 /* CLASS, PROPS */, ["onClick"])
+                ], 8 /* PROPS */, ["aria-label"]),
+                _createElementVNode("section", {
+                  class: "settings-card",
+                  "aria-label": _ctx.t('settings.timeline.style.title')
+                }, [
+                  _createElementVNode("div", { class: "settings-card-main" }, [
+                    _createElementVNode("div", { class: "settings-card-content" }, [
+                      _createElementVNode("div", { class: "settings-card-title" }, _toDisplayString(_ctx.t('settings.timeline.style.title')), 1 /* TEXT */),
+                      _createElementVNode("p", { class: "settings-card-desc" }, _toDisplayString(_ctx.t('settings.timeline.style.meta')), 1 /* TEXT */),
+                      _createElementVNode("div", { class: "settings-toggle-group" }, [
+                        _createElementVNode("button", {
+                          type: "button",
+                          class: _normalizeClass(['toggle-btn', { active: _ctx.sessionTimelineStyle === 'dots' }]),
+                          onClick: $event => (_ctx.setSessionTimelineStyle('dots'))
+                        }, _toDisplayString(_ctx.t('settings.timeline.style.dots')), 11 /* TEXT, CLASS, PROPS */, ["onClick"]),
+                        _createElementVNode("button", {
+                          type: "button",
+                          class: _normalizeClass(['toggle-btn', { active: _ctx.sessionTimelineStyle === 'bar' }]),
+                          onClick: $event => (_ctx.setSessionTimelineStyle('bar'))
+                        }, _toDisplayString(_ctx.t('settings.timeline.style.bar')), 11 /* TEXT, CLASS, PROPS */, ["onClick"])
+                      ]),
+                      _createElementVNode("p", { class: "settings-card-hint" }, _toDisplayString(_ctx.t('settings.timeline.style.hint')), 1 /* TEXT */)
+                    ])
+                  ])
                 ], 8 /* PROPS */, ["aria-label"])
               ])
             ], 512 /* NEED_PATCH */), [

--- a/web-ui/styles/sessions-list.css
+++ b/web-ui/styles/sessions-list.css
@@ -472,11 +472,12 @@
     content: "";
     position: absolute;
     left: 0;
-    top: 10px;
-    bottom: 10px;
-    width: 3px;
+    top: 12px;
+    bottom: 12px;
+    width: 2px;
     border-radius: 999px;
     background: var(--color-border-soft);
+    opacity: 0.6;
     transition: background var(--transition-fast) var(--ease-spring);
 }
 

--- a/web-ui/styles/sessions-preview.css
+++ b/web-ui/styles/sessions-preview.css
@@ -23,7 +23,7 @@
 
 .session-preview-header {
     padding: 14px var(--spacing-sm);
-    border-bottom: 1px solid var(--color-border-soft);
+    border-bottom: none;
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
@@ -31,8 +31,8 @@
     position: sticky;
     top: 0;
     z-index: 2;
-    background: var(--color-surface-elevated);
-    backdrop-filter: blur(12px);
+    background: rgba(255, 253, 252, 0.92);
+    backdrop-filter: blur(20px);
 }
 
 .session-preview-header > div:first-child {
@@ -179,13 +179,69 @@
     text-overflow: ellipsis;
 }
 
+/* 条状时间线 */
+.session-timeline-bar {
+    width: 8px;
+    padding: 0;
+}
+
+.session-timeline-bar-track {
+    position: absolute;
+    left: 50%;
+    top: 10px;
+    bottom: 32px;
+    width: 6px;
+    transform: translateX(-50%);
+    background: var(--color-border-soft);
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.session-timeline-bar-progress {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    background: var(--color-brand);
+    border-radius: 3px;
+    transition: height var(--transition-fast) var(--ease-spring);
+}
+
+.session-timeline-bar-node {
+    position: absolute;
+    left: 50%;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid var(--color-border-strong);
+    background: var(--color-surface);
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    padding: 0;
+    transition: all var(--transition-fast) var(--ease-spring);
+    z-index: 2;
+}
+
+.session-timeline-bar-node:hover {
+    border-color: var(--color-brand);
+    background: var(--color-surface);
+    box-shadow: 0 0 0 3px rgba(210, 107, 90, 0.15);
+}
+
+.session-timeline-bar-node.active {
+    border-color: var(--color-brand);
+    background: var(--color-brand);
+    box-shadow: 0 0 0 3px rgba(210, 107, 90, 0.2);
+}
+
 .session-msg {
     border-radius: var(--radius-md);
-    padding: 10px 14px 10px 20px;
-    border: 1px solid var(--color-border-soft);
+    padding: 12px 18px 12px 24px;
+    border: none;
     background: var(--color-surface);
     position: relative;
-    box-shadow: var(--shadow-subtle);
+    box-shadow: none;
     contain: layout style paint;
 }
 
@@ -197,10 +253,10 @@
 .session-msg::before {
     content: "";
     position: absolute;
-    left: 8px;
-    top: 10px;
-    bottom: 10px;
-    width: 3px;
+    left: 6px;
+    top: 12px;
+    bottom: 12px;
+    width: 4px;
     border-radius: 999px;
     background: var(--color-border-soft);
 }

--- a/web-ui/styles/sessions-toolbar-trash.css
+++ b/web-ui/styles/sessions-toolbar-trash.css
@@ -525,17 +525,19 @@
 }
 
 .session-match-snippets {
-    margin-top: 4px;
+    margin-top: 6px;
+    padding-top: 6px;
+    border-top: 1px solid var(--color-border-soft);
     grid-column: 1 / -1;
 }
 
 .session-match-snippet {
     font-size: var(--font-size-caption);
     color: var(--color-text-tertiary);
-    line-height: 1.35;
-    padding: 3px 8px;
+    line-height: 1.4;
+    padding: 4px 8px;
     margin-bottom: 2px;
-    background: var(--color-surface-alt);
+    background: rgba(0, 0, 0, 0.02);
     border-radius: var(--radius-sm);
     border-left: 2px solid var(--color-brand-light);
     overflow: hidden;

--- a/web-ui/styles/settings-panel.css
+++ b/web-ui/styles/settings-panel.css
@@ -191,6 +191,53 @@
     color: var(--color-text-secondary);
 }
 
+/* ---- 切换按钮组 ---- */
+.settings-toggle-group {
+    display: flex;
+    gap: 4px;
+    padding: 3px;
+    border-radius: var(--radius-md);
+    background: var(--color-surface-alt);
+    border: 1px solid var(--color-border-soft);
+    margin: 12px 0;
+}
+
+.settings-toggle-group .toggle-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    border-radius: var(--radius-sm);
+    border: none;
+    background: transparent;
+    color: var(--color-text-tertiary);
+    font-size: var(--font-size-secondary);
+    font-family: var(--font-family);
+    font-weight: var(--font-weight-secondary);
+    cursor: pointer;
+    transition: all var(--transition-fast) var(--ease-spring);
+    white-space: nowrap;
+    user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    flex: 1;
+}
+
+.settings-toggle-group .toggle-btn:hover:not(:disabled) {
+    color: var(--color-text-secondary);
+    background: var(--color-surface);
+}
+
+.settings-toggle-group .toggle-btn:active:not(:disabled) {
+    transform: scale(0.97);
+}
+
+.settings-toggle-group .toggle-btn.active {
+    color: #fff;
+    background: var(--color-brand);
+    box-shadow: 0 1px 3px rgba(200, 121, 99, 0.35);
+    font-weight: var(--font-weight-primary);
+}
+
 /* ---- 保留天数输入 ---- */
 .settings-retention {
     display: inline-flex;


### PR DESCRIPTION
## Summary

- Add timeline style setting (dots/bar) in Settings panel with localStorage persistence
- Optimize session preview panel: remove message borders, enhance glass header effect
- Refine session card layout: subtle left indicator, snippet divider
- Add bar timeline mode with progress indicator and node markers
- Update all locale translations (zh/zh-tw/en/ja/vi)
- Update precompiled render and test baselines

## Technical changes

- New state: `sessionTimelineStyle` (default: 'dots')
- New computed: `sessionTimelineProgressPercent`
- New methods: `normalizeSessionTimelineStyle`, `setSessionTimelineStyle`
- Timeline rendering: conditional template for dots/bar modes
- Settings panel: toggle group component for style selection
- CSS: bar timeline styles, refined preview panel, card optimizations

## Verification

- Unit tests: 660 passed
- Lint: 238 files passed
- All locale files synchronized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session timeline display style option: users can now switch between "dots" and "bar" visualization modes in settings
  * Timeline progress indicator available in bar mode

* **Documentation**
  * Added multi-language support for timeline style settings (English, Japanese, Vietnamese, Traditional Chinese, Simplified Chinese)

* **Style**
  * Enhanced session preview header and timeline styling
  * Refined session list and message display appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->