### PR TITLE
fix: apply Claude config and preserve Codex proxy identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Have you ever felt overwhelmed by managing multiple local AI agents? Each has it
 
 Unlike simple wrappers, Codex Mate acts as a **Local Agent Bridge**:
 - **Unified Session Browser**: Search, inspect, filter, and export local sessions across Codex, Claude Code, Gemini CLI, and CodeBuddy Code from one place.
-- **OpenAI-Compatible Bridge**: Use Codex with any OpenAI-compatible UI by normalizing the Responses API.
+- **OpenAI-Compatible Bridge**: Use Codex with any OpenAI-compatible UI by normalizing the Responses API; the built-in Codex conversion also fills and normalizes Codex fingerprint headers such as `User-Agent`, `Version`, `OpenAI-Beta`, and `Originator` so upstream providers see an official Codex CLI-shaped request.
 - **Claude Provider Bridge**: Connect Claude Code to OpenAI Chat Completions-compatible providers and Ollama through the built-in local Claude-compatible proxy.
 - **OpenCode Provider Control**: Manage OpenCode provider/model selection with a CodexMate-owned provider store under `~/.codexmate`, projecting only the active provider into native OpenCode config to avoid polluting or deleting user-owned settings.
 - **Skills Marketplace**: A local-first market to share and import skills between different agent apps.
@@ -73,7 +73,7 @@ Unlike simple wrappers, Codex Mate acts as a **Local Agent Bridge**:
 | **Usage Analytics** | ✅ | Visualize message trends and top projects |
 | **Local Skills Market** | ✅ | Cross-app import/export of agent skills |
 | **Task Queue** | ✅ | DAG-based task execution and logs |
-| **OpenAI Bridge** | ✅ | Convert Codex Responses API to standard OpenAI format |
+| **OpenAI Bridge** | ✅ | Convert Codex Responses API to standard OpenAI format and attach/normalize Codex fingerprints in the built-in conversion |
 | **Claude Provider Bridge** | ✅ | Connect Claude Code to OpenAI Chat Completions-compatible providers and Ollama via the built-in Claude-compatible proxy |
 | **OpenCode Provider Store** | ✅ | Keep multiple OpenCode providers in `~/.codexmate` while projecting only the selected provider to native OpenCode config |
 | **Prompt Templates** | ✅ | Reusable prompt plugins with variables |

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,7 +54,7 @@
 
 不同于简单的封装，Codex Mate 充当了 **本地智能体桥接器**：
 - **统一会话浏览器**：在一个地方检索、预览、筛选并导出 Codex、Claude Code、Gemini CLI 与 CodeBuddy Code 的本地会话。
-- **OpenAI 兼容桥接**：通过归一化 Responses API，让 Codex 能够与任何支持 OpenAI 格式的 UI 配合使用。
+- **OpenAI 兼容桥接**：通过归一化 Responses API，让 Codex 能够与任何支持 OpenAI 格式的 UI 配合使用；内建 Codex 转换会补齐并规范化 `User-Agent`、`Version`、`OpenAI-Beta`、`Originator` 等 Codex 指纹，对上游伪装为官方 Codex CLI 请求。
 - **Claude Provider 桥接**：通过内建本地 Claude 兼容代理，让 Claude Code 接入 OpenAI Chat Completions 兼容 provider 与 Ollama。
 - **OpenCode Provider 控制**：在 `~/.codexmate` 下维护 CodexMate 自有的 OpenCode 多 provider 存储，只将当前选中的 provider 投影到 OpenCode 原生配置，避免污染或误删用户已有配置。
 - **Skills 市场**：本地优先的市场，支持在不同的智能体应用之间共享和导入 Skills。
@@ -73,7 +73,7 @@
 | **Usage 统计** | ✅ | 可视化消息趋势与热门项目统计 |
 | **本地 Skills 市场** | ✅ | 跨应用的智能体 Skills 导入与导出 |
 | **任务队列** | ✅ | 基于 DAG 的任务执行与日志查看 |
-| **OpenAI 桥接** | ✅ | 将 Codex Responses API 转换为标准 OpenAI 格式 |
+| **OpenAI 桥接** | ✅ | 将 Codex Responses API 转换为标准 OpenAI 格式，并在内建转换中附加/规范化 Codex 指纹 |
 | **Claude Provider 桥接** | ✅ | 通过内建 Claude 兼容代理，让 Claude Code 接入 OpenAI Chat Completions 兼容 provider 与 Ollama |
 | **OpenCode Provider 存储** | ✅ | 在 `~/.codexmate` 中保留多个 OpenCode provider，只将当前选中的 provider 投影到 OpenCode 原生配置 |
 | **提示词模板** | ✅ | 支持变量的可复用提示词插件 |

--- a/cli/builtin-proxy.js
+++ b/cli/builtin-proxy.js
@@ -1459,6 +1459,127 @@ function createBuiltinProxyRuntimeController(deps = {}) {
         });
     }
 
