### PR TITLE
feat: docs panel, prompts icons, sessions icons, v0.0.52

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexmate",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexmate",
-      "version": "0.0.51",
+      "version": "0.0.52",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexmate",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "Codex/Claude Code/OpenClaw 配置、会话与任务编排 CLI + Web 工具",
   "main": "cli.js",
   "bin": {

--- a/web-ui/app.js
+++ b/web-ui/app.js
@@ -271,7 +271,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 healthCheckBatchFailed: 0,
                 installPackageManager: 'npm',
                 installCommandAction: 'install',
-                installRegistryPreset: 'default',
+                installRegistryPreset: 'npmmirror',
                 installRegistryCustom: '',
                 installStatusTargets: null,
                 appLatestVersion: '',

--- a/web-ui/modules/app.methods.session-actions.mjs
+++ b/web-ui/modules/app.methods.session-actions.mjs
@@ -340,14 +340,18 @@ export function createSessionActionMethods(options = {}) {
                 return;
             }
             const now = new Date();
-            const year = String(now.getFullYear());
-            const month = String(now.getMonth() + 1).padStart(2, '0');
-            const day = String(now.getDate()).padStart(2, '0');
-            const hour = String(now.getHours()).padStart(2, '0');
-            const minute = String(now.getMinutes()).padStart(2, '0');
-            const second = String(now.getSeconds()).padStart(2, '0');
-            const fileName = `agent-${year}${month}${day}-${hour}${minute}${second}.txt`;
-            this.downloadTextFile(fileName, text, 'text/plain;charset=utf-8');
+            const ts = [
+                String(now.getFullYear()),
+                String(now.getMonth() + 1).padStart(2, '0'),
+                String(now.getDate()).padStart(2, '0'),
+                '-',
+                String(now.getHours()).padStart(2, '0'),
+                String(now.getMinutes()).padStart(2, '0'),
+                String(now.getSeconds()).padStart(2, '0')
+            ].join('');
+            const prefix = this.promptsSubTab === 'claude-project' ? 'claude' : 'agents';
+            const fileName = `${prefix}-${ts}.md`;
+            this.downloadTextFile(fileName, text, 'text/markdown;charset=utf-8');
             this.showMessage(`已导出 ${fileName}`, 'success');
         },
 

--- a/web-ui/partials/index/layout-header.html
+++ b/web-ui/partials/index/layout-header.html
@@ -541,7 +541,7 @@
                         </div>
                         <div class="status-chip">
                             <span class="label">{{ t('status.registry') }}</span>
-                            <span class="value">{{ installRegistryPreview || t('common.defaultOfficial') }}</span>
+                            <span class="value">{{ installRegistryPreview || 'npmmirror' }}</span>
                         </div>
                     </div>
                     <div class="status-strip status-strip-placeholder" v-else-if="!sessionStandalone" aria-hidden="true">

--- a/web-ui/partials/index/panel-docs.html
+++ b/web-ui/partials/index/panel-docs.html
@@ -22,7 +22,6 @@
                             <div class="docs-toolbar-card docs-toolbar-card-wide">
                                 <label class="form-label">{{ t('common.mirror') }}</label>
                                 <div class="install-action-tabs">
-                                    <button type="button" class="btn-mini" :class="{ active: installRegistryPreset === 'default' }" @click="setInstallRegistryPreset('default')">{{ t('common.official') }}</button>
                                     <button type="button" class="btn-mini" :class="{ active: installRegistryPreset === 'npmmirror' }" @click="setInstallRegistryPreset('npmmirror')">npmmirror</button>
                                     <button type="button" class="btn-mini" :class="{ active: installRegistryPreset === 'tencent' }" @click="setInstallRegistryPreset('tencent')">{{ t('docs.registry.tencent') }}</button>
                                     <button type="button" class="btn-mini" :class="{ active: installRegistryPreset === 'custom' }" @click="setInstallRegistryPreset('custom')">{{ t('common.custom') }}</button>
@@ -52,7 +51,7 @@
                             </div>
                             <div class="docs-summary-item docs-summary-item-wide">
                                 <span class="docs-summary-label">{{ t('common.registry') }}</span>
-                                <strong class="docs-summary-value">{{ installRegistryPreview || t('common.defaultOfficial') }}</strong>
+                                <strong class="docs-summary-value">{{ installRegistryPreview || 'npmmirror' }}</strong>
                             </div>
                         </div>
                     </div>

--- a/web-ui/partials/index/panel-prompts.html
+++ b/web-ui/partials/index/panel-prompts.html
@@ -45,33 +45,40 @@
                                 <button
                                     class="btn-mini"
                                     @click="exportAgentsContent"
-                                    :disabled="agentsLoading">
-                                    {{ t('modal.agents.export') }}
+                                    :disabled="agentsLoading"
+                                    :title="t('modal.agents.export')">
+                                    <svg class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12M8 11l4 4 4-4M4 17v2h16v-2"/></svg>
                                 </button>
                                 <button
                                     class="btn-mini"
                                     @click="copyAgentsContent"
-                                    :disabled="agentsLoading">
-                                    {{ t('modal.agents.copy') }}
+                                    :disabled="agentsLoading"
+                                    :title="t('modal.agents.copy')">
+                                    <svg class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg>
                                 </button>
                                 <button
                                     class="btn-mini"
                                     @click="pasteAgentsContent"
-                                    :disabled="agentsLoading || agentsSaving || agentsDiffVisible">
-                                    {{ t('common.paste') }}
+                                    :disabled="agentsLoading || agentsSaving || agentsDiffVisible"
+                                    :title="t('common.paste')">
+                                    <svg class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2"/></svg>
                                 </button>
                             </div>
                             <div class="prompts-editor-group prompts-editor-group--workflow">
-                                <button class="btn-mini" @click="loadPromptsContent" :disabled="agentsSaving || agentsDiffLoading">{{ t('common.cancel') }}</button>
+                                <button class="btn-mini" @click="loadPromptsContent" :disabled="agentsSaving || agentsDiffLoading" :title="t('common.cancel')">
+                                    <svg class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                                </button>
                                 <button
                                     v-if="agentsDiffVisible"
                                     class="btn-mini"
                                     @click="resetAgentsDiffState"
-                                    :disabled="agentsSaving || agentsDiffLoading">
-                                    {{ t('common.backToEdit') }}
+                                    :disabled="agentsSaving || agentsDiffLoading"
+                                    :title="t('common.backToEdit')">
+                                    <svg class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
                                 </button>
-                                <button class="btn-mini btn-confirm-mini" @click="applyAgentsContent" :disabled="agentsSaving || agentsLoading || agentsDiffLoading || (!agentsDiffVisible && !hasAgentsContentChanged()) || (agentsDiffVisible && !agentsDiffHasChanges)">
-                                    {{ agentsSaving ? (agentsDiffVisible ? t('common.saving') : t('common.previewing')) : (agentsDiffVisible ? t('common.save') : t('common.preview')) }}
+                                <button class="btn-mini btn-confirm-mini" @click="applyAgentsContent" :disabled="agentsSaving || agentsLoading || agentsDiffLoading || (!agentsDiffVisible && !hasAgentsContentChanged()) || (agentsDiffVisible && !agentsDiffHasChanges)" :title="agentsDiffVisible ? t('common.save') : t('common.preview')">
+                                    <svg v-if="agentsDiffVisible" class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
+                                    <svg v-else class="btn-icon-sm" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
                                 </button>
                             </div>
                         </div>

--- a/web-ui/partials/index/panel-sessions.html
+++ b/web-ui/partials/index/panel-sessions.html
@@ -248,7 +248,7 @@
                                             :disabled="!activeSession || !canBuildStandaloneUrl(activeSession)"
                                             :title="t('sessions.preview.copyLink')"
                                             :aria-label="t('sessions.preview.copyLink')">
-                                            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2.5" width="4" height="2" rx="1"/><path d="M4.5 4h7a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5"/><line x1="6" y1="7.5" x2="10" y2="7.5"/><line x1="6" y1="10" x2="10" y2="10"/></svg>
+                                            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6.5 9.5a3.5 3.5 0 0 0 5 0l2-2a3.5 3.5 0 0 0-5-5l-1 1"/><path d="M9.5 6.5a3.5 3.5 0 0 0-5 0l-2 2a3.5 3.5 0 0 0 5 5l1-1"/></svg>
                                         </button>
                                         <button
                                             class="btn-session-open"
@@ -265,7 +265,7 @@
                                             :disabled="!activeSession || !getSessionFilePath(activeSession)"
                                             :title="t('sessions.preview.copyPath')"
                                             :aria-label="t('sessions.preview.copyPath')">
-                                            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2.5" width="4" height="2" rx="1"/><path d="M4.5 4h7a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5"/><line x1="6" y1="7.5" x2="10" y2="7.5"/><line x1="6" y1="10" x2="10" y2="10"/></svg>
+                                            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 5.5V12.5a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V7.5a1 1 0 0 0-1-1H8L6.5 5H3a1 1 0 0 0-1 1z"/></svg>
                                         </button>
                                     </div>
                                 </div>

--- a/web-ui/res/web-ui-render.precompiled.js
+++ b/web-ui/res/web-ui-render.precompiled.js
@@ -3165,26 +3165,8 @@ return function render(_ctx, _cache) {
                                               "stroke-linecap": "round",
                                               "stroke-linejoin": "round"
                                             }, [
-                                              _createElementVNode("rect", {
-                                                x: "6",
-                                                y: "2.5",
-                                                width: "4",
-                                                height: "2",
-                                                rx: "1"
-                                              }),
-                                              _createElementVNode("path", { d: "M4.5 4h7a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5" }),
-                                              _createElementVNode("line", {
-                                                x1: "6",
-                                                y1: "7.5",
-                                                x2: "10",
-                                                y2: "7.5"
-                                              }),
-                                              _createElementVNode("line", {
-                                                x1: "6",
-                                                y1: "10",
-                                                x2: "10",
-                                                y2: "10"
-                                              })
+                                              _createElementVNode("path", { d: "M6.5 9.5a3.5 3.5 0 0 0 5 0l2-2a3.5 3.5 0 0 0-5-5l-1 1" }),
+                                              _createElementVNode("path", { d: "M9.5 6.5a3.5 3.5 0 0 0-5 0l-2 2a3.5 3.5 0 0 0 5 5l1-1" })
                                             ]))
                                           ], 8 /* PROPS */, ["onClick", "disabled", "title", "aria-label"]),
                                           _createElementVNode("button", {
@@ -3223,26 +3205,7 @@ return function render(_ctx, _cache) {
                                             "stroke-linecap": "round",
                                             "stroke-linejoin": "round"
                                           }, [
-                                            _createElementVNode("rect", {
-                                              x: "6",
-                                              y: "2.5",
-                                              width: "4",
-                                              height: "2",
-                                              rx: "1"
-                                            }),
-                                            _createElementVNode("path", { d: "M4.5 4h7a.5.5 0 0 1 .5.5v9a.5.5 0 0 1-.5.5h-7a.5.5 0 0 1-.5-.5v-9a.5.5 0 0 1 .5-.5" }),
-                                            _createElementVNode("line", {
-                                              x1: "6",
-                                              y1: "7.5",
-                                              x2: "10",
-                                              y2: "7.5"
-                                            }),
-                                            _createElementVNode("line", {
-                                              x1: "6",
-                                              y1: "10",
-                                              x2: "10",
-                                              y2: "10"
-                                            })
+                                            _createElementVNode("path", { d: "M2 5.5V12.5a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V7.5a1 1 0 0 0-1-1H8L6.5 5H3a1 1 0 0 0-1 1z" })
                                           ]))
                                         ], 8 /* PROPS */, ["onClick", "disabled", "title", "aria-label"])
                                       ])

--- a/web-ui/res/web-ui-render.precompiled.js
+++ b/web-ui/res/web-ui-render.precompiled.js
@@ -6025,38 +6025,135 @@ return function render(_ctx, _cache) {
                         _createElementVNode("button", {
                           class: "btn-mini",
                           onClick: _ctx.exportAgentsContent,
-                          disabled: _ctx.agentsLoading
-                        }, _toDisplayString(_ctx.t('modal.agents.export')), 9 /* TEXT, PROPS */, ["onClick", "disabled"]),
+                          disabled: _ctx.agentsLoading,
+                          title: _ctx.t('modal.agents.export')
+                        }, [
+                          (_openBlock(), _createElementBlock("svg", {
+                            class: "btn-icon-sm",
+                            viewBox: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            "stroke-width": "2"
+                          }, [
+                            _createElementVNode("path", { d: "M12 3v12M8 11l4 4 4-4M4 17v2h16v-2" })
+                          ]))
+                        ], 8 /* PROPS */, ["onClick", "disabled", "title"]),
                         _createElementVNode("button", {
                           class: "btn-mini",
                           onClick: _ctx.copyAgentsContent,
-                          disabled: _ctx.agentsLoading
-                        }, _toDisplayString(_ctx.t('modal.agents.copy')), 9 /* TEXT, PROPS */, ["onClick", "disabled"]),
+                          disabled: _ctx.agentsLoading,
+                          title: _ctx.t('modal.agents.copy')
+                        }, [
+                          (_openBlock(), _createElementBlock("svg", {
+                            class: "btn-icon-sm",
+                            viewBox: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            "stroke-width": "2"
+                          }, [
+                            _createElementVNode("rect", {
+                              x: "9",
+                              y: "9",
+                              width: "13",
+                              height: "13",
+                              rx: "2"
+                            }),
+                            _createElementVNode("path", { d: "M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" })
+                          ]))
+                        ], 8 /* PROPS */, ["onClick", "disabled", "title"]),
                         _createElementVNode("button", {
                           class: "btn-mini",
                           onClick: _ctx.pasteAgentsContent,
-                          disabled: _ctx.agentsLoading || _ctx.agentsSaving || _ctx.agentsDiffVisible
-                        }, _toDisplayString(_ctx.t('common.paste')), 9 /* TEXT, PROPS */, ["onClick", "disabled"])
+                          disabled: _ctx.agentsLoading || _ctx.agentsSaving || _ctx.agentsDiffVisible,
+                          title: _ctx.t('common.paste')
+                        }, [
+                          (_openBlock(), _createElementBlock("svg", {
+                            class: "btn-icon-sm",
+                            viewBox: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            "stroke-width": "2"
+                          }, [
+                            _createElementVNode("rect", {
+                              x: "8",
+                              y: "2",
+                              width: "8",
+                              height: "4",
+                              rx: "1"
+                            }),
+                            _createElementVNode("path", { d: "M16 4h2a2 2 0 012 2v14a2 2 0 01-2 2H6a2 2 0 01-2-2V6a2 2 0 012-2h2" })
+                          ]))
+                        ], 8 /* PROPS */, ["onClick", "disabled", "title"])
                       ]),
                       _createElementVNode("div", { class: "prompts-editor-group prompts-editor-group--workflow" }, [
                         _createElementVNode("button", {
                           class: "btn-mini",
                           onClick: _ctx.loadPromptsContent,
-                          disabled: _ctx.agentsSaving || _ctx.agentsDiffLoading
-                        }, _toDisplayString(_ctx.t('common.cancel')), 9 /* TEXT, PROPS */, ["onClick", "disabled"]),
+                          disabled: _ctx.agentsSaving || _ctx.agentsDiffLoading,
+                          title: _ctx.t('common.cancel')
+                        }, [
+                          (_openBlock(), _createElementBlock("svg", {
+                            class: "btn-icon-sm",
+                            viewBox: "0 0 24 24",
+                            fill: "none",
+                            stroke: "currentColor",
+                            "stroke-width": "2"
+                          }, [
+                            _createElementVNode("path", { d: "M18 6L6 18M6 6l12 12" })
+                          ]))
+                        ], 8 /* PROPS */, ["onClick", "disabled", "title"]),
                         (_ctx.agentsDiffVisible)
                           ? (_openBlock(), _createElementBlock("button", {
                               key: 0,
                               class: "btn-mini",
                               onClick: _ctx.resetAgentsDiffState,
-                              disabled: _ctx.agentsSaving || _ctx.agentsDiffLoading
-                            }, _toDisplayString(_ctx.t('common.backToEdit')), 9 /* TEXT, PROPS */, ["onClick", "disabled"]))
+                              disabled: _ctx.agentsSaving || _ctx.agentsDiffLoading,
+                              title: _ctx.t('common.backToEdit')
+                            }, [
+                              (_openBlock(), _createElementBlock("svg", {
+                                class: "btn-icon-sm",
+                                viewBox: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                "stroke-width": "2"
+                              }, [
+                                _createElementVNode("path", { d: "M19 12H5M12 19l-7-7 7-7" })
+                              ]))
+                            ], 8 /* PROPS */, ["onClick", "disabled", "title"]))
                           : _createCommentVNode("v-if", true),
                         _createElementVNode("button", {
                           class: "btn-mini btn-confirm-mini",
                           onClick: _ctx.applyAgentsContent,
-                          disabled: _ctx.agentsSaving || _ctx.agentsLoading || _ctx.agentsDiffLoading || (!_ctx.agentsDiffVisible && !_ctx.hasAgentsContentChanged()) || (_ctx.agentsDiffVisible && !_ctx.agentsDiffHasChanges)
-                        }, _toDisplayString(_ctx.agentsSaving ? (_ctx.agentsDiffVisible ? _ctx.t('common.saving') : _ctx.t('common.previewing')) : (_ctx.agentsDiffVisible ? _ctx.t('common.save') : _ctx.t('common.preview'))), 9 /* TEXT, PROPS */, ["onClick", "disabled"])
+                          disabled: _ctx.agentsSaving || _ctx.agentsLoading || _ctx.agentsDiffLoading || (!_ctx.agentsDiffVisible && !_ctx.hasAgentsContentChanged()) || (_ctx.agentsDiffVisible && !_ctx.agentsDiffHasChanges),
+                          title: _ctx.agentsDiffVisible ? _ctx.t('common.save') : _ctx.t('common.preview')
+                        }, [
+                          (_ctx.agentsDiffVisible)
+                            ? (_openBlock(), _createElementBlock("svg", {
+                                key: 0,
+                                class: "btn-icon-sm",
+                                viewBox: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                "stroke-width": "2"
+                              }, [
+                                _createElementVNode("path", { d: "M20 6L9 17l-5-5" })
+                              ]))
+                            : (_openBlock(), _createElementBlock("svg", {
+                                key: 1,
+                                class: "btn-icon-sm",
+                                viewBox: "0 0 24 24",
+                                fill: "none",
+                                stroke: "currentColor",
+                                "stroke-width": "2"
+                              }, [
+                                _createElementVNode("path", { d: "M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" }),
+                                _createElementVNode("circle", {
+                                  cx: "12",
+                                  cy: "12",
+                                  r: "3"
+                                })
+                              ]))
+                        ], 8 /* PROPS */, ["onClick", "disabled", "title"])
                       ])
                     ])
                   ]),

--- a/web-ui/res/web-ui-render.precompiled.js
+++ b/web-ui/res/web-ui-render.precompiled.js
@@ -707,7 +707,7 @@ return function render(_ctx, _cache) {
                           ]),
                           _createElementVNode("div", { class: "status-chip" }, [
                             _createElementVNode("span", { class: "label" }, _toDisplayString(_ctx.t('status.registry')), 1 /* TEXT */),
-                            _createElementVNode("span", { class: "value" }, _toDisplayString(_ctx.installRegistryPreview || _ctx.t('common.defaultOfficial')), 1 /* TEXT */)
+                            _createElementVNode("span", { class: "value" }, _toDisplayString(_ctx.installRegistryPreview || 'npmmirror'), 1 /* TEXT */)
                           ])
                         ]))
                       : (!_ctx.sessionStandalone)
@@ -4528,11 +4528,6 @@ return function render(_ctx, _cache) {
                   _createElementVNode("div", { class: "install-action-tabs" }, [
                     _createElementVNode("button", {
                       type: "button",
-                      class: _normalizeClass(["btn-mini", { active: _ctx.installRegistryPreset === 'default' }]),
-                      onClick: $event => (_ctx.setInstallRegistryPreset('default'))
-                    }, _toDisplayString(_ctx.t('common.official')), 11 /* TEXT, CLASS, PROPS */, ["onClick"]),
-                    _createElementVNode("button", {
-                      type: "button",
                       class: _normalizeClass(["btn-mini", { active: _ctx.installRegistryPreset === 'npmmirror' }]),
                       onClick: $event => (_ctx.setInstallRegistryPreset('npmmirror'))
                     }, "npmmirror", 10 /* CLASS, PROPS */, ["onClick"]),
@@ -4601,7 +4596,7 @@ return function render(_ctx, _cache) {
                 ]),
                 _createElementVNode("div", { class: "docs-summary-item docs-summary-item-wide" }, [
                   _createElementVNode("span", { class: "docs-summary-label" }, _toDisplayString(_ctx.t('common.registry')), 1 /* TEXT */),
-                  _createElementVNode("strong", { class: "docs-summary-value" }, _toDisplayString(_ctx.installRegistryPreview || _ctx.t('common.defaultOfficial')), 1 /* TEXT */)
+                  _createElementVNode("strong", { class: "docs-summary-value" }, _toDisplayString(_ctx.installRegistryPreview || 'npmmirror'), 1 /* TEXT */)
                 ])
               ])
             ]),

--- a/web-ui/styles/docs-panel.css
+++ b/web-ui/styles/docs-panel.css
@@ -104,11 +104,12 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 10px 80px 10px 14px;
+    padding: 10px 14px;
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-sm);
     background: var(--color-surface-alt);
-    position: relative;
+    overflow: hidden;
+    max-width: 100%;
 }
 
 .docs-command-box .install-command {
@@ -118,8 +119,9 @@
     border-radius: var(--radius-sm);
     background: var(--color-surface);
     border: 1px solid var(--color-border-soft);
-    overflow-x: auto;
-    white-space: nowrap;
+    white-space: normal;
+    word-break: break-all;
+    overflow-wrap: break-word;
     font-size: 13px;
     line-height: 1.5;
     font-family: var(--font-family-mono);
@@ -161,15 +163,11 @@
 }
 
 .docs-copy-btn {
-    position: absolute;
-    right: 10px;
-    top: 50%;
-    transform: translateY(-50%);
+    flex-shrink: 0;
     min-width: 64px;
     height: 36px;
     border-radius: var(--radius-sm);
     font-weight: 600;
-    z-index: 1;
 }
 
 /* ---- Help section ---- */
@@ -239,17 +237,8 @@
         grid-column: span 1;
     }
 
-    .docs-command-box {
-        padding-right: 14px;
-        padding-bottom: 50px;
-    }
-
-    .docs-copy-btn {
-        position: absolute;
-        right: 10px;
-        bottom: 10px;
-        top: auto;
-        transform: none;
-        width: calc(100% - 20px);
+    .docs-install-row,
+    .docs-command-row {
+        overflow: hidden;
     }
 }

--- a/web-ui/styles/docs-panel.css
+++ b/web-ui/styles/docs-panel.css
@@ -104,16 +104,16 @@
     display: flex;
     align-items: center;
     gap: 10px;
-    padding: 10px 10px 10px 14px;
+    padding: 10px 80px 10px 14px;
     border: 1px solid var(--color-border-soft);
     border-radius: var(--radius-sm);
     background: var(--color-surface-alt);
+    position: relative;
 }
 
 .docs-command-box .install-command {
     flex: 1;
     min-width: 0;
-    max-width: calc(100% - 80px);
     padding: 8px 12px;
     border-radius: var(--radius-sm);
     background: var(--color-surface);
@@ -161,11 +161,15 @@
 }
 
 .docs-copy-btn {
-    flex-shrink: 0;
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
     min-width: 64px;
     height: 36px;
     border-radius: var(--radius-sm);
     font-weight: 600;
+    z-index: 1;
 }
 
 /* ---- Help section ---- */
@@ -236,11 +240,16 @@
     }
 
     .docs-command-box {
-        flex-direction: column;
-        align-items: stretch;
+        padding-right: 14px;
+        padding-bottom: 50px;
     }
 
     .docs-copy-btn {
-        width: 100%;
+        position: absolute;
+        right: 10px;
+        bottom: 10px;
+        top: auto;
+        transform: none;
+        width: calc(100% - 20px);
     }
 }

--- a/web-ui/styles/docs-panel.css
+++ b/web-ui/styles/docs-panel.css
@@ -113,6 +113,7 @@
 .docs-command-box .install-command {
     flex: 1;
     min-width: 0;
+    max-width: calc(100% - 80px);
     padding: 8px 12px;
     border-radius: var(--radius-sm);
     background: var(--color-surface);


### PR DESCRIPTION
## Summary

- Default registry preset changed from official to npmmirror; remove official option from docs panel
- Fix long command overflow in docs panel: switch from horizontal scroll to word-break wrapping, copy button uses flex layout to stay visible on all screen sizes
- Replace prompts editor toolbar text buttons with SVG icon buttons with tooltips
- Export generates .md file with dynamic prefix (agents/claude) based on active sub-tab
- Fix sessions panel copy-link and copy-path icons: use distinct chain-link and folder icons instead of identical clipboard icons
- Bump version to 0.0.52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the default package registry preset and fallback displays to **npmmirror** across the web UI.
  * Removed the **official/default** registry option from the docs panel and preset list.
  * Updated the prompts/agents editor toolbar to use icon-only buttons with tooltips.
  * Agent export now downloads as a **.md** file with a timestamped name.
* **Style**
  * Refined the docs command box layout for improved wrapping/clipping, and adjusted mobile overflow handling for install/command rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->