### PR TITLE
fix(responses): align chat fallback and bump version to 0.0.54

### DIFF
--- a/cli/builtin-proxy.js
+++ b/cli/builtin-proxy.js
@@ -940,7 +940,6 @@ function createBuiltinProxyRuntimeController(deps = {}) {
             'n',
             'modalities',
             'audio',
-            'reasoning',
             'reasoning_effort',
             'service_tier'
         ];
@@ -964,16 +963,33 @@ function createBuiltinProxyRuntimeController(deps = {}) {
         if (isRecord(source.text) && asTrimmedString(source.text.verbosity)) {
             chatBody.verbosity = asTrimmedString(source.text.verbosity);
         }
+        if (isRecord(source.reasoning) && asTrimmedString(source.reasoning.effort)) {
+            chatBody.reasoning_effort = asTrimmedString(source.reasoning.effort);
+        }
 
         pruneInvalidChatToolChoice(chatBody);
 
-        if (Object.prototype.hasOwnProperty.call(source, 'max_tokens')) {
+        if (Object.prototype.hasOwnProperty.call(source, 'max_completion_tokens')) {
+            chatBody.max_tokens = Math.max(128, Number(source.max_completion_tokens) || 0);
+        } else if (Object.prototype.hasOwnProperty.call(source, 'max_tokens')) {
             chatBody.max_tokens = source.max_tokens;
         } else if (source.max_output_tokens != null) {
             chatBody.max_tokens = source.max_output_tokens;
         }
 
         return chatBody;
+    }
+
+    function normalizeResponsesPayloadForUpstream(payload, stream) {
+        const source = isRecord(payload) ? payload : {};
+        const normalized = { ...source, stream };
+        if (isRecord(source.reasoning)) {
+            const include = Array.isArray(source.include) ? source.include.filter((item) => typeof item === 'string') : [];
+            if (!include.includes('reasoning.encrypted_content')) {
+                normalized.include = [...include, 'reasoning.encrypted_content'];
+            }
+        }
+        return normalized;
     }
 
     function ensureResponseMetadata(payload) {
@@ -999,6 +1015,112 @@ function createBuiltinProxyRuntimeController(deps = {}) {
             return;
         }
         res.write(`data: ${JSON.stringify(dataObj)}\n\n`);
+    }
+
+    function buildResponsesSseItem(item, fallbackId) {
+        const source = isRecord(item) ? item : {};
+        const itemId = asTrimmedString(source.id || source.call_id) || fallbackId || `item_${crypto.randomBytes(8).toString('hex')}`;
+        if (source.type === 'message') {
+            return {
+                ...source,
+                id: itemId,
+                role: source.role || 'assistant',
+                content: Array.isArray(source.content)
+                    ? source.content.map((part) => {
+                        if (!isRecord(part)) return part;
+                        if (part.type !== 'output_text') return cloneJsonValue(part);
+                        return {
+                            ...part,
+                            text: typeof part.text === 'string' ? part.text : '',
+                            annotations: Array.isArray(part.annotations) ? part.annotations : [],
+                            logprobs: Array.isArray(part.logprobs) ? part.logprobs : []
+                        };
+                    })
+                    : []
+            };
+        }
+        if (source.type === 'reasoning') {
+            return {
+                ...source,
+                id: itemId,
+                summary: Array.isArray(source.summary) ? source.summary : []
+            };
+        }
+        if (source.type === 'function_call') {
+            return {
+                ...source,
+                id: itemId,
+                call_id: asTrimmedString(source.call_id) || itemId,
+                name: asTrimmedString(source.name),
+                arguments: typeof source.arguments === 'string' ? source.arguments : ''
+            };
+        }
+        if (source.type === 'custom_tool_call') {
+            return {
+                ...source,
+                id: itemId,
+                call_id: asTrimmedString(source.call_id) || itemId,
+                name: asTrimmedString(source.name),
+                input: typeof source.input === 'string' ? source.input : ''
+            };
+        }
+        return { ...source, id: itemId };
+    }
+
+    function emitResponsesTextPartAdded(res, itemId, outputIndex, contentIndex, nextSeq) {
+        writeSse(res, 'response.content_part.added', {
+            type: 'response.content_part.added',
+            item_id: itemId,
+            output_index: outputIndex,
+            content_index: contentIndex,
+            part: { type: 'output_text', text: '', annotations: [], logprobs: [] },
+            sequence_number: nextSeq()
+        });
+    }
+
+    function emitResponsesTextPartDone(res, itemId, outputIndex, contentIndex, text, nextSeq) {
+        writeSse(res, 'response.content_part.done', {
+            type: 'response.content_part.done',
+            item_id: itemId,
+            output_index: outputIndex,
+            content_index: contentIndex,
+            part: { type: 'output_text', text: typeof text === 'string' ? text : '', annotations: [], logprobs: [] },
+            sequence_number: nextSeq()
+        });
+    }
+
+    function emitResponsesToolArgumentEvents(res, item, outputIndex, nextSeq) {
+        const eventType = item.type === 'custom_tool_call'
+            ? 'response.custom_tool_call_input.delta'
+            : 'response.function_call_arguments.delta';
+        const doneType = item.type === 'custom_tool_call'
+            ? ''
+            : 'response.function_call_arguments.done';
+        const value = item.type === 'custom_tool_call'
+            ? (typeof item.input === 'string' ? item.input : '')
+            : (typeof item.arguments === 'string' ? item.arguments : '');
+        if (value) {
+            writeSse(res, eventType, {
+                type: eventType,
+                item_id: item.id,
+                output_index: outputIndex,
+                call_id: item.call_id,
+                name: item.name,
+                delta: value,
+                sequence_number: nextSeq()
+            });
+        }
+        if (doneType) {
+            writeSse(res, doneType, {
+                type: doneType,
+                item_id: item.id,
+                output_index: outputIndex,
+                call_id: item.call_id,
+                name: item.name,
+                arguments: value,
+                sequence_number: nextSeq()
+            });
+        }
     }
 
     function sendResponsesSse(res, responsePayload) {
@@ -1027,12 +1149,14 @@ function createBuiltinProxyRuntimeController(deps = {}) {
             const itemType = typeof item.type === 'string' ? item.type : '';
             const itemId = typeof item.id === 'string' && item.id.trim()
                 ? item.id.trim()
-                : `item_${crypto.randomBytes(8).toString('hex')}`;
+                : (typeof item.call_id === 'string' && item.call_id.trim() ? item.call_id.trim() : `item_${crypto.randomBytes(8).toString('hex')}`);
+            const wireItem = buildResponsesSseItem(item, itemId);
 
             writeSse(res, 'response.output_item.added', {
                 type: 'response.output_item.added',
                 output_index: outputIndex,
-                item: { ...item, id: itemId }
+                item: wireItem,
+                sequence_number: nextSeq()
             });
 
             if (itemType === 'message') {
@@ -1042,6 +1166,7 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                     if (!block || typeof block !== 'object') continue;
                     if (block.type !== 'output_text') continue;
                     const text = typeof block.text === 'string' ? block.text : '';
+                    emitResponsesTextPartAdded(res, itemId, outputIndex, contentIndex, nextSeq);
                     if (text) {
                         writeSse(res, 'response.output_text.delta', {
                             type: 'response.output_text.delta',
@@ -1060,13 +1185,40 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                         text,
                         sequence_number: nextSeq()
                     });
+                    emitResponsesTextPartDone(res, itemId, outputIndex, contentIndex, text, nextSeq);
+                }
+            } else if (itemType === 'function_call' || itemType === 'custom_tool_call') {
+                emitResponsesToolArgumentEvents(res, wireItem, outputIndex, nextSeq);
+            } else if (itemType === 'reasoning') {
+                const summary = Array.isArray(item.summary) ? item.summary : [];
+                for (let summaryIndex = 0; summaryIndex < summary.length; summaryIndex += 1) {
+                    const block = summary[summaryIndex];
+                    const text = block && typeof block.text === 'string' ? block.text : '';
+                    if (text) {
+                        writeSse(res, 'response.reasoning_summary_text.delta', {
+                            type: 'response.reasoning_summary_text.delta',
+                            item_id: itemId,
+                            output_index: outputIndex,
+                            summary_index: summaryIndex,
+                            delta: text,
+                            sequence_number: nextSeq()
+                        });
+                    }
+                    writeSse(res, 'response.reasoning_summary_text.done', {
+                        type: 'response.reasoning_summary_text.done',
+                        item_id: itemId,
+                        output_index: outputIndex,
+                        summary_index: summaryIndex,
+                        text,
+                        sequence_number: nextSeq()
+                    });
                 }
             }
 
             writeSse(res, 'response.output_item.done', {
                 type: 'response.output_item.done',
                 output_index: outputIndex,
-                item: { ...item, id: itemId },
+                item: wireItem,
                 sequence_number: nextSeq()
             });
         }
@@ -1105,6 +1257,40 @@ function createBuiltinProxyRuntimeController(deps = {}) {
             const delta = choice && choice.delta && typeof choice.delta === 'object' ? choice.delta : null;
             if (!delta) continue;
 
+            const reasoningSegment = typeof delta.reasoning_content === 'string'
+                ? delta.reasoning_content
+                : (typeof delta.reasoning === 'string'
+                    ? delta.reasoning
+                    : (typeof delta.reasoning_text === 'string' ? delta.reasoning_text : ''));
+            if (reasoningSegment) {
+                if (!state.reasoningItem) {
+                    state.reasoningItem = {
+                        id: `rs_${crypto.randomBytes(8).toString('hex')}`,
+                        type: 'reasoning',
+                        summary: [{ type: 'summary_text', text: '' }]
+                    };
+                    state.output.push(state.reasoningItem);
+                    state.outputStarted = true;
+                    beginChatStreamResponsesSse(state);
+                    writeSse(state.res, 'response.output_item.added', {
+                        type: 'response.output_item.added',
+                        output_index: state.output.length - 1,
+                        item: buildResponsesSseItem(state.reasoningItem, state.reasoningItem.id),
+                        sequence_number: state.nextSeq()
+                    });
+                }
+                state.reasoningText += reasoningSegment;
+                state.reasoningItem.summary[0].text = state.reasoningText;
+                writeSse(state.res, 'response.reasoning_summary_text.delta', {
+                    type: 'response.reasoning_summary_text.delta',
+                    item_id: state.reasoningItem.id,
+                    output_index: state.output.indexOf(state.reasoningItem),
+                    summary_index: 0,
+                    delta: reasoningSegment,
+                    sequence_number: state.nextSeq()
+                });
+            }
+
             if (typeof delta.content === 'string' && delta.content) {
                 if (!state.messageItem) {
                     state.messageItem = {
@@ -1119,8 +1305,10 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                     writeSse(state.res, 'response.output_item.added', {
                         type: 'response.output_item.added',
                         output_index: state.output.length - 1,
-                        item: state.messageItem
+                        item: buildResponsesSseItem(state.messageItem, state.messageItem.id),
+                        sequence_number: state.nextSeq()
                     });
+                    emitResponsesTextPartAdded(state.res, state.messageItem.id, state.output.length - 1, 0, state.nextSeq);
                 }
                 state.messageText += delta.content;
                 state.messageItem.content[0].text = state.messageText;
@@ -1172,6 +1360,24 @@ function createBuiltinProxyRuntimeController(deps = {}) {
         state.finished = true;
         stopChatStreamHeartbeat(state);
 
+        if (state.reasoningItem) {
+            const outputIndex = state.output.indexOf(state.reasoningItem);
+            writeSse(state.res, 'response.reasoning_summary_text.done', {
+                type: 'response.reasoning_summary_text.done',
+                item_id: state.reasoningItem.id,
+                output_index: outputIndex,
+                summary_index: 0,
+                text: state.reasoningText,
+                sequence_number: state.nextSeq()
+            });
+            writeSse(state.res, 'response.output_item.done', {
+                type: 'response.output_item.done',
+                output_index: outputIndex,
+                item: buildResponsesSseItem(state.reasoningItem, state.reasoningItem.id),
+                sequence_number: state.nextSeq()
+            });
+        }
+
         if (state.messageItem) {
             const outputIndex = state.output.indexOf(state.messageItem);
             writeSse(state.res, 'response.output_text.done', {
@@ -1182,10 +1388,11 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                 text: state.messageText,
                 sequence_number: state.nextSeq()
             });
+            emitResponsesTextPartDone(state.res, state.messageItem.id, outputIndex, 0, state.messageText, state.nextSeq);
             writeSse(state.res, 'response.output_item.done', {
                 type: 'response.output_item.done',
                 output_index: outputIndex,
-                item: state.messageItem,
+                item: buildResponsesSseItem(state.messageItem, state.messageItem.id),
                 sequence_number: state.nextSeq()
             });
         }
@@ -1200,12 +1407,14 @@ function createBuiltinProxyRuntimeController(deps = {}) {
             writeSse(state.res, 'response.output_item.added', {
                 type: 'response.output_item.added',
                 output_index: outputIndex,
-                item
+                item: buildResponsesSseItem(item, item.call_id),
+                sequence_number: state.nextSeq()
             });
+            emitResponsesToolArgumentEvents(state.res, buildResponsesSseItem(item, item.call_id), outputIndex, state.nextSeq);
             writeSse(state.res, 'response.output_item.done', {
                 type: 'response.output_item.done',
                 output_index: outputIndex,
-                item,
+                item: buildResponsesSseItem(item, item.call_id),
                 sequence_number: state.nextSeq()
             });
         }
@@ -1282,6 +1491,8 @@ function createBuiltinProxyRuntimeController(deps = {}) {
             output: [],
             messageItem: null,
             messageText: '',
+            reasoningItem: null,
+            reasoningText: '',
             toolCalls: [],
             toolTypesByName: options.toolTypesByName || {},
             finished: false,
@@ -1983,7 +2194,7 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                             method: 'POST',
                             headers: commonHeaders,
                             timeoutMs,
-                            body: { ...payload, stream: true },
+                            body: normalizeResponsesPayloadForUpstream(payload, true),
                             res,
                             model
                         });
@@ -2031,7 +2242,7 @@ function createBuiltinProxyRuntimeController(deps = {}) {
                         method: 'POST',
                         headers: commonHeaders,
                         timeoutMs,
-                        body: { ...payload, stream: false }
+                        body: normalizeResponsesPayloadForUpstream(payload, false)
                     });
 
                     // 优先走上游 /responses（如果支持）。若上游报错且不是“端点不支持”，则直接透传错误。

--- a/cli/openai-bridge.js
+++ b/cli/openai-bridge.js
@@ -300,9 +300,28 @@ function cloneJsonValue(value) {
 }
 
 function normalizeResponsesToolOutput(value) {
-    if (typeof value === 'string') return value;
-    if (value == null) return '';
-    return stringifyJsonValue(value, '');
+    if (typeof value === 'string') return value || '(empty)';
+    if (value == null) return '(empty)';
+    return stringifyJsonValue(value, '(empty)') || '(empty)';
+}
+
+function chatContentToPlainText(content) {
+    if (typeof content === 'string') return content;
+    if (!Array.isArray(content)) return '';
+    return content
+        .map((item) => {
+            if (typeof item === 'string') return item;
+            if (!isRecord(item)) return '';
+            if (typeof item.text === 'string') return item.text;
+            if (typeof item.content === 'string') return item.content;
+            return '';
+        })
+        .join('');
+}
+
+function wrapReasoningContentForChat(content) {
+    const text = chatContentToPlainText(content).trim();
+    return text ? `<thinking>${text}</thinking>` : '';
 }
 
 function normalizeOpenAiToolArguments(value) {
@@ -530,7 +549,7 @@ function normalizeResponsesInputToChatMessages(input) {
 
         if (itemType === 'reasoning') {
             flushPendingToolCalls();
-            const reasoningContent = toOpenAiMessageContent(item.summary != null ? item.summary : (item.content != null ? item.content : item));
+            const reasoningContent = wrapReasoningContentForChat(toOpenAiMessageContent(item.summary != null ? item.summary : (item.content != null ? item.content : item)));
             const reasoningSignature = asTrimmedString(item.encrypted_content || item.reasoning_signature);
             if (!hasOpenAiMessageContent(reasoningContent) && !reasoningSignature) return;
             const message = { role: 'assistant', content: reasoningContent };
@@ -889,6 +908,12 @@ function convertResponsesRequestToChatCompletions(payload) {
         top_p: Number.isFinite(body.top_p) ? Number(body.top_p) : undefined,
         max_tokens: Number.isFinite(maxOutputTokens) && maxOutputTokens > 0 ? maxOutputTokens : undefined
     };
+    if (isRecord(body.reasoning)) {
+        const effort = asTrimmedString(body.reasoning.effort);
+        if (effort) chat.reasoning_effort = effort;
+    } else if (asTrimmedString(body.reasoning_effort)) {
+        chat.reasoning_effort = asTrimmedString(body.reasoning_effort);
+    }
     if (Array.isArray(body.stop) && body.stop.length) {
         chat.stop = body.stop.filter((item) => typeof item === 'string' && item.trim());
     }
@@ -940,12 +965,22 @@ function buildResponsesPayloadFromChatResult(model, text, toolCalls, upstreamPay
         }
     }
 
+    const choice = upstreamPayload && typeof upstreamPayload === 'object' && Array.isArray(upstreamPayload.choices)
+        ? upstreamPayload.choices[0]
+        : null;
+    const finishReason = choice && typeof choice.finish_reason === 'string' ? choice.finish_reason : '';
+    const statusPatch = finishReason === 'length'
+        ? { status: 'incomplete', incomplete_details: { reason: 'max_output_tokens' } }
+        : (finishReason === 'content_filter'
+            ? { status: 'incomplete', incomplete_details: { reason: 'content_filter' } }
+            : { status: 'completed' });
+
     const payload = {
         id: responseId,
         object: 'response',
         model,
         created_at: createdAt,
-        status: 'completed',
+        ...statusPatch,
         output,
         output_text: trimmedText
     };
@@ -1017,12 +1052,14 @@ function sendResponsesSse(res, responsePayload) {
         const itemId = typeof item.id === 'string' && item.id.trim()
             ? item.id.trim()
             : (typeof item.call_id === 'string' && item.call_id.trim() ? item.call_id.trim() : `item_${crypto.randomBytes(8).toString('hex')}`);
+        const wireItem = buildResponsesSseItem(item, itemId);
 
         // Emit item added so Codex can anchor subsequent deltas by output_index/content_index/item_id.
         writeSse(res, 'response.output_item.added', {
             type: 'response.output_item.added',
             output_index: outputIndex,
-            item: { ...item, id: itemId }
+            item: wireItem,
+            sequence_number: nextSeq()
         });
 
         if (itemType === 'message') {
@@ -1032,6 +1069,7 @@ function sendResponsesSse(res, responsePayload) {
                 if (!block || typeof block !== 'object') continue;
                 if (block.type !== 'output_text') continue;
                 const text = typeof block.text === 'string' ? block.text : '';
+                emitResponsesTextPartAdded(res, itemId, outputIndex, contentIndex, nextSeq);
                 if (text) {
                     writeSse(res, 'response.output_text.delta', {
                         type: 'response.output_text.delta',
@@ -1050,6 +1088,33 @@ function sendResponsesSse(res, responsePayload) {
                     text,
                     sequence_number: nextSeq()
                 });
+                emitResponsesTextPartDone(res, itemId, outputIndex, contentIndex, text, nextSeq);
+            }
+        } else if (itemType === 'function_call' || itemType === 'custom_tool_call') {
+            emitResponsesToolArgumentEvents(res, wireItem, outputIndex, nextSeq);
+        } else if (itemType === 'reasoning') {
+            const summary = Array.isArray(item.summary) ? item.summary : [];
+            for (let summaryIndex = 0; summaryIndex < summary.length; summaryIndex += 1) {
+                const block = summary[summaryIndex];
+                const text = block && typeof block.text === 'string' ? block.text : '';
+                if (text) {
+                    writeSse(res, 'response.reasoning_summary_text.delta', {
+                        type: 'response.reasoning_summary_text.delta',
+                        item_id: itemId,
+                        output_index: outputIndex,
+                        summary_index: summaryIndex,
+                        delta: text,
+                        sequence_number: nextSeq()
+                    });
+                }
+                writeSse(res, 'response.reasoning_summary_text.done', {
+                    type: 'response.reasoning_summary_text.done',
+                    item_id: itemId,
+                    output_index: outputIndex,
+                    summary_index: summaryIndex,
+                    text,
+                    sequence_number: nextSeq()
+                });
             }
         }
 
@@ -1057,7 +1122,7 @@ function sendResponsesSse(res, responsePayload) {
         writeSse(res, 'response.output_item.done', {
             type: 'response.output_item.done',
             output_index: outputIndex,
-            item: { ...item, id: itemId },
+            item: wireItem,
             sequence_number: nextSeq()
         });
     }
@@ -1083,13 +1148,23 @@ function extractResponsesOutputText(payload) {
     return '';
 }
 
-function toUpstreamNonStreamingResponsesPayload(payload) {
+function normalizeResponsesPayloadForUpstream(payload, stream) {
     const body = payload && typeof payload === 'object' ? payload : {};
-    const normalized = { ...body, stream: false };
+    const normalized = { ...body, stream };
     if (Array.isArray(body.tools)) {
         normalized.tools = normalizeResponsesToolsForResponsesApi(body.tools);
     }
+    if (isRecord(body.reasoning)) {
+        const include = Array.isArray(body.include) ? body.include.filter((item) => typeof item === 'string') : [];
+        if (!include.includes('reasoning.encrypted_content')) {
+            normalized.include = [...include, 'reasoning.encrypted_content'];
+        }
+    }
     return normalized;
+}
+
+function toUpstreamNonStreamingResponsesPayload(payload) {
+    return normalizeResponsesPayloadForUpstream(payload, false);
 }
 
 function shouldFallbackFromUpstreamResponses(status, bodyText) {
@@ -1202,6 +1277,101 @@ function writeSse(res, eventName, dataObj) {
     res.write(`data: ${JSON.stringify(dataObj)}\n\n`);
 }
 
+function buildResponsesSseItem(item, fallbackId) {
+    const source = isRecord(item) ? item : {};
+    const itemId = asTrimmedString(source.id || source.call_id) || fallbackId || `item_${crypto.randomBytes(8).toString('hex')}`;
+    if (source.type === 'message') {
+        return {
+            ...source,
+            id: itemId,
+            role: source.role || 'assistant',
+            content: Array.isArray(source.content) ? source.content : []
+        };
+    }
+    if (source.type === 'reasoning') {
+        return {
+            ...source,
+            id: itemId,
+            summary: Array.isArray(source.summary) ? source.summary : []
+        };
+    }
+    if (source.type === 'function_call') {
+        return {
+            ...source,
+            id: itemId,
+            call_id: asTrimmedString(source.call_id) || itemId,
+            name: asTrimmedString(source.name),
+            arguments: typeof source.arguments === 'string' ? source.arguments : ''
+        };
+    }
+    if (source.type === 'custom_tool_call') {
+        return {
+            ...source,
+            id: itemId,
+            call_id: asTrimmedString(source.call_id) || itemId,
+            name: asTrimmedString(source.name),
+            input: typeof source.input === 'string' ? source.input : ''
+        };
+    }
+    return { ...source, id: itemId };
+}
+
+function emitResponsesTextPartAdded(res, itemId, outputIndex, contentIndex, nextSeq) {
+    writeSse(res, 'response.content_part.added', {
+        type: 'response.content_part.added',
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: contentIndex,
+        part: { type: 'output_text', text: '', annotations: [], logprobs: [] },
+        sequence_number: nextSeq()
+    });
+}
+
+function emitResponsesTextPartDone(res, itemId, outputIndex, contentIndex, text, nextSeq) {
+    writeSse(res, 'response.content_part.done', {
+        type: 'response.content_part.done',
+        item_id: itemId,
+        output_index: outputIndex,
+        content_index: contentIndex,
+        part: { type: 'output_text', text: typeof text === 'string' ? text : '', annotations: [], logprobs: [] },
+        sequence_number: nextSeq()
+    });
+}
+
+function emitResponsesToolArgumentEvents(res, item, outputIndex, nextSeq) {
+    const eventType = item.type === 'custom_tool_call'
+        ? 'response.custom_tool_call_input.delta'
+        : 'response.function_call_arguments.delta';
+    const doneType = item.type === 'custom_tool_call'
+        ? ''
+        : 'response.function_call_arguments.done';
+    const value = item.type === 'custom_tool_call'
+        ? (typeof item.input === 'string' ? item.input : '')
+        : (typeof item.arguments === 'string' ? item.arguments : '');
+    if (value) {
+        writeSse(res, eventType, {
+            type: eventType,
+            item_id: item.id,
+            output_index: outputIndex,
+            call_id: item.call_id,
+            name: item.name,
+            delta: value,
+            sequence_number: nextSeq()
+        });
+    }
+    if (doneType) {
+        writeSse(res, doneType, {
+            type: doneType,
+            item_id: item.id,
+            output_index: outputIndex,
+            call_id: item.call_id,
+            name: item.name,
+            arguments: value,
+            sequence_number: nextSeq()
+        });
+    }
+}
+
 function appendChatStreamToolCall(target, toolCall) {
     if (!toolCall || typeof toolCall !== 'object') return;
     const index = Number.isFinite(toolCall.index) ? toolCall.index : target.length;
@@ -1232,6 +1402,37 @@ function writeChatCompletionChunkAsResponsesSse(state, chunk) {
         const delta = choice && choice.delta && typeof choice.delta === 'object' ? choice.delta : null;
         if (!delta) continue;
 
+        const reasoningSegment = typeof delta.reasoning_content === 'string'
+            ? delta.reasoning_content
+            : (typeof delta.reasoning === 'string'
+                ? delta.reasoning
+                : (typeof delta.reasoning_text === 'string' ? delta.reasoning_text : ''));
+        if (reasoningSegment) {
+            if (!state.reasoningItem) {
+                state.reasoningItem = {
+                    id: `rs_${crypto.randomBytes(8).toString('hex')}`,
+                    type: 'reasoning',
+                    summary: [{ type: 'summary_text', text: '' }]
+                };
+                state.output.push(state.reasoningItem);
+                writeSse(state.res, 'response.output_item.added', {
+                    type: 'response.output_item.added',
+                    output_index: state.output.length - 1,
+                    item: buildResponsesSseItem(state.reasoningItem, state.reasoningItem.id)
+                });
+            }
+            state.reasoningText += reasoningSegment;
+            state.reasoningItem.summary[0].text = state.reasoningText;
+            writeSse(state.res, 'response.reasoning_summary_text.delta', {
+                type: 'response.reasoning_summary_text.delta',
+                item_id: state.reasoningItem.id,
+                output_index: state.output.indexOf(state.reasoningItem),
+                summary_index: 0,
+                delta: reasoningSegment,
+                sequence_number: state.nextSeq()
+            });
+        }
+
         const segments = [];
         // DeepSeek-style OpenAI-compatible streams may emit private reasoning in
         // `reasoning_content` before the final answer. Responses `output_text`
@@ -1252,8 +1453,9 @@ function writeChatCompletionChunkAsResponsesSse(state, chunk) {
                 writeSse(state.res, 'response.output_item.added', {
                     type: 'response.output_item.added',
                     output_index: state.output.length - 1,
-                    item: state.messageItem
+                    item: buildResponsesSseItem(state.messageItem, state.messageItem.id)
                 });
+                emitResponsesTextPartAdded(state.res, state.messageItem.id, state.output.length - 1, 0, state.nextSeq);
             }
             state.messageText += seg;
             state.messageItem.content[0].text = state.messageText;
@@ -1283,6 +1485,24 @@ function finishChatStreamResponsesSse(state) {
     if (!state || state.finished) return;
     state.finished = true;
 
+    if (state.reasoningItem) {
+        const outputIndex = state.output.indexOf(state.reasoningItem);
+        writeSse(state.res, 'response.reasoning_summary_text.done', {
+            type: 'response.reasoning_summary_text.done',
+            item_id: state.reasoningItem.id,
+            output_index: outputIndex,
+            summary_index: 0,
+            text: state.reasoningText,
+            sequence_number: state.nextSeq()
+        });
+        writeSse(state.res, 'response.output_item.done', {
+            type: 'response.output_item.done',
+            output_index: outputIndex,
+            item: buildResponsesSseItem(state.reasoningItem, state.reasoningItem.id),
+            sequence_number: state.nextSeq()
+        });
+    }
+
     if (state.messageItem) {
         const outputIndex = state.output.indexOf(state.messageItem);
         writeSse(state.res, 'response.output_text.done', {
@@ -1293,10 +1513,11 @@ function finishChatStreamResponsesSse(state) {
             text: state.messageText,
             sequence_number: state.nextSeq()
         });
+        emitResponsesTextPartDone(state.res, state.messageItem.id, outputIndex, 0, state.messageText, state.nextSeq);
         writeSse(state.res, 'response.output_item.done', {
             type: 'response.output_item.done',
             output_index: outputIndex,
-            item: state.messageItem,
+            item: buildResponsesSseItem(state.messageItem, state.messageItem.id),
             sequence_number: state.nextSeq()
         });
     }
@@ -1310,12 +1531,13 @@ function finishChatStreamResponsesSse(state) {
         writeSse(state.res, 'response.output_item.added', {
             type: 'response.output_item.added',
             output_index: outputIndex,
-            item
+            item: buildResponsesSseItem(item, item.call_id)
         });
+        emitResponsesToolArgumentEvents(state.res, buildResponsesSseItem(item, item.call_id), outputIndex, state.nextSeq);
         writeSse(state.res, 'response.output_item.done', {
             type: 'response.output_item.done',
             output_index: outputIndex,
-            item,
+            item: buildResponsesSseItem(item, item.call_id),
             sequence_number: state.nextSeq()
         });
     }
@@ -1485,6 +1707,8 @@ function streamChatCompletionsAsResponsesSse(targetUrl, options = {}) {
                 output: [],
                 messageItem: null,
                 messageText: '',
+                reasoningItem: null,
+                reasoningText: '',
                 toolCalls: [],
                 toolTypesByName: options.toolTypesByName || {},
                 finished: false,
@@ -2012,7 +2236,7 @@ function createOpenaiBridgeHttpHandler(options = {}) {
                     ? { ok: false, status: 404, bodyText: '' }
                     : await retryTransientRequest(() => streamResponsesSse(upstreamResponsesUrl, {
                         method: 'POST',
-                        body: responsesRequest,
+                        body: normalizeResponsesPayloadForUpstream(responsesRequest, true),
                         headers: codexHeaders,
                         timeoutMs: streamTimeoutMs,
                         maxBytes: maxUpstreamBytes,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codexmate",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codexmate",
-      "version": "0.0.53",
+      "version": "0.0.54",
       "license": "Apache-2.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codexmate",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "Codex/Claude Code/OpenClaw 配置、会话与任务编排 CLI + Web 工具",
   "main": "cli.js",
   "bin": {

--- a/tests/unit/builtin-proxy-responses-shim.test.mjs
+++ b/tests/unit/builtin-proxy-responses-shim.test.mjs
@@ -1377,3 +1377,176 @@ test('builtin-proxy /v1/responses retries upstream after a transient connection 
         await closeServer(upstream);
     }
 });
+
+test('builtin-proxy /v1/responses adds encrypted reasoning include for upstream Responses', async () => {
+    let capturedRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            const chunks = [];
+            req.on('data', (chunk) => chunks.push(chunk));
+            req.on('end', () => {
+                capturedRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ id: 'resp_reasoning', model: 'gpt-test', output: [] }));
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+    let proxyRuntime = null;
+
+    try {
+        proxyRuntime = await startTestProxy(upstreamPort);
+        const proxyPort = proxyRuntime.server.address().port;
+        const resp = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: {
+                model: 'gpt-test',
+                input: 'think privately',
+                reasoning: { effort: 'high' },
+                include: ['file_search_call.results'],
+                stream: false
+            }
+        });
+
+        assert.equal(resp.status, 200);
+        assert.ok(capturedRequest, 'upstream Responses request should be captured');
+        assert.equal(capturedRequest.stream, false);
+        assert.deepStrictEqual(capturedRequest.reasoning, { effort: 'high' });
+        assert.deepStrictEqual(capturedRequest.include, ['file_search_call.results', 'reasoning.encrypted_content']);
+    } finally {
+        if (proxyRuntime) {
+            await closeServer(proxyRuntime.server, proxyRuntime.connections);
+        }
+        await closeServer(upstream);
+    }
+});
+
+test('builtin-proxy /v1/responses maps reasoning effort, max_completion_tokens, and finish_reason length through chat fallback', async () => {
+    let capturedChatRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'responses endpoint unavailable' }));
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            const chunks = [];
+            req.on('data', (chunk) => chunks.push(chunk));
+            req.on('end', () => {
+                capturedChatRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({
+                    id: 'chatcmpl_length',
+                    model: 'gpt-test',
+                    choices: [{
+                        finish_reason: 'length',
+                        message: { role: 'assistant', content: '' }
+                    }],
+                    usage: { prompt_tokens: 2, completion_tokens: 4, total_tokens: 6 }
+                }));
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+    let proxyRuntime = null;
+
+    try {
+        proxyRuntime = await startTestProxy(upstreamPort);
+        const proxyPort = proxyRuntime.server.address().port;
+        const resp = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: {
+                model: 'gpt-test',
+                input: 'short answer',
+                reasoning: { effort: 'medium' },
+                max_completion_tokens: 64,
+                stream: false
+            }
+        });
+
+        assert.equal(resp.status, 200);
+        assert.ok(capturedChatRequest, 'chat fallback request should be captured');
+        assert.equal(capturedChatRequest.reasoning_effort, 'medium');
+        assert.equal(capturedChatRequest.max_tokens, 128);
+
+        const parsed = JSON.parse(resp.text);
+        assert.equal(parsed.status, 'incomplete');
+        assert.deepStrictEqual(parsed.incomplete_details, { reason: 'max_output_tokens' });
+        assert.equal(parsed.output[0].type, 'message');
+        assert.equal(parsed.output[0].content[0].type, 'output_text');
+        assert.equal(parsed.output[0].content[0].text, '');
+        assert.deepStrictEqual(parsed.usage, { input_tokens: 2, output_tokens: 4, total_tokens: 6 });
+    } finally {
+        if (proxyRuntime) {
+            await closeServer(proxyRuntime.server, proxyRuntime.connections);
+        }
+        await closeServer(upstream);
+    }
+});
+
+test('builtin-proxy /v1/responses stream=true emits reasoning and tool events from chat fallback', async () => {
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'responses endpoint unavailable' }));
+            return;
+        }
+        if (req.url === '/v1/chat/completions' && req.method === 'POST') {
+            res.writeHead(200, { 'Content-Type': 'text/event-stream; charset=utf-8' });
+            res.write('data: {"id":"chatcmpl_reason_tool","model":"gpt-test","choices":[{"delta":{"reasoning_content":"private "}}]}\n\n');
+            res.write('data: {"id":"chatcmpl_reason_tool","model":"gpt-test","choices":[{"delta":{"reasoning_content":"thought"}}]}\n\n');
+            res.write('data: {"id":"chatcmpl_reason_tool","model":"gpt-test","choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_lookup","type":"function","function":{"name":"lookup","arguments":"{\\\"q\\\":"}}]}}]}\n\n');
+            res.write('data: {"id":"chatcmpl_reason_tool","model":"gpt-test","choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\\\"codexmate\\\"}"}}]},"finish_reason":"tool_calls"}]}\n\n');
+            res.end('data: [DONE]\n\n');
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+    let proxyRuntime = null;
+
+    try {
+        proxyRuntime = await startTestProxy(upstreamPort);
+        const proxyPort = proxyRuntime.server.address().port;
+        const sse = await requestText(`http://127.0.0.1:${proxyPort}/v1/responses`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: {
+                model: 'gpt-test',
+                input: 'use lookup',
+                tools: [{ type: 'function', name: 'lookup', parameters: { type: 'object' } }],
+                stream: true
+            }
+        });
+
+        assert.equal(sse.status, 200);
+        assert.match(sse.headers['content-type'], /text\/event-stream/i);
+        assert.match(sse.text, /event: response\.reasoning_summary_text\.delta/);
+        assert.match(sse.text, /"delta":"private "/);
+        assert.match(sse.text, /"delta":"thought"/);
+        assert.match(sse.text, /event: response\.reasoning_summary_text\.done/);
+        assert.match(sse.text, /"text":"private thought"/);
+        assert.match(sse.text, /event: response\.function_call_arguments\.delta/);
+        assert.match(sse.text, /"delta":"\{\\"q\\":\\"codexmate\\"\}"/);
+        assert.match(sse.text, /event: response\.function_call_arguments\.done/);
+        assert.match(sse.text, /"arguments":"\{\\"q\\":\\"codexmate\\"\}"/);
+        assert.match(sse.text, /"type":"reasoning"/);
+        assert.match(sse.text, /"type":"function_call"/);
+        assert.match(sse.text, /event: response\.completed/);
+        assert.match(sse.text, /data: \[DONE\]/);
+    } finally {
+        if (proxyRuntime) {
+            await closeServer(proxyRuntime.server, proxyRuntime.connections);
+        }
+        await closeServer(upstream);
+    }
+});

--- a/tests/unit/openai-bridge-upstream-responses.test.mjs
+++ b/tests/unit/openai-bridge-upstream-responses.test.mjs
@@ -349,8 +349,11 @@ test('openai-bridge omits upstream reasoning_content from output_text deltas', a
         body: { model: 'deepseek-v4', input: 'ping', stream: true }
     });
     assert.equal(sse.status, 200);
-    assert.doesNotMatch(sse.text, /"delta":"thinking-"/);
-    assert.doesNotMatch(sse.text, /"delta":"step"/);
+    assert.match(sse.text, /event: response\.reasoning_summary_text\.delta/);
+    assert.match(sse.text, /"delta":"thinking-"/);
+    assert.match(sse.text, /"delta":"step"/);
+    const outputTextLines = sse.text.split('\n').filter((line) => line.includes('response.output_text'));
+    assert.equal(outputTextLines.some((line) => line.includes('thinking-') || line.includes('step')), false);
     assert.match(sse.text, /"delta":"answer"/);
     assert.match(sse.text, /"text":"answer"/);
     assert.match(sse.text, /data: \[DONE\]/);
@@ -1434,4 +1437,114 @@ test('openai-bridge tells chat fallback to poll running Codex exec sessions', ()
     assert.match(converted.chat.messages[0].content, /write_stdin/);
     assert.match(converted.chat.messages[0].content, /session_id/);
     assert.match(converted.chat.messages[0].content, /Do not merely say that you are waiting/);
+});
+
+test('openai-bridge converts empty probes, empty tool output, and reasoning effort for chat fallback', () => {
+    const emptyProbe = convertResponsesRequestToChatCompletions({
+        model: 'gpt-test',
+        input: [],
+        reasoning: { effort: 'high' },
+        stream: false
+    });
+
+    assert.equal(emptyProbe.error, undefined);
+    assert.deepStrictEqual(emptyProbe.chat.messages, [{ role: 'user', content: '' }]);
+    assert.equal(emptyProbe.chat.reasoning_effort, 'high');
+
+    const withEmptyToolOutput = convertResponsesRequestToChatCompletions({
+        model: 'gpt-test',
+        input: [
+            { type: 'function_call', call_id: 'call_empty', name: 'lookup', arguments: {} },
+            { type: 'function_call_output', call_id: 'call_empty', output: '' }
+        ],
+        reasoning_effort: 'medium',
+        stream: false
+    });
+
+    assert.equal(withEmptyToolOutput.error, undefined);
+    assert.equal(withEmptyToolOutput.chat.reasoning_effort, 'medium');
+    assert.deepStrictEqual(withEmptyToolOutput.chat.messages, [
+        {
+            role: 'assistant',
+            content: null,
+            tool_calls: [{
+                id: 'call_empty',
+                type: 'function',
+                function: { name: 'lookup', arguments: '{}' }
+            }]
+        },
+        { role: 'tool', tool_call_id: 'call_empty', content: '(empty)' }
+    ]);
+});
+
+test('openai-bridge marks finish_reason length as incomplete Responses payload', () => {
+    const payload = buildResponsesPayloadFromChatResult('gpt-test', '', [], {
+        choices: [{ finish_reason: 'length', message: { role: 'assistant', content: '' } }],
+        usage: { prompt_tokens: 3, completion_tokens: 7, total_tokens: 10 }
+    });
+
+    assert.equal(payload.status, 'incomplete');
+    assert.deepStrictEqual(payload.incomplete_details, { reason: 'max_output_tokens' });
+    assert.deepStrictEqual(payload.output, []);
+    assert.equal(payload.output_text, '');
+    assert.deepStrictEqual(payload.usage, { input_tokens: 3, output_tokens: 7, total_tokens: 10 });
+});
+
+test('openai-bridge adds encrypted reasoning include when proxying upstream Responses', async () => {
+    let capturedRequest = null;
+    const upstream = http.createServer((req, res) => {
+        if (req.url === '/v1/responses' && req.method === 'POST') {
+            const chunks = [];
+            req.on('data', (chunk) => chunks.push(chunk));
+            req.on('end', () => {
+                capturedRequest = JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(JSON.stringify({ id: 'resp_reasoning', model: 'gpt-test', output: [] }));
+            });
+            return;
+        }
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+    });
+    const { port: upstreamPort } = await listen(upstream);
+
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'codexmate-bridge-test-'));
+    const settingsFile = path.join(tmpDir, 'bridge.json');
+    await writeFile(settingsFile, JSON.stringify({
+        version: 1,
+        providers: {
+            test: { baseUrl: `http://127.0.0.1:${upstreamPort}/v1`, apiKey: 'sk-upstream' }
+        }
+    }), 'utf-8');
+
+    const handler = createOpenaiBridgeHttpHandler({ settingsFile, expectedToken: 'codexmate' });
+    const bridge = http.createServer((req, res) => {
+        if (!handler(req, res)) {
+            res.statusCode = 404;
+            res.end('not handled');
+        }
+    });
+    const { port: bridgePort } = await listen(bridge);
+
+    const resp = await requestText(`http://127.0.0.1:${bridgePort}/bridge/openai/test/v1/responses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer codexmate' },
+        body: {
+            model: 'gpt-test',
+            input: 'think privately',
+            reasoning: { effort: 'high' },
+            include: ['file_search_call.results'],
+            stream: false
+        }
+    });
+
+    assert.equal(resp.status, 200);
+    assert.ok(capturedRequest, 'upstream Responses request should be captured');
+    assert.equal(capturedRequest.stream, false);
+    assert.deepStrictEqual(capturedRequest.reasoning, { effort: 'high' });
+    assert.deepStrictEqual(capturedRequest.include, ['file_search_call.results', 'reasoning.encrypted_content']);
+
+    await bridge.close();
+    await upstream.close();
+    await rm(tmpDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- align Responses-to-chat fallback conversion around empty probes, empty tool outputs, reasoning effort, and token limits
- preserve Responses reasoning include behavior for upstream `/v1/responses`
- add regression coverage for `finish_reason: "length"` mapping to incomplete Responses payloads
- cover streaming chat fallback reasoning and tool-call SSE events
- bump package version from `0.0.53` to `0.0.54` in `package.json` and `package-lock.json`
- add git tag `v0.0.54` pointing at current PR head `2539072d215160f60539ed07a1995a8ce8bfa943`

## Commits
- `a4d918d fix(responses): align chat fallback edge cases`
- `2539072 chore(release): bump version to 0.0.54`

## Tests
- `node --check cli/openai-bridge.js`
- `node --check cli/builtin-proxy.js`
- `node --check tests/unit/openai-bridge-upstream-responses.test.mjs`
- `node --check tests/unit/builtin-proxy-responses-shim.test.mjs`
- `node --test tests/unit/builtin-proxy-responses-shim.test.mjs`
- `node --test tests/unit/openai-bridge-upstream-responses.test.mjs`
- `node -e "const p=require('./package.json'); const l=require('./package-lock.json'); if (p.version !== '0.0.54' || l.version !== '0.0.54' || l.packages[''].version !== '0.0.54') process.exit(1); console.log('version ok', p.version);"`
- `node tests/unit/run.mjs` (`All 664 tests passed`, exit 0; existing argparse usage output appeared after the pass line but did not fail the runner)

## Notes
- Direct `node --test tests/unit/update-version-status.test.mjs tests/unit/install-target-cards.test.mjs` was attempted but those files rely on the repository unit runner for global `test`; it failed with `ReferenceError: test is not defined`, so the repository-standard `node tests/unit/run.mjs` result above is the valid verification.