+    function streamResponsesSse(targetUrl, options = {}) {
+        const parsed = new URL(targetUrl);
+        const transport = parsed.protocol === 'https:' ? https : http;
+        const bodyText = options.body ? JSON.stringify(options.body) : '';
+        const headers = {
+            'Accept': 'text/event-stream',
+            ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+            ...(options.headers || {})
+        };
+        if (options.body) {
+            headers['Content-Length'] = Buffer.byteLength(bodyText, 'utf-8');
+        }
+        const timeoutMs = Number.isFinite(options.timeoutMs)
+            ? Math.max(1000, Number(options.timeoutMs))
+            : 30000;
+        const res = options.res;
+
+        return new Promise((resolve) => {
+            let settled = false;
+            let streamAccepted = false;
+            const finish = (value) => {
+                if (settled) return;
+                settled = true;
+                resolve(value);
+            };
+            const req = transport.request({
+                protocol: parsed.protocol,
+                hostname: parsed.hostname,
+                port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+                method: options.method || 'POST',
+                path: `${parsed.pathname}${parsed.search}`,
+                headers,
+                agent: parsed.protocol === 'https:' ? HTTPS_KEEP_ALIVE_AGENT : HTTP_KEEP_ALIVE_AGENT
+            }, (upstreamRes) => {
+                const status = upstreamRes.statusCode || 0;
+                const chunks = [];
+                const contentType = String(upstreamRes.headers && upstreamRes.headers['content-type'] || '');
+
+                const collectBody = (done) => {
+                    upstreamRes.on('data', (chunk) => chunk && chunks.push(chunk));
+                    upstreamRes.on('end', () => done(chunks.length ? Buffer.concat(chunks).toString('utf-8') : ''));
+                };
+
+                upstreamRes.on('error', (err) => finish({ ok: false, error: err && err.message ? err.message : 'upstream stream failed' }));
+                upstreamRes.on('aborted', () => finish({ ok: false, retryTransient: true, error: 'upstream stream aborted' }));
+
+                if (status === 404 || status === 405) {
+                    collectBody((bodyTextResult) => finish({ retry: true, status, bodyText: bodyTextResult }));
+                    return;
+                }
+
+                if (status >= 400) {
+                    collectBody((bodyTextResult) => finish({ ok: false, status, bodyText: bodyTextResult }));
+                    return;
+                }
+
+                if (/text\/event-stream/i.test(contentType)) {
+                    streamAccepted = true;
+                    req.setTimeout(0);
+                    res.writeHead(200, {
+                        'Content-Type': 'text/event-stream; charset=utf-8',
+                        'Cache-Control': 'no-cache',
+                        'Connection': 'keep-alive',
+                        'X-Accel-Buffering': 'no'
+                    });
+                    upstreamRes.on('data', (chunk) => {
+                        if (chunk && !res.writableEnded) res.write(chunk);
+                    });
+                    upstreamRes.on('end', () => {
+                        if (!res.writableEnded) res.end();
+                        finish({ ok: true });
+                    });
+                    return;
+                }
+
+                collectBody((text) => {
+                    const parsedJson = parseJsonOrError(text);
+                    res.writeHead(200, {
+                        'Content-Type': 'text/event-stream; charset=utf-8',
+                        'Cache-Control': 'no-cache',
+                        'Connection': 'keep-alive',
+                        'X-Accel-Buffering': 'no'
+                    });
+                    if (parsedJson.error) {
+                        writeSse(res, 'response.failed', { type: 'response.failed', error: `invalid upstream response: ${parsedJson.error}` });
+                        writeSse(res, 'done', '[DONE]');
+                        res.end();
+                        finish({ ok: true });
+                        return;
+                    }
+                    sendResponsesSse(res, ensureResponseMetadata(parsedJson.value));
+                    res.end();
+                    finish({ ok: true });
+                });
+            });
+            req.setTimeout(timeoutMs, () => {
+                if (streamAccepted) return;
+                try { req.destroy(new Error('timeout')); } catch (_) {}
+                finish({ ok: false, error: 'timeout' });
+            });
+            req.on('error', (err) => finish({ ok: false, error: err && err.message ? err.message : 'request failed' }));
+            if (bodyText) req.write(bodyText);
+            req.end();
+        });
+    }
+
+    async function streamResponsesSseWithFallbackUrls(baseUrl, pathSuffix, options = {}) {
+        const urls = buildUpstreamUrlCandidates(baseUrl, pathSuffix);
+        if (urls.length === 0) {
+            return { ok: false, error: 'failed to build upstream URL' };
+        }
+        let lastResult = null;
+        for (const url of urls) {
+            const result = await retryTransientRequest(() => streamResponsesSse(url, options));
+            lastResult = result;
+            if (result && result.retry) continue;
+            return result;
+        }
+        return lastResult || { ok: false, error: 'failed to build upstream URL' };
+    }
+
     async function streamChatCompletionsAsResponsesSseWithFallbackUrls(baseUrl, pathSuffix, options = {}) {
         const urls = buildUpstreamUrlCandidates(baseUrl, pathSuffix);
         if (urls.length === 0) {
@@ -1825,8 +1946,8 @@ function createBuiltinProxyRuntimeController(deps = {}) {
 
             // Responses shim：
             // - Codex CLI 默认走 /v1/responses（含 SSE）
-            // - SSE/streaming 任务优先走 chat/completions fallback，避免卡在会接收但不产出 Responses 的兼容网关
-            // - 非流式请求仍优先尝试 /v1/responses（stream=false），失败再转换到 chat/completions 并回包为 responses。
+            // - SSE/streaming 任务优先保持 /v1/responses，避免 Codex-only upstream 把 fallback 后的 chat/completions 链路误判为非 Codex 客户端
+            // - 仅在上游明确不支持 Responses 时，才转换到 chat/completions 并回包为 responses。
             if ((incomingPath === '/v1/responses' || incomingPath === '/v1/responses/') && (req.method || 'GET').toUpperCase() === 'POST') {
                 void (async () => {
                     const { body, error } = await readRequestBody(req, 10 * 1024 * 1024);
@@ -1852,6 +1973,31 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                     const toolTypesByName = collectResponsesToolTypesByName(payload.tools);
 
                     if (wantsStream) {
+                        const streamedResponses = await streamResponsesSseWithFallbackUrls(upstream.baseUrl, 'responses', {
+                            method: 'POST',
+                            headers: commonHeaders,
+                            timeoutMs,
+                            body: { ...payload, stream: true },
+                            res,
+                            model
+                        });
+                        if (streamedResponses.ok) return;
+                        const canFallbackToChat = streamedResponses.status
+                            ? shouldFallbackFromUpstreamResponses(streamedResponses.status, streamedResponses.bodyText)
+                            : false;
+                        if (!canFallbackToChat) {
+                            if (!res.headersSent) {
+                                const status = streamedResponses.status && streamedResponses.status >= 400 ? streamedResponses.status : 502;
+                                res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+                                res.end(streamedResponses.bodyText || JSON.stringify({ error: streamedResponses.error || 'proxy request failed' }));
+                            } else if (!res.writableEnded) {
+                                writeSse(res, 'response.failed', { type: 'response.failed', error: streamedResponses.error || streamedResponses.bodyText || 'proxy request failed' });
+                                writeSse(res, 'done', '[DONE]');
+                                res.end();
+                            }
+                            return;
+                        }
+
                         const streamingChatBody = { ...chatBody, stream: true };
                         const streamed = await streamChatCompletionsAsResponsesSseWithFallbackUrls(upstream.baseUrl, 'chat/completions', {
                             method: 'POST',

--- a/cli/builtin-proxy.js
+++ b/cli/builtin-proxy.js
@@ -84,16 +84,22 @@ function createBuiltinProxyRuntimeController(deps = {}) {
         return DEFAULT_CODEX_USER_AGENT;
     }
 
+    function resolveCodexOriginator() {
+        // Some Codex-only upstreams validate Originator separately from User-Agent.
+        // The local TUI may send values such as `codex-tui`, but upstream Codex
+        // gates commonly expect the official Rust CLI originator token.
+        return DEFAULT_CODEX_ORIGINATOR;
+    }
+
     function codexUpstreamHeaders(req, upstream) {
         const version = firstHeaderValue(req, 'version').trim() || DEFAULT_CODEX_VERSION;
         const openaiBeta = firstHeaderValue(req, 'openai-beta').trim() || DEFAULT_OPENAI_BETA;
-        const originator = firstHeaderValue(req, 'originator').trim() || DEFAULT_CODEX_ORIGINATOR;
         return {
             ...(upstream && upstream.authHeader ? { 'Authorization': upstream.authHeader } : {}),
             'User-Agent': resolveCodexUserAgent(req),
             'Version': version,
             'OpenAI-Beta': openaiBeta,
-            'Originator': originator,
+            'Originator': resolveCodexOriginator(),
             'X-Codexmate-Proxy': '1'
         };
     }

--- a/cli/builtin-proxy.js
+++ b/cli/builtin-proxy.js
@@ -66,6 +66,38 @@ function createBuiltinProxyRuntimeController(deps = {}) {
 
     let runtime = null;
 
+    const DEFAULT_CODEX_VERSION = '0.98.0';
+    const DEFAULT_CODEX_USER_AGENT = 'codex_cli_rs/0.98.0 (Mac OS 26.0.1; arm64) Apple_Terminal/464';
+    const DEFAULT_CODEX_ORIGINATOR = 'codex_cli_rs';
+    const DEFAULT_OPENAI_BETA = 'responses=experimental';
+
+    function firstHeaderValue(req, name) {
+        if (!req || !req.headers || typeof req.headers !== 'object') return '';
+        const value = req.headers[String(name || '').toLowerCase()];
+        if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : '';
+        return typeof value === 'string' ? value : '';
+    }
+
+    function resolveCodexUserAgent(req) {
+        const incoming = firstHeaderValue(req, 'user-agent').trim();
+        if (/^(codex_cli_rs|codex-cli)\//i.test(incoming)) return incoming;
+        return DEFAULT_CODEX_USER_AGENT;
+    }
+
+    function codexUpstreamHeaders(req, upstream) {
+        const version = firstHeaderValue(req, 'version').trim() || DEFAULT_CODEX_VERSION;
+        const openaiBeta = firstHeaderValue(req, 'openai-beta').trim() || DEFAULT_OPENAI_BETA;
+        const originator = firstHeaderValue(req, 'originator').trim() || DEFAULT_CODEX_ORIGINATOR;
+        return {
+            ...(upstream && upstream.authHeader ? { 'Authorization': upstream.authHeader } : {}),
+            'User-Agent': resolveCodexUserAgent(req),
+            'Version': version,
+            'OpenAI-Beta': openaiBeta,
+            'Originator': originator,
+            'X-Codexmate-Proxy': '1'
+        };
+    }
+
     function readRequestBody(req, maxBytes) {
         return new Promise((resolve) => {
             let body = '';
@@ -1813,10 +1845,7 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                     const payload = parsed.value && typeof parsed.value === 'object' ? parsed.value : {};
                     const wantsStream = payload.stream === true;
 
-                    const commonHeaders = {
-                        ...(upstream.authHeader ? { 'Authorization': upstream.authHeader } : {}),
-                        'X-Codexmate-Proxy': '1'
-                    };
+                    const commonHeaders = codexUpstreamHeaders(req, upstream);
 
                     const model = typeof payload.model === 'string' ? payload.model : '';
                     const chatBody = buildChatCompletionsBodyFromResponsesPayload(payload);

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -38,20 +38,26 @@ function resolveCodexUserAgent(req) {
     return DEFAULT_CODEX_USER_AGENT;
 }
 
+function resolveCodexOriginator() {
+    // Some Codex-only upstreams validate Originator separately from User-Agent.
+    // The local TUI may send values such as `codex-tui`, but upstream Codex
+    // gates commonly expect the official Rust CLI originator token.
+    return DEFAULT_CODEX_ORIGINATOR;
+}
+
 function buildCodexBridgeHeaders(req, upstream, authHeader) {
     const upstreamHeaders = upstream && upstream.headers && typeof upstream.headers === 'object' && !Array.isArray(upstream.headers)
         ? upstream.headers
         : {};
     const version = firstHeaderValue(req, 'version').trim() || DEFAULT_CODEX_VERSION;
     const openaiBeta = firstHeaderValue(req, 'openai-beta').trim() || DEFAULT_OPENAI_BETA;
-    const originator = firstHeaderValue(req, 'originator').trim() || DEFAULT_CODEX_ORIGINATOR;
     return {
         ...(authHeader ? { Authorization: authHeader } : {}),
         ...upstreamHeaders,
         'User-Agent': resolveCodexUserAgent(req),
         'Version': version,
         'OpenAI-Beta': openaiBeta,
-        'Originator': originator
+        'Originator': resolveCodexOriginator()
     };
 }
 

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -11,6 +11,10 @@ const SETTINGS_VERSION = 1;
 const STREAM_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
 const REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
 const RESPONSES_UNSUPPORTED_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_CODEX_VERSION = '0.98.0';
+const DEFAULT_CODEX_USER_AGENT = 'codex_cli_rs/0.98.0 (Mac OS 26.0.1; arm64) Apple_Terminal/464';
+const DEFAULT_CODEX_ORIGINATOR = 'codex_cli_rs';
+const DEFAULT_OPENAI_BETA = 'responses=experimental';
 
 function normalizeText(value) {
     return typeof value === 'string' ? value.trim() : '';
@@ -19,6 +23,36 @@ function normalizeText(value) {
 function normalizeProviderName(value) {
     // Provider name validation is done elsewhere; keep this conservative.
     return normalizeText(value);
+}
+
+function firstHeaderValue(req, name) {
+    if (!req || !req.headers || typeof req.headers !== 'object') return '';
+    const value = req.headers[String(name || '').toLowerCase()];
+    if (Array.isArray(value)) return typeof value[0] === 'string' ? value[0] : '';
+    return typeof value === 'string' ? value : '';
+}
+
+function resolveCodexUserAgent(req) {
+    const incoming = firstHeaderValue(req, 'user-agent').trim();
+    if (/^(codex_cli_rs|codex-cli)\//i.test(incoming)) return incoming;
+    return DEFAULT_CODEX_USER_AGENT;
+}
+
+function buildCodexBridgeHeaders(req, upstream, authHeader) {
+    const upstreamHeaders = upstream && upstream.headers && typeof upstream.headers === 'object' && !Array.isArray(upstream.headers)
+        ? upstream.headers
+        : {};
+    const version = firstHeaderValue(req, 'version').trim() || DEFAULT_CODEX_VERSION;
+    const openaiBeta = firstHeaderValue(req, 'openai-beta').trim() || DEFAULT_OPENAI_BETA;
+    const originator = firstHeaderValue(req, 'originator').trim() || DEFAULT_CODEX_ORIGINATOR;
+    return {
+        ...(authHeader ? { Authorization: authHeader } : {}),
+        ...upstreamHeaders,
+        'User-Agent': resolveCodexUserAgent(req),
+        'Version': version,
+        'OpenAI-Beta': openaiBeta,
+        'Originator': originator
+    };
 }
 
 function normalizeOpenaiUpstreamBaseUrl(rawValue) {
@@ -1533,6 +1567,160 @@ function streamChatCompletionsAsResponsesSse(targetUrl, options = {}) {
     });
 }
 
+function streamResponsesSse(targetUrl, options = {}) {
+    const parsed = new URL(targetUrl);
+    const transport = parsed.protocol === 'https:' ? https : http;
+    const bodyText = options.body ? JSON.stringify(options.body) : '';
+    const maxBytes = Number.isFinite(options.maxBytes) && options.maxBytes > 0
+        ? Math.floor(options.maxBytes)
+        : 0;
+    const headers = {
+        'Accept': 'text/event-stream',
+        ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+        ...(options.headers || {})
+    };
+    if (options.body) {
+        headers['Content-Length'] = Buffer.byteLength(bodyText, 'utf-8');
+    }
+    const timeoutMs = Number.isFinite(options.timeoutMs)
+        ? Math.max(1000, Number(options.timeoutMs))
+        : STREAM_IDLE_TIMEOUT_MS;
+    const res = options.res;
+
+    return new Promise((resolve) => {
+        let settled = false;
+        let upstreamReq = null;
+        let streamAccepted = false;
+        const finish = (value) => {
+            if (settled) return;
+            settled = true;
+            resolve(value);
+        };
+        const abortUpstream = () => {
+            if (upstreamReq) {
+                try { upstreamReq.destroy(new Error('client aborted')); } catch (_) {}
+            }
+        };
+        if (res && typeof res.once === 'function') {
+            res.once('close', abortUpstream);
+        }
+
+        upstreamReq = transport.request({
+            protocol: parsed.protocol,
+            hostname: parsed.hostname,
+            port: parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+            method: options.method || 'POST',
+            path: `${parsed.pathname}${parsed.search}`,
+            headers,
+            agent: parsed.protocol === 'https:' ? options.httpsAgent : options.httpAgent
+        }, (upstreamRes) => {
+            const status = upstreamRes.statusCode || 0;
+            const chunks = [];
+            let size = 0;
+            const contentType = String(upstreamRes.headers && upstreamRes.headers['content-type'] || '');
+            const collectChunk = (chunk) => {
+                if (!chunk) return true;
+                if (maxBytes > 0) {
+                    size += chunk.length;
+                    if (size > maxBytes) {
+                        chunks.length = 0;
+                        try { upstreamRes.destroy(new Error('response too large')); } catch (_) {}
+                        try { upstreamReq.destroy(new Error('response too large')); } catch (_) {}
+                        finish({ ok: false, status, error: 'response too large' });
+                        return false;
+                    }
+                }
+                chunks.push(chunk);
+                return true;
+            };
+            const bodyFromChunks = () => (chunks.length ? Buffer.concat(chunks).toString('utf-8') : '');
+
+            if (status === 404 || status === 405) {
+                upstreamRes.on('data', collectChunk);
+                upstreamRes.on('end', () => finish({ retry: true, status, bodyText: bodyFromChunks() }));
+                return;
+            }
+
+            if (status >= 400) {
+                upstreamRes.on('data', collectChunk);
+                upstreamRes.on('end', () => finish({ ok: false, status, bodyText: bodyFromChunks() }));
+                return;
+            }
+
+            if (/text\/event-stream/i.test(contentType)) {
+                streamAccepted = true;
+                upstreamReq.setTimeout(0);
+                if (!res.headersSent) {
+                    res.writeHead(200, {
+                        'Content-Type': 'text/event-stream; charset=utf-8',
+                        'Cache-Control': 'no-cache',
+                        'Connection': 'keep-alive',
+                        'X-Accel-Buffering': 'no'
+                    });
+                    if (typeof res.flushHeaders === 'function') res.flushHeaders();
+                }
+                upstreamRes.on('data', (chunk) => {
+                    if (chunk && !res.writableEnded && !res.destroyed) res.write(chunk);
+                });
+                upstreamRes.on('end', () => {
+                    if (!res.writableEnded && !res.destroyed) res.end();
+                    finish({ ok: true });
+                });
+                upstreamRes.on('aborted', () => {
+                    if (!res.writableEnded && !res.destroyed) {
+                        writeSse(res, 'response.failed', { type: 'response.failed', error: 'upstream stream aborted' });
+                        writeSse(res, 'done', '[DONE]');
+                        res.end();
+                    }
+                    finish({ ok: true });
+                });
+                upstreamRes.on('error', (err) => {
+                    if (!res.writableEnded && !res.destroyed) {
+                        writeSse(res, 'response.failed', { type: 'response.failed', error: err && err.message ? err.message : 'upstream stream failed' });
+                        writeSse(res, 'done', '[DONE]');
+                        res.end();
+                    }
+                    finish({ ok: true });
+                });
+                return;
+            }
+
+            upstreamRes.on('data', collectChunk);
+            upstreamRes.on('end', () => {
+                const text = bodyFromChunks();
+                const parsedJson = parseJsonOrError(text);
+                if (!res.headersSent) {
+                    res.writeHead(200, {
+                        'Content-Type': 'text/event-stream; charset=utf-8',
+                        'Cache-Control': 'no-cache',
+                        'Connection': 'keep-alive',
+                        'X-Accel-Buffering': 'no'
+                    });
+                    if (typeof res.flushHeaders === 'function') res.flushHeaders();
+                }
+                if (parsedJson.error) {
+                    writeSse(res, 'response.failed', { type: 'response.failed', error: `invalid upstream response: ${parsedJson.error}` });
+                    writeSse(res, 'done', '[DONE]');
+                    if (!res.writableEnded && !res.destroyed) res.end();
+                    finish({ ok: true });
+                    return;
+                }
+                sendResponsesSse(res, ensureResponseMetadata(parsedJson.value));
+                if (!res.writableEnded && !res.destroyed) res.end();
+                finish({ ok: true });
+            });
+        });
+        upstreamReq.setTimeout(timeoutMs, () => {
+            if (streamAccepted) return;
+            try { upstreamReq.destroy(new Error('timeout')); } catch (_) {}
+            finish({ ok: false, error: 'timeout' });
+        });
+        upstreamReq.on('error', (err) => finish({ ok: false, error: err && err.message ? err.message : 'request failed' }));
+        if (bodyText) upstreamReq.write(bodyText);
+        upstreamReq.end();
+    });
+}
+
 async function proxyRequestJson(targetUrl, options = {}) {
     const parsed = new URL(targetUrl);
     const transport = parsed.protocol === 'https:' ? https : http;
@@ -1618,6 +1806,9 @@ function createOpenaiBridgeHttpHandler(options = {}) {
     const maxUpstreamBytes = Number.isFinite(options.maxUpstreamBytes) && options.maxUpstreamBytes > 0
         ? Math.floor(options.maxUpstreamBytes)
         : Math.max(16 * 1024 * 1024, maxBodySize > 0 ? maxBodySize * 4 : 0);
+    const streamTimeoutMs = Number.isFinite(options.streamTimeoutMs) && options.streamTimeoutMs > 0
+        ? Math.floor(options.streamTimeoutMs)
+        : STREAM_IDLE_TIMEOUT_MS;
 
     if (!settingsFile) {
         throw new Error('createOpenaiBridgeHttpHandler 缺少 settingsFile');
@@ -1708,6 +1899,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
             const upstreamHeaders = upstream && upstream.headers && typeof upstream.headers === 'object' && !Array.isArray(upstream.headers)
                 ? upstream.headers
                 : {};
+            const codexHeaders = buildCodexBridgeHeaders(req, upstream, authHeader);
 
             if (!normalizedSuffix) {
                 if ((req.method || 'GET').toUpperCase() !== 'GET') {
@@ -1784,6 +1976,47 @@ function createOpenaiBridgeHttpHandler(options = {}) {
             const wantsSse = /text\/event-stream/i.test(String(acceptHeader || ''));
 
             if (streamRequested && wantsSse) {
+                const upstreamResponsesUrl = joinApiUrl(upstream.baseUrl, 'responses');
+                const skipResponsesProbe = isResponsesKnownUnsupported(upstream.baseUrl);
+                const streamedResponses = skipResponsesProbe
+                    ? { ok: false, status: 404, bodyText: '' }
+                    : await retryTransientRequest(() => streamResponsesSse(upstreamResponsesUrl, {
+                        method: 'POST',
+                        body: responsesRequest,
+                        headers: codexHeaders,
+                        timeoutMs: streamTimeoutMs,
+                        maxBytes: maxUpstreamBytes,
+                        httpAgent,
+                        httpsAgent,
+                        res
+                    }));
+
+                if (streamedResponses.ok) {
+                    clearResponsesUnsupported(upstream.baseUrl);
+                    return;
+                }
+
+                const canFallbackToChat = streamedResponses.status
+                    ? shouldFallbackFromUpstreamResponses(streamedResponses.status, streamedResponses.bodyText)
+                    : false;
+                if (!canFallbackToChat) {
+                    if (res.writableEnded || res.destroyed) return;
+                    const status = streamedResponses.status && streamedResponses.status >= 400 ? streamedResponses.status : 502;
+                    if (!res.headersSent) {
+                        res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+                        res.end(streamedResponses.bodyText || JSON.stringify({ error: streamedResponses.error || 'Upstream request failed' }));
+                    } else {
+                        writeSse(res, 'response.failed', { type: 'response.failed', error: streamedResponses.error || streamedResponses.bodyText || 'Upstream request failed' });
+                        writeSse(res, 'done', '[DONE]');
+                        res.end();
+                    }
+                    return;
+                }
+
+                if (!skipResponsesProbe && isResponsesEndpointUnsupported(streamedResponses.status, streamedResponses.bodyText)) {
+                    markResponsesUnsupported(upstream.baseUrl);
+                }
+
                 const converted = convertResponsesRequestToChatCompletions(responsesRequest);
                 if (converted.error) {
                     res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
@@ -1795,10 +2028,8 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                 const streamed = await retryTransientRequest(() => streamChatCompletionsAsResponsesSse(upstreamUrl, {
                     method: 'POST',
                     body: chatBody,
-                    headers: {
-                        ...(authHeader ? { Authorization: authHeader } : {}),
-                        ...upstreamHeaders
-                    },
+                    headers: codexHeaders,
+                    timeoutMs: streamTimeoutMs,
                     maxBytes: maxUpstreamBytes,
                     httpAgent,
                     httpsAgent,
@@ -1832,10 +2063,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                 : await retryTransientRequest(() => proxyRequestJson(upstreamResponsesUrl, {
                     method: 'POST',
                     body: toUpstreamNonStreamingResponsesPayload(responsesRequest),
-                    headers: {
-                        ...(authHeader ? { Authorization: authHeader } : {}),
-                        ...upstreamHeaders
-                    },
+                    headers: codexHeaders,
                     maxBytes: maxUpstreamBytes,
                     httpAgent,
                     httpsAgent
@@ -1897,10 +2125,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
             const upstreamResult = await retryTransientRequest(() => proxyRequestJson(upstreamUrl, {
                 method: 'POST',
                 body: converted.chat,
-                headers: {
-                    ...(authHeader ? { Authorization: authHeader } : {}),
-                    ...upstreamHeaders
-                },
+                headers: codexHeaders,
                 maxBytes: maxUpstreamBytes,
                 httpAgent,
                 httpsAgent

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -1597,9 +1597,14 @@ function streamResponsesSse(targetUrl, options = {}) {
         let settled = false;
         let upstreamReq = null;
         let streamAccepted = false;
+        let streamIdleTimer = null;
         const finish = (value) => {
             if (settled) return;
             settled = true;
+            if (streamIdleTimer) {
+                clearTimeout(streamIdleTimer);
+                streamIdleTimer = null;
+            }
             resolve(value);
         };
         const abortUpstream = () => {
@@ -1656,6 +1661,23 @@ function streamResponsesSse(targetUrl, options = {}) {
             if (/text\/event-stream/i.test(contentType)) {
                 streamAccepted = true;
                 upstreamReq.setTimeout(0);
+                const failAcceptedStream = (message) => {
+                    if (!res.writableEnded && !res.destroyed) {
+                        writeSse(res, 'response.failed', { type: 'response.failed', error: message });
+                        writeSse(res, 'done', '[DONE]');
+                        res.end();
+                    }
+                    try { upstreamRes.destroy(new Error(message)); } catch (_) {}
+                    try { upstreamReq.destroy(new Error(message)); } catch (_) {}
+                    finish({ ok: true });
+                };
+                const resetStreamIdleTimer = () => {
+                    if (streamIdleTimer) clearTimeout(streamIdleTimer);
+                    streamIdleTimer = setTimeout(() => {
+                        failAcceptedStream('upstream stream idle timeout');
+                    }, timeoutMs);
+                    if (typeof streamIdleTimer.unref === 'function') streamIdleTimer.unref();
+                };
                 if (!res.headersSent) {
                     res.writeHead(200, {
                         'Content-Type': 'text/event-stream; charset=utf-8',
@@ -1665,7 +1687,9 @@ function streamResponsesSse(targetUrl, options = {}) {
                     });
                     if (typeof res.flushHeaders === 'function') res.flushHeaders();
                 }
+                resetStreamIdleTimer();
                 upstreamRes.on('data', (chunk) => {
+                    resetStreamIdleTimer();
                     if (chunk && !res.writableEnded && !res.destroyed) res.write(chunk);
                 });
                 upstreamRes.on('end', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexmate",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexmate",
-      "version": "0.0.52",
+      "version": "0.0.53",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexmate",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "Codex/Claude Code/OpenClaw 配置、会话与任务编排 CLI + Web 工具",
   "main": "cli.js",
   "bin": {

--- a/tests/unit/builtin-proxy-responses-shim.test.mjs
+++ b/tests/unit/builtin-proxy-responses-shim.test.mjs
@@ -128,6 +128,46 @@ function createNestedNamespace(depth, leafTool) {
     return current;
 }
 
+test('builtin-proxy /v1/responses sends Codex client identity upstream', async () => {
+    let capturedHeaders = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            capturedHeaders = req.headers;
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ id: 'resp_test', model: 'gpt-5', output: [] }));
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+
+    let proxyRuntime;
+    try {
+        const { port: upstreamPort } = await listen(upstream);
+        proxyRuntime = await startTestProxy(upstreamPort);
+        const proxyPort = proxyRuntime.server.address().port;
+
+        const resp = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: { model: 'gpt-5', input: 'hello', stream: false }
+        });
+
+        assert.equal(resp.status, 200);
+        assert.ok(capturedHeaders, 'upstream should receive /v1/responses request');
+        assert.match(capturedHeaders['user-agent'] || '', /^codex_cli_rs\//);
+        assert.equal(capturedHeaders.version, '0.98.0');
+        assert.equal(capturedHeaders['openai-beta'], 'responses=experimental');
+        assert.equal(capturedHeaders.originator, 'codex_cli_rs');
+        assert.equal(capturedHeaders['x-codexmate-proxy'], '1');
+    } finally {
+        if (proxyRuntime) {
+            await closeServer(proxyRuntime.server, proxyRuntime.connections);
+        }
+        await closeServer(upstream);
+    }
+});
+
 test('builtin-proxy /v1/responses falls back to chat-only upstream and returns Responses JSON', async () => {
     const upstream = http.createServer((req, res) => {
         if (req.url === '/v1/responses' && req.method === 'POST') {
@@ -384,6 +424,7 @@ test('builtin-proxy /v1/responses falls back to chat when upstream responses tim
 
 test('builtin-proxy /v1/responses stream=true streams chat fallback as Responses SSE', async () => {
     let capturedChatRequest = null;
+    let capturedChatHeaders = null;
     const upstream = http.createServer((req, res) => {
         if (req.url === '/v1/responses' && req.method === 'POST') {
             res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -391,6 +432,7 @@ test('builtin-proxy /v1/responses stream=true streams chat fallback as Responses
             return;
         }
         if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            capturedChatHeaders = req.headers;
             const chunks = [];
             req.on('data', (chunk) => chunks.push(chunk));
             req.on('end', () => {
@@ -420,6 +462,10 @@ test('builtin-proxy /v1/responses stream=true streams chat fallback as Responses
         assert.equal(sse.status, 200);
         assert.ok(capturedChatRequest, 'streaming chat fallback should be called');
         assert.equal(capturedChatRequest.stream, true);
+        assert.match(capturedChatHeaders['user-agent'] || '', /^codex_cli_rs\//);
+        assert.equal(capturedChatHeaders.version, '0.98.0');
+        assert.equal(capturedChatHeaders['openai-beta'], 'responses=experimental');
+        assert.equal(capturedChatHeaders.originator, 'codex_cli_rs');
         assert.match(sse.headers['content-type'], /text\/event-stream/i);
         assert.match(sse.text, /event: response\.created/);
         assert.match(sse.text, /event: response\.output_text\.delta/);

--- a/tests/unit/builtin-proxy-responses-shim.test.mjs
+++ b/tests/unit/builtin-proxy-responses-shim.test.mjs
@@ -149,7 +149,7 @@ test('builtin-proxy /v1/responses sends Codex client identity upstream', async (
 
         const resp = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: { 'Content-Type': 'application/json', 'Originator': 'codex-tui' },
             body: { model: 'gpt-5', input: 'hello', stream: false }
         });
 

--- a/tests/unit/builtin-proxy-responses-shim.test.mjs
+++ b/tests/unit/builtin-proxy-responses-shim.test.mjs
@@ -481,27 +481,23 @@ test('builtin-proxy /v1/responses stream=true streams chat fallback as Responses
     }
 });
 
-test('builtin-proxy /v1/responses stream=true bypasses hanging upstream Responses probe for ordinary Codex tasks', async () => {
+test('builtin-proxy /v1/responses stream=true does not fallback to chat when upstream Responses hangs', async () => {
     let responsesHit = false;
-    let capturedChatRequest = null;
+    let chatHit = false;
+    let capturedResponsesHeaders = null;
     const upstream = http.createServer((req, res) => {
         if (req.url === '/v1/responses' && req.method === 'POST') {
             responsesHit = true;
-            // Simulate an OpenAI-compatible gateway that accepts /responses but never
-            // produces a usable body. Streaming Codex requests must not block here.
+            capturedResponsesHeaders = req.headers;
+            // A hanging Responses endpoint is not proof that Responses is unsupported.
+            // Falling back to chat/completions can route through non-Codex client paths
+            // and break Codex-only upstream groups.
             return;
         }
         if (req.url === '/v1/chat/completions' && req.method === 'POST') {
-            const chunks = [];
-            req.on('data', (chunk) => chunks.push(chunk));
-            req.on('end', () => {
-                capturedChatRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
-                res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
-                res.write('data: {"id":"chatcmpl_real_task","model":"gpt-test","choices":[{"delta":{"role":"assistant"}}]}\n\n');
-                res.write('data: {"id":"chatcmpl_real_task","model":"gpt-test","choices":[{"delta":{"content":"real"}}]}\n\n');
-                res.write('data: {"id":"chatcmpl_real_task","model":"gpt-test","choices":[{"delta":{"content":" task"}}]}\n\n');
-                res.end('data: [DONE]\n\n');
-            });
+            chatHit = true;
+            res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+            res.end('data: [DONE]\n\n');
             return;
         }
         res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -534,24 +530,16 @@ test('builtin-proxy /v1/responses stream=true bypasses hanging upstream Response
         });
         const elapsedMs = Date.now() - started;
 
-        assert.equal(sse.status, 200);
-        assert.equal(responsesHit, false, 'streaming Codex tasks should not probe hanging upstream /responses first');
-        assert.ok(elapsedMs < 900, `streaming fast path should not wait for upstream responses timeout; took ${elapsedMs}ms`);
-        assert.ok(capturedChatRequest, 'streaming request should be converted to chat/completions');
-        assert.deepStrictEqual(capturedChatRequest.messages, [
-            { role: 'system', content: 'You are Codex. Be concise.' },
-            { role: 'system', content: [{ type: 'text', text: 'follow repo rules' }] },
-            { role: 'user', content: [{ type: 'text', text: 'do a normal task' }] }
-        ]);
-        assert.equal(capturedChatRequest.stream, true);
-        assert.equal(capturedChatRequest.max_tokens, 512);
-        assert.equal(capturedChatRequest.temperature, 0.2);
-        assert.match(sse.headers['content-type'], /text\/event-stream/i);
-        assert.match(sse.text, /event: response\.created/);
-        assert.match(sse.text, /"delta":"real"/);
-        assert.match(sse.text, /"delta":" task"/);
-        assert.match(sse.text, /event: response\.completed/);
-        assert.match(sse.text, /data: \[DONE\]/);
+        assert.equal(sse.status, 502);
+        assert.equal(responsesHit, true, 'streaming Codex tasks should probe upstream /responses first');
+        assert.match(capturedResponsesHeaders['user-agent'] || '', /^codex_cli_rs\//);
+        assert.equal(capturedResponsesHeaders.version, '0.98.0');
+        assert.equal(capturedResponsesHeaders['openai-beta'], 'responses=experimental');
+        assert.equal(capturedResponsesHeaders.originator, 'codex_cli_rs');
+        assert.equal(chatHit, false, 'hanging Responses must not fallback to chat/completions');
+        assert.ok(elapsedMs >= 900, `proxy should wait for the upstream Responses timeout; took ${elapsedMs}ms`);
+        assert.match(sse.headers['content-type'], /application\/json/i);
+        assert.match(sse.text, /timeout/);
     } finally {
         if (proxyRuntime) {
             await closeServer(proxyRuntime.server, proxyRuntime.connections);

--- a/tests/unit/claude-settings-sync.test.mjs
+++ b/tests/unit/claude-settings-sync.test.mjs
@@ -238,7 +238,7 @@ test('buildClaudeImportedConfigName derives host-based fallback name', () => {
 });
 
 
-test('addClaudeConfig requires a visible model value before saving', () => {
+test('addClaudeConfig requires a visible model value before saving', async () => {
     const source = extractClaudeMethodAsFunction(appSource, 'addClaudeConfig');
     const addClaudeConfig = instantiateFunction(source, 'addClaudeConfig');
     const messages = [];
@@ -263,7 +263,7 @@ test('addClaudeConfig requires a visible model value before saving', () => {
         refreshClaudeModelContext() {}
     };
 
-    addClaudeConfig.call(context);
+    await addClaudeConfig.call(context);
 
     assert.deepStrictEqual(messages, [{ text: '模型名称必填', type: 'error' }]);
     assert.deepStrictEqual(context.claudeConfigs, {});
@@ -406,13 +406,13 @@ test('openEditConfigModal carries external credential metadata into edit validat
     assert.strictEqual(context.showEditConfigModal, true);
 });
 
-test('addClaudeConfig trims and persists the entered model', () => {
+test('addClaudeConfig trims, persists, and applies the entered model', async () => {
     const source = extractClaudeMethodAsFunction(appSource, 'addClaudeConfig');
     const addClaudeConfig = instantiateFunction(source, 'addClaudeConfig');
     const messages = [];
     let saveCount = 0;
     let closed = false;
-    let refreshed = false;
+    const applied = [];
     const i18nMethods = createI18nMethods();
     const context = {
         ...i18nMethods,
@@ -430,17 +430,17 @@ test('addClaudeConfig trims and persists the entered model', () => {
         mergeClaudeConfig: (_, cfg) => ({ ...cfg }),
         saveClaudeConfigs() { saveCount += 1; },
         closeClaudeConfigModal() { closed = true; },
-        refreshClaudeModelContext() { refreshed = true; }
+        async applyClaudeConfig(name) { applied.push(name); }
     };
 
-    addClaudeConfig.call(context);
+    await addClaudeConfig.call(context);
 
     assert.strictEqual(context.currentClaudeConfig, 'Claude Test');
     assert.strictEqual(context.claudeConfigs['Claude Test'].model, 'claude-test-model');
     assert.strictEqual(saveCount, 1);
     assert.strictEqual(closed, true);
-    assert.strictEqual(refreshed, true);
-    assert.deepStrictEqual(messages, [{ text: '操作成功', type: 'success' }]);
+    assert.deepStrictEqual(applied, ['Claude Test']);
+    assert.deepStrictEqual(messages, []);
 });
 
 test('ensureClaudeConfigFromSettings creates imported config for unmatched Claude settings', () => {

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -144,7 +144,8 @@ test('openai-bridge keeps streaming Codex requests on upstream Responses before 
         headers: {
             'Content-Type': 'application/json',
             'Accept': 'text/event-stream',
-            'Authorization': 'Bearer codexmate'
+            'Authorization': 'Bearer codexmate',
+            'Originator': 'codex-tui'
         },
         body: {
             model: 'gpt-test',
@@ -215,7 +216,8 @@ test('openai-bridge streams upstream Responses SSE with Codex identity headers',
         headers: {
             'Content-Type': 'application/json',
             'Accept': 'text/event-stream',
-            'Authorization': 'Bearer codexmate'
+            'Authorization': 'Bearer codexmate',
+            'Originator': 'codex-tui'
         },
         body: { model: 'gpt-test', input: 'ping', stream: true }
     });

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -92,31 +92,99 @@ test('openai-bridge GET /v1 returns local bridge status without probing upstream
     await rm(tmpDir, { recursive: true, force: true });
 });
 
-test('openai-bridge streams chat/completions directly when Responses client requests SSE', async () => {
+test('openai-bridge keeps streaming Codex requests on upstream Responses before chat fallback', async () => {
     let responsesHit = false;
-    let capturedChatRequest = null;
+    let chatHit = false;
+    let capturedResponsesHeaders = null;
     const upstream = http.createServer((req, res) => {
         if (req.url === '/v1/responses' && req.method === 'POST') {
             responsesHit = true;
-            // Simulate gateways that accept /responses but never produce a usable response.
+            capturedResponsesHeaders = req.headers;
+            // A hanging Responses endpoint is not proof that Responses is unsupported.
+            // Do not silently route Codex-only requests into chat/completions.
             return;
         }
         if (req.url === '/v1/chat/completions' && req.method === 'POST') {
-            let body = '';
-            req.on('data', (c) => (body += c));
-            req.on('end', () => {
-                capturedChatRequest = JSON.parse(body || '{}');
-                res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
-                res.write('data: {"id":"chatcmpl_stream","model":"gpt-test","choices":[{"delta":{"role":"assistant"}}]}\n\n');
-                res.write('data: {"id":"chatcmpl_stream","model":"gpt-test","choices":[{"delta":{"content":"hello"}}]}\n\n');
-                res.write('data: {"id":"chatcmpl_stream","model":"gpt-test","choices":[{"delta":{"content":"-bridge"}}]}\n\n');
-                res.end('data: [DONE]\n\n');
-            });
+            chatHit = true;
+            res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+            res.end('data: [DONE]\n\n');
             return;
         }
         if (req.url === '/v1/models' && req.method === 'GET') {
             res.writeHead(200, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ object: 'list', data: [] }));
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate', streamTimeoutMs: 1000 });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const base = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
+    const sse = await requestText(base, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream',
+            'Authorization': 'Bearer codexmate'
+        },
+        body: {
+            model: 'gpt-test',
+            input: 'ping',
+            stream: true
+        }
+    });
+    assert.equal(sse.status, 502);
+    assert.equal(responsesHit, true, 'streaming bridge should call upstream /responses first');
+    assert.equal(chatHit, false, 'hanging Responses should not fall back to chat/completions');
+    assert.match(capturedResponsesHeaders['user-agent'] || '', /^codex_cli_rs\//);
+    assert.equal(capturedResponsesHeaders.version, '0.98.0');
+    assert.equal(capturedResponsesHeaders['openai-beta'], 'responses=experimental');
+    assert.equal(capturedResponsesHeaders.originator, 'codex_cli_rs');
+    assert.match(sse.headers['content-type'], /application\/json/i);
+    assert.match(sse.text, /timeout/);
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});
+
+test('openai-bridge streams upstream Responses SSE with Codex identity headers', async () => {
+    let capturedResponsesHeaders = null;
+    let chatHit = false;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            capturedResponsesHeaders = req.headers;
+            res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+            res.write('event: response.created\n');
+            res.write('data: {"type":"response.created","response":{"id":"resp_test","model":"gpt-test"}}\n\n');
+            res.write('event: response.completed\n');
+            res.write('data: {"type":"response.completed","response":{"id":"resp_test","model":"gpt-test","output":[]}}\n\n');
+            res.end('data: [DONE]\n\n');
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            chatHit = true;
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true }));
             return;
         }
         res.writeHead(404, { 'Content-Type': 'application/json' });
@@ -142,31 +210,26 @@ test('openai-bridge streams chat/completions directly when Responses client requ
     });
     const { port: bridgePort } = await listen(bridge);
 
-    const base = `http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`;
-    const sse = await requestText(base, {
+    const sse = await requestText(`http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
             'Accept': 'text/event-stream',
             'Authorization': 'Bearer codexmate'
         },
-        body: {
-            model: 'gpt-test',
-            input: 'ping',
-            stream: true
-        }
+        body: { model: 'gpt-test', input: 'ping', stream: true }
     });
+
     assert.equal(sse.status, 200);
-    assert.equal(responsesHit, false, 'streaming bridge should not block on upstream /responses probe');
-    assert.ok(capturedChatRequest, 'streaming bridge should call upstream chat/completions');
-    assert.equal(capturedChatRequest.stream, true);
+    assert.equal(chatHit, false, 'successful upstream Responses stream should not call chat/completions');
+    assert.ok(capturedResponsesHeaders, 'upstream Responses request should be captured');
+    assert.match(capturedResponsesHeaders['user-agent'] || '', /^codex_cli_rs\//);
+    assert.equal(capturedResponsesHeaders.version, '0.98.0');
+    assert.equal(capturedResponsesHeaders['openai-beta'], 'responses=experimental');
+    assert.equal(capturedResponsesHeaders.originator, 'codex_cli_rs');
     assert.match(sse.headers['content-type'], /text\/event-stream/i);
-    assert.match(sse.text, /response\.output_item\.added/);
-    assert.match(sse.text, /response\.output_text\.delta/);
-    assert.match(sse.text, /"delta":"hello"/);
-    assert.match(sse.text, /"delta":"-bridge"/);
-    assert.match(sse.text, /event: response\.completed/);
-    assert.match(sse.text, /data: \[DONE\]/);
+    assert.match(sse.text, /response\.created/);
+    assert.match(sse.text, /response\.completed/);
 
     await bridge.close();
     await upstream.close();

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -238,6 +238,69 @@ test('openai-bridge streams upstream Responses SSE with Codex identity headers',
     await rm(tmpDir, { recursive: true, force: true });
 });
 
+test('openai-bridge fails accepted upstream Responses SSE when stream goes idle', async () => {
+    let responsesHit = false;
+    let chatHit = false;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            responsesHit = true;
+            res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+            if (typeof res.flushHeaders === 'function') res.flushHeaders();
+            // Keep the connection open without data; the bridge must not hang forever.
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            chatHit = true;
+            res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+            res.end('data: [DONE]\n\n');
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: '***' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate', streamTimeoutMs: 1000 });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const sse = await requestText(`http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'text/event-stream',
+            'Authorization': 'Bearer codexmate'
+        },
+        body: { model: 'gpt-test', input: 'ping', stream: true }
+    });
+
+    assert.equal(sse.status, 200);
+    assert.equal(responsesHit, true, 'upstream Responses SSE should be attempted');
+    assert.equal(chatHit, false, 'accepted but idle Responses SSE should not fall back to chat/completions');
+    assert.match(sse.headers['content-type'], /text\/event-stream/i);
+    assert.match(sse.text, /response\.failed/);
+    assert.match(sse.text, /upstream stream idle timeout/);
+    assert.match(sse.text, /data: \[DONE\]/);
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
+});
+
 test('openai-bridge omits upstream reasoning_content from output_text deltas', async () => {
     const upstream = http.createServer((req, res) => {
         if (req.url === '/v1/chat/completions' && req.method === 'POST') {

--- a/web-ui/modules/app.methods.claude-config.mjs
+++ b/web-ui/modules/app.methods.claude-config.mjs
@@ -231,7 +231,7 @@ export function createClaudeConfigMethods(options = {}) {
             }
         },
 
-        addClaudeConfig() {
+        async addClaudeConfig() {
             const validation = getClaudeConfigValidationForContext(this, 'add');
             if (!validation.ok) {
                 return this.showMessage(validation.errors.name || validation.errors.apiKey || validation.errors.baseUrl || validation.errors.model || this.t('toast.claude.checkConfig'), 'error');
@@ -252,9 +252,8 @@ export function createClaudeConfigMethods(options = {}) {
 
             this.currentClaudeConfig = name;
             this.saveClaudeConfigs();
-            this.showMessage(this.t('toast.operation.success'), 'success');
             this.closeClaudeConfigModal();
-            this.refreshClaudeModelContext();
+            await this.applyClaudeConfig(name);
         },
 
         async deleteClaudeConfig(name) {


### PR DESCRIPTION
## Summary
- apply newly added Claude configs through the same `applyClaudeConfig(name)` path used by manual selection
- keep the UI-selected Claude config and the persisted Claude settings in sync after adding a provider
- preserve Codex client identity headers across both builtin proxy and `--bridge openai` upstream requests
- keep streaming Codex `/v1/responses` requests on upstream Responses first, only falling back to `/chat/completions` when Responses is explicitly unsupported
- normalize upstream Codex `Originator` to `codex_cli_rs` even when the local TUI sends `codex-tui`, matching Codex-only upstream gates
- add an idle timeout for accepted upstream Responses SSE streams so a headers-only stalled stream fails instead of hanging forever
- document that the built-in Codex conversion attaches/normalizes Codex fingerprint headers in both English and Chinese READMEs
- bump the package version to `0.0.53` and update git tag `v0.0.53` to point at PR head `d1223be4eb12704974d5822b840e42dfa16d09aa`

## Validation
- `node --input-type=module ...` targeted harness for `tests/unit/claude-settings-sync.test.mjs` → 34 tests passed
- `node --test tests/unit/builtin-proxy-responses-shim.test.mjs` → 18 tests passed
- `node --test tests/unit/openai-bridge-upstream-responses.test.mjs` → 23 tests passed
- `npm run lint` → passed for 220 files
- `npm run test:unit` → 661 tests passed
- README update inspected with `grep` for the new Codex fingerprint wording
- version update inspected with `grep` for no remaining `0.0.52` / `v0.0.52` matches outside dependencies/git metadata

## Notes
- `npm ci` reported existing dependency audit warnings before validation; no dependency changes were made.
- Some `npm run test:unit` runs emit the existing `search_sessions.py --limit -1` usage message at the end while exiting 0.
- The reported Codex-only group failures first lacked Codex identity (`Go-http-client/1.1`), then failed on `Originator: codex-tui`; the latest code normalizes the upstream Codex originator while preserving the Responses-first streaming behavior.