### PR TITLE
feat(sessions): add pi as session source for browsing pi coding agent sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Have you ever felt overwhelmed by managing multiple local AI agents? Each has it
 ### What's So Special?
 
 Unlike simple wrappers, Codex Mate acts as a **Local Agent Bridge**:
-- **Unified Session Browser**: Search, inspect, filter, and export local sessions across Codex, Claude Code, Gemini CLI, and CodeBuddy Code from one place.
+- **Unified Session Browser**: Search, inspect, filter, and export local sessions across Codex, Claude Code, Gemini CLI, CodeBuddy Code, and Pi from one place.
 - **OpenAI-Compatible Bridge**: Use Codex with any OpenAI-compatible UI by normalizing the Responses API; the built-in Codex conversion also fills and normalizes Codex fingerprint headers such as `User-Agent`, `Version`, `OpenAI-Beta`, and `Originator` so upstream providers see an official Codex CLI-shaped request.
 - **Claude Provider Bridge**: Connect Claude Code to OpenAI Chat Completions-compatible providers and Ollama through the built-in local Claude-compatible proxy.
 - **OpenCode Provider Control**: Manage OpenCode provider/model selection with a CodexMate-owned provider store under `~/.codexmate`, projecting only the active provider into native OpenCode config to avoid polluting or deleting user-owned settings.
@@ -72,7 +72,7 @@ Unlike simple wrappers, Codex Mate acts as a **Local Agent Bridge**:
 | --- | --- | --- |
 | **Provider Management** | ✅ | Switch providers/models for Codex, Claude, OpenCode, KiloCode, and OpenClaw |
 | **Live Agent Sync** | ✅ | Real-time monitoring of Codex/Claude config & status |
-| **Session Browser** | ✅ | Search, preview, filter, and export sessions across Codex, Claude Code, Gemini CLI, and CodeBuddy Code |
+| **Session Browser** | ✅ | Search, preview, filter, and export sessions across Codex, Claude Code, Gemini CLI, CodeBuddy Code, and Pi |
 | **Usage Analytics** | ✅ | Visualize message trends and top projects |
 | **Local Skills Market** | ✅ | Cross-app import/export of agent skills |
 | **Task Queue** | ✅ | DAG-based task execution and logs |

--- a/README.vi.md
+++ b/README.vi.md
@@ -46,7 +46,7 @@ Bạn có bao giờ cảm thấy rối khi phải quản lý nhiều AI agent c�
 ### Điểm nổi bật
 
 Khác với các wrapper đơn giản, Codex Mate hoạt động như một **Agent Bridge cục bộ**:
-- **Trình duyệt phiên thống nhất**: Tìm kiếm và xuất phiên làm việc từ tất cả tool trong một nơi duy nhất.
+- **Trình duyệt phiên thống nhất**: Tìm kiếm, xem trước, lọc và xuất phiên làm việc từ Codex, Claude Code, Gemini CLI, CodeBuddy Code và Pi trong một nơi duy nhất.
 - **Bridge tương thích OpenAI**: Dùng Codex với bất kỳ UI nào hỗ trợ OpenAI bằng cách chuẩn hóa Responses API.
 - **Dọn dẹp provider lỗi**: Kiểm tra route provider cục bộ của Codex/Claude, hiển thị cấu hình lỗi trong một modal và xóa hàng loạt các provider hỏng đã chọn mà không chạm vào mục khỏe mạnh hoặc được bảo vệ.
 - **Chợ skill cục bộ**: Chia sẻ và nhập skill giữa các app agent khác nhau.
@@ -60,7 +60,7 @@ Khác với các wrapper đơn giản, Codex Mate hoạt động như một **Ag
 | --- | --- | --- |
 | **Quản lý Provider** | ✅ | Chuyển đổi provider/model cho Codex, Claude và OpenClaw |
 | **Đồng bộ Agent trực tiếp** | ✅ | Giám sát cấu hình & trạng thái Codex/Claude theo thời gian thực |
-| **Trình duyệt phiên** | ✅ | Liệt kê, lọc và xuất phiên (Codex/Claude/Gemini) |
+| **Trình duyệt phiên** | ✅ | Liệt kê, xem trước, lọc và xuất phiên (Codex/Claude/Gemini/CodeBuddy/Pi) |
 | **Phân tích sử dụng** | ✅ | Trực quan hóa xu hướng tin nhắn và dự án nổi bật |
 | **Chợ skill cục bộ** | ✅ | Import/export skill giữa các app agent |
 | **Hàng đợi tác vụ** | ✅ | Thực thi tác vụ theo DAG và xem log |

--- a/README.zh.md
+++ b/README.zh.md
@@ -53,7 +53,7 @@
 ### 有什么独特之处？
 
 不同于简单的封装，Codex Mate 充当了 **本地智能体桥接器**：
-- **统一会话浏览器**：在一个地方检索、预览、筛选并导出 Codex、Claude Code、Gemini CLI 与 CodeBuddy Code 的本地会话。
+- **统一会话浏览器**：在一个地方检索、预览、筛选并导出 Codex、Claude Code、Gemini CLI、CodeBuddy Code 与 Pi 的本地会话。
 - **OpenAI 兼容桥接**：通过归一化 Responses API，让 Codex 能够与任何支持 OpenAI 格式的 UI 配合使用；内建 Codex 转换会补齐并规范化 `User-Agent`、`Version`、`OpenAI-Beta`、`Originator` 等 Codex 指纹，对上游伪装为官方 Codex CLI 请求。
 - **Claude Provider 桥接**：通过内建本地 Claude 兼容代理，让 Claude Code 接入 OpenAI Chat Completions 兼容 provider 与 Ollama。
 - **OpenCode Provider 控制**：在 `~/.codexmate` 下维护 CodexMate 自有的 OpenCode 多 provider 存储，只将当前选中的 provider 投影到 OpenCode 原生配置，避免污染或误删用户已有配置。
@@ -70,7 +70,7 @@
 | --- | --- | --- |
 | **Provider 管理** | ✅ | 切换 Codex、Claude、OpenCode 和 OpenClaw 的 provider/model |
 | **状态实时同步** | ✅ | 实时感知 Codex/Claude 的配置与运行状态变更 |
-| **会话浏览器** | ✅ | 跨 Codex、Claude Code、Gemini CLI 与 CodeBuddy Code 的本地会话进行检索、预览、筛选与导出 |
+| **会话浏览器** | ✅ | 跨 Codex、Claude Code、Gemini CLI、CodeBuddy Code 与 Pi 的本地会话进行检索、预览、筛选与导出 |
 | **Usage 统计** | ✅ | 可视化消息趋势与热门项目统计 |
 | **本地 Skills 市场** | ✅ | 跨应用的智能体 Skills 导入与导出 |
 | **任务队列** | ✅ | 基于 DAG 的任务执行与日志查看 |

--- a/cli.js
+++ b/cli.js
@@ -260,6 +260,8 @@ const CODEXMATE_DERIVED_CODEX_DIR = path.join(CODEXMATE_DERIVED_SESSIONS_DIR, 'c
 const CODEXMATE_DERIVED_CLAUDE_DIR = path.join(CODEXMATE_DERIVED_SESSIONS_DIR, 'claude');
 const GEMINI_DIR = path.join(os.homedir(), '.gemini');
 const GEMINI_TMP_DIR = path.join(GEMINI_DIR, 'tmp');
+const PI_DIR = path.join(os.homedir(), '.pi');
+const PI_SESSIONS_DIR = path.join(PI_DIR, 'agent', 'sessions');
 const RECENT_CONFIGS_FILE = path.join(CONFIG_DIR, 'recent-configs.json');
 const WORKFLOW_DEFINITIONS_FILE = path.join(CONFIG_DIR, 'codexmate-workflows.json');
 const WORKFLOW_RUNS_FILE = path.join(CONFIG_DIR, 'codexmate-workflow-runs.jsonl');
@@ -770,7 +772,8 @@ let g_sessionFileLookupCache = {
     codex: new Map(),
     claude: new Map(),
     gemini: new Map(),
-    codebuddy: new Map()
+    codebuddy: new Map(),
+    pi: new Map()
 };
 let g_exactMessageCountCache = new Map();
 let g_modelsCache = new Map();
@@ -1821,6 +1824,20 @@ function getCodeBuddyProjectsDir() {
     }
     candidates.push(CODEBUDDY_PROJECTS_DIR);
     return resolveExistingDir(candidates, CODEBUDDY_PROJECTS_DIR);
+}
+
+function getPiSessionsDir() {
+    const candidates = [];
+    const envPiHome = process.env.PI_HOME;
+    if (envPiHome) {
+        candidates.push(path.join(envPiHome, 'agent', 'sessions'));
+    }
+    const xdgConfig = process.env.XDG_CONFIG_HOME;
+    if (xdgConfig) {
+        candidates.push(path.join(xdgConfig, 'pi', 'agent', 'sessions'));
+    }
+    candidates.push(PI_SESSIONS_DIR);
+    return resolveExistingDir(candidates, PI_SESSIONS_DIR);
 }
 
 function getCodexmateDerivedSessionsRoot(target) {
@@ -3842,6 +3859,15 @@ async function countConversationMessagesInFile(filePath, source) {
                         role = '';
                     }
                 }
+            } else if (source === 'pi') {
+                if (record && record.type === 'message' && record.message && typeof record.message === 'object') {
+                    role = normalizeRole(record.message.role);
+                    if (role === 'assistant' || role === 'user' || role === 'system') {
+                        text = extractMessageText(record.message.content);
+                    } else {
+                        role = '';
+                    }
+                }
             } else {
                 role = normalizeRole(record.type);
                 if (role === 'assistant' || role === 'user' || role === 'system') {
@@ -4010,7 +4036,9 @@ async function hydrateSessionTrashEntries(entries, options = {}) {
             ? 'codex'
             : (options.source === 'gemini'
                 ? 'gemini'
-                : (options.source === 'codebuddy' ? 'codebuddy' : 'all')));
+                : (options.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (options.source === 'pi' ? 'pi' : 'all'))));
     const hydratedEntries = await mapWithConcurrency(Array.isArray(entries) ? entries : [], 8, async (entry) => {
         const normalizedEntry = normalizeSessionTrashEntry(entry);
         if (!normalizedEntry) {
@@ -4019,7 +4047,7 @@ async function hydrateSessionTrashEntries(entries, options = {}) {
         return await resolveSessionTrashEntryExactMessageCount(normalizedEntry);
     });
 
-    if (source === 'codex' || source === 'claude' || source === 'gemini' || source === 'codebuddy') {
+    if (source === 'codex' || source === 'claude' || source === 'gemini' || source === 'codebuddy' || source === 'pi') {
         return hydratedEntries.filter((entry) => entry.source === source);
     }
     return hydratedEntries;
@@ -4037,7 +4065,11 @@ async function hydrateSessionItemsExactMessageCount(items) {
             ? 'claude'
             : (item.source === 'codex'
                 ? 'codex'
-                : (item.source === 'gemini' ? 'gemini' : (item.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (item.source === 'gemini'
+                    ? 'gemini'
+                    : (item.source === 'codebuddy'
+                        ? 'codebuddy'
+                        : (item.source === 'pi' ? 'pi' : ''))));
         const filePath = typeof item.filePath === 'string' ? item.filePath : '';
         if (!source || !filePath || !fs.existsSync(filePath)) {
             return item;
@@ -4085,7 +4117,11 @@ async function readSessionMessageCounts(params = {}) {
             ? 'claude'
             : (item.source === 'codex'
                 ? 'codex'
-                : (item.source === 'gemini' ? 'gemini' : (item.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (item.source === 'gemini'
+                    ? 'gemini'
+                    : (item.source === 'codebuddy'
+                        ? 'codebuddy'
+                        : (item.source === 'pi' ? 'pi' : ''))));
         const filePath = typeof item.filePath === 'string' ? item.filePath : '';
         if (!source || !filePath || !fs.existsSync(filePath)) {
             return { key };
@@ -4599,7 +4635,13 @@ function setSessionListCache(cacheKey, value) {
 }
 
 function buildSessionInventoryCacheKey(source, limit, options = {}) {
-    const normalizedSource = source === 'claude' ? 'claude' : 'codex';
+    const normalizedSource = source === 'claude'
+        ? 'claude'
+        : (source === 'gemini'
+            ? 'gemini'
+            : (source === 'codebuddy'
+                ? 'codebuddy'
+                : (source === 'pi' ? 'pi' : 'codex')));
     const normalizedLimit = Number.isFinite(Number(limit))
         ? Math.max(1, Math.floor(Number(limit)))
         : 1;
@@ -4685,7 +4727,7 @@ function getSessionInventoryCache(cacheKey, forceRefresh = false) {
 }
 
 function registerSessionFileLookupEntries(source, sessions = []) {
-    const normalizedSource = source === 'claude' || source === 'gemini' || source === 'codebuddy'
+    const normalizedSource = source === 'claude' || source === 'gemini' || source === 'codebuddy' || source === 'pi'
         ? source
         : 'codex';
     const store = g_sessionFileLookupCache[normalizedSource];
@@ -4726,7 +4768,7 @@ function setSessionInventoryCache(cacheKey, source, value) {
 }
 
 function listSessionInventoryBySource(source, limit, scanOptions = {}, options = {}) {
-    const normalizedSource = source === 'claude' || source === 'gemini' || source === 'codebuddy'
+    const normalizedSource = source === 'claude' || source === 'gemini' || source === 'codebuddy' || source === 'pi'
         ? source
         : 'codex';
     const forceRefresh = !!options.forceRefresh;
@@ -4742,7 +4784,9 @@ function listSessionInventoryBySource(source, limit, scanOptions = {}, options =
             ? listGeminiSessions(limit, scanOptions)
             : (normalizedSource === 'codebuddy'
                 ? listCodeBuddySessions(limit, scanOptions)
-                : listCodexSessions(limit, scanOptions)));
+                : (normalizedSource === 'pi'
+                    ? listPiSessions(limit, scanOptions)
+                    : listCodexSessions(limit, scanOptions))));
     setSessionInventoryCache(cacheKey, normalizedSource, sessions);
     return sessions;
 }
@@ -4754,7 +4798,8 @@ function invalidateSessionListCache() {
         codex: new Map(),
         claude: new Map(),
         gemini: new Map(),
-        codebuddy: new Map()
+        codebuddy: new Map(),
+        pi: new Map()
     };
 }
 
@@ -4988,7 +5033,13 @@ function readSessionProviderFromRecord(record, source = '') {
     if (provider) {
         return provider;
     }
-    return source === 'claude' ? 'claude' : 'codex';
+    return source === 'claude'
+        ? 'claude'
+        : (source === 'gemini'
+            ? 'gemini'
+            : (source === 'codebuddy'
+                ? 'codebuddy'
+                : (source === 'pi' ? 'pi' : 'codex')));
 }
 
 function applySessionUsageSummaryFromRecord(state, record, source) {
@@ -5687,6 +5738,177 @@ function parseGeminiSessionSummary(filePath, options = {}) {
     };
 }
 
+function extractPiUsageFromMessage(message) {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+        return null;
+    }
+    const usage = message.usage;
+    if (!usage || typeof usage !== 'object' || Array.isArray(usage)) {
+        return null;
+    }
+    const inputTokens = readNonNegativeInteger(usage.input);
+    const outputTokens = readNonNegativeInteger(usage.output);
+    const cachedInputTokens = readNonNegativeInteger(usage.cacheRead);
+    const cacheCreationInputTokens = readNonNegativeInteger(usage.cacheWrite);
+    const reasoningOutputTokens = readNonNegativeInteger(usage.reasoning);
+    if (inputTokens === null && outputTokens === null && cachedInputTokens === null && cacheCreationInputTokens === null && reasoningOutputTokens === null) {
+        return null;
+    }
+    return {
+        inputTokens: inputTokens || 0,
+        cachedInputTokens: cachedInputTokens || 0,
+        cacheCreationInputTokens: cacheCreationInputTokens || 0,
+        outputTokens: outputTokens || 0,
+        reasoningOutputTokens: reasoningOutputTokens || 0
+    };
+}
+
+function parsePiSessionSummary(filePath, options = {}) {
+    const summaryReadBytes = Number.isFinite(Number(options.summaryReadBytes))
+        ? Math.max(1024, Math.floor(Number(options.summaryReadBytes)))
+        : SESSION_SUMMARY_READ_BYTES;
+    const titleReadBytes = Number.isFinite(Number(options.titleReadBytes))
+        ? Math.max(1024, Math.floor(Number(options.titleReadBytes)))
+        : SESSION_TITLE_READ_BYTES;
+    const records = parseJsonlHeadRecords(filePath, summaryReadBytes);
+    if (records.length === 0) {
+        return null;
+    }
+
+    let stat;
+    try {
+        stat = fs.statSync(filePath);
+    } catch (_) {
+        return null;
+    }
+
+    let sessionId = path.basename(filePath, '.jsonl');
+    let cwd = '';
+    let createdAt = '';
+    let updatedAt = stat.mtime.toISOString();
+    let firstPrompt = '';
+    let messageCount = 0;
+    let totalTokens = 0;
+    let contextWindow = 0;
+    let inputTokens = 0;
+    let cachedInputTokens = 0;
+    let cacheCreationInputTokens = 0;
+    let outputTokens = 0;
+    let reasoningOutputTokens = 0;
+    let provider = 'pi';
+    let model = '';
+    const models = [];
+    const previewMessages = [];
+
+    for (const record of records) {
+        if (!createdAt && record && record.type === 'session' && record.timestamp) {
+            createdAt = toIsoTime(record.timestamp, createdAt);
+        }
+        if (record && record.timestamp) {
+            updatedAt = updateLatestIso(updatedAt, record.timestamp);
+        }
+        if (record && record.type === 'session') {
+            sessionId = record.id || sessionId;
+            cwd = record.cwd || cwd;
+        }
+        if (record && record.type === 'model_change' && record.modelId) {
+            if (!models.includes(record.modelId)) {
+                models.push(record.modelId);
+            }
+            model = model || record.modelId;
+            if (record.provider) {
+                provider = record.provider;
+            }
+        }
+        if (record && record.type === 'message' && record.message && typeof record.message === 'object') {
+            const role = normalizeRole(record.message.role);
+            if (role === 'user' || role === 'assistant' || role === 'system') {
+                messageCount += 1;
+                const text = extractMessageText(record.message.content);
+                if (role === 'assistant' && record.message.model && !models.includes(record.message.model)) {
+                    models.push(record.message.model);
+                    model = model || record.message.model;
+                }
+                if (record.message.provider) {
+                    provider = record.message.provider;
+                }
+                const piUsage = extractPiUsageFromMessage(record.message);
+                if (piUsage) {
+                    inputTokens += piUsage.inputTokens;
+                    cachedInputTokens += piUsage.cachedInputTokens;
+                    cacheCreationInputTokens += piUsage.cacheCreationInputTokens;
+                    outputTokens += piUsage.outputTokens;
+                    reasoningOutputTokens += piUsage.reasoningOutputTokens;
+                }
+                if (text) {
+                    previewMessages.push({ role, text });
+                    if (!firstPrompt && role === 'user') {
+                        firstPrompt = text.split('\n')[0].slice(0, 80);
+                    }
+                }
+            }
+        }
+    }
+
+    totalTokens = inputTokens + cachedInputTokens + cacheCreationInputTokens + outputTokens + reasoningOutputTokens;
+
+    const tailRecords = parseJsonlTailRecords(filePath, summaryReadBytes);
+    let tailMessageCount = 0;
+    let tailHasMore = false;
+    for (const record of tailRecords) {
+        if (record && record.timestamp) {
+            updatedAt = updateLatestIso(updatedAt, record.timestamp);
+        }
+        if (record && record.type === 'message' && record.message && typeof record.message === 'object') {
+            const role = normalizeRole(record.message.role);
+            if (role === 'user' || role === 'assistant' || role === 'system') {
+                tailMessageCount += 1;
+                const piUsage = extractPiUsageFromMessage(record.message);
+                if (piUsage) {
+                    inputTokens += piUsage.inputTokens;
+                    cachedInputTokens += piUsage.cachedInputTokens;
+                    cacheCreationInputTokens += piUsage.cacheCreationInputTokens;
+                    outputTokens += piUsage.outputTokens;
+                    reasoningOutputTokens += piUsage.reasoningOutputTokens;
+                }
+                if (role === 'assistant' && record.message.model && !models.includes(record.message.model)) {
+                    models.push(record.message.model);
+                }
+                if (record.message.provider) {
+                    provider = record.message.provider;
+                }
+            }
+        }
+    }
+    totalTokens = inputTokens + cachedInputTokens + cacheCreationInputTokens + outputTokens + reasoningOutputTokens;
+
+    const fileName = path.basename(filePath, '.jsonl');
+    return {
+        source: 'pi',
+        sourceLabel: 'Pi',
+        provider,
+        model,
+        models,
+        sessionId,
+        title: firstPrompt || sessionId || fileName,
+        cwd,
+        createdAt,
+        updatedAt,
+        messageCount,
+        totalTokens,
+        contextWindow,
+        inputTokens,
+        cachedInputTokens,
+        cacheCreationInputTokens,
+        outputTokens,
+        reasoningOutputTokens,
+        __messageCountExact: false,
+        filePath,
+        keywords: [],
+        capabilities: { code: true }
+    };
+}
+
 function listCodexSessions(limit, options = {}) {
     const codexSessionsDir = getCodexSessionsDir();
     const scanFactor = Number.isFinite(Number(options.scanFactor))
@@ -6126,8 +6348,56 @@ function listCodeBuddySessions(limit, options = {}) {
     return mergeAndLimitSessions(sessions, limit);
 }
 
+function listPiSessions(limit, options = {}) {
+    const sessionsDir = getPiSessionsDir();
+    if (!fs.existsSync(sessionsDir)) {
+        return [];
+    }
+
+    const scanFactor = Number.isFinite(Number(options.scanFactor))
+        ? Math.max(1, Number(options.scanFactor))
+        : SESSION_SCAN_FACTOR;
+    const minFiles = Number.isFinite(Number(options.minFiles))
+        ? Math.max(1, Number(options.minFiles))
+        : Math.min(SESSION_SCAN_MIN_FILES, MAX_SESSION_LIST_SIZE * SESSION_SCAN_FACTOR);
+    const targetCount = Number.isFinite(Number(options.targetCount))
+        ? Math.max(1, Math.floor(Number(options.targetCount)))
+        : Math.max(1, Math.floor(limit * scanFactor));
+    const scanCount = Number.isFinite(Number(options.scanCount))
+        ? Math.max(targetCount, Math.floor(Number(options.scanCount)))
+        : Math.max(targetCount, minFiles);
+    const maxFilesScanned = Number.isFinite(Number(options.maxFilesScanned))
+        ? Math.max(scanCount, Math.floor(Number(options.maxFilesScanned)))
+        : Math.max(scanCount * 2, minFiles);
+    const summaryReadBytes = Number.isFinite(Number(options.summaryReadBytes))
+        ? Math.max(1024, Math.floor(Number(options.summaryReadBytes)))
+        : SESSION_SUMMARY_READ_BYTES;
+    const titleReadBytes = Number.isFinite(Number(options.titleReadBytes))
+        ? Math.max(1024, Math.floor(Number(options.titleReadBytes)))
+        : SESSION_TITLE_READ_BYTES;
+
+    const files = collectRecentJsonlFiles(sessionsDir, {
+        returnCount: scanCount,
+        maxFilesScanned
+    });
+    const sessions = [];
+    for (const filePath of files) {
+        const summary = parsePiSessionSummary(filePath, {
+            summaryReadBytes,
+            titleReadBytes
+        });
+        if (summary) {
+            sessions.push(summary);
+        }
+        if (sessions.length >= targetCount) {
+            break;
+        }
+    }
+    return mergeAndLimitSessions(sessions, limit);
+}
+
 async function listAllSessions(params = {}) {
-    const source = params.source === 'codex' || params.source === 'claude' || params.source === 'gemini' || params.source === 'codebuddy'
+    const source = params.source === 'codex' || params.source === 'claude' || params.source === 'gemini' || params.source === 'codebuddy' || params.source === 'pi'
         ? params.source
         : 'all';
     const rawLimit = Number(params.limit);
@@ -6176,6 +6446,9 @@ async function listAllSessions(params = {}) {
     }
     if (source === 'all' || source === 'codebuddy') {
         sessions = sessions.concat(listSessionInventoryBySource('codebuddy', limit, scanOptions, { forceRefresh }));
+    }
+    if (source === 'all' || source === 'pi') {
+        sessions = sessions.concat(listSessionInventoryBySource('pi', limit, scanOptions, { forceRefresh }));
     }
 
     if (hasPathFilter) {
@@ -6259,6 +6532,7 @@ async function listSessionUsage(params = {}) {
         parseClaudeSessionSummary,
         parseCodeBuddySessionSummary,
         parseGeminiSessionSummary,
+        parsePiSessionSummary,
         MAX_SESSION_USAGE_LIST_SIZE,
         SESSION_BROWSE_SUMMARY_READ_BYTES
     });
@@ -6272,10 +6546,10 @@ async function exportSessionUsage(params = {}) {
 
 function listSessionPaths(params = {}) {
     const source = typeof params.source === 'string' ? params.source.trim().toLowerCase() : '';
-    if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'all') {
+    if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi' && source !== 'all') {
         return [];
     }
-    const validSource = source === 'codex' || source === 'claude' || source === 'gemini' || source === 'codebuddy' ? source : 'all';
+    const validSource = source === 'codex' || source === 'claude' || source === 'gemini' || source === 'codebuddy' || source === 'pi' ? source : 'all';
     const rawLimit = Number(params.limit);
     const limit = Number.isFinite(rawLimit)
         ? Math.max(1, Math.min(rawLimit, MAX_SESSION_PATH_LIST_SIZE))
@@ -6309,6 +6583,9 @@ function listSessionPaths(params = {}) {
     if (validSource === 'all' || validSource === 'codebuddy') {
         sessions = sessions.concat(listSessionInventoryBySource('codebuddy', gatherLimit, scanOptions, { forceRefresh }));
     }
+    if (validSource === 'all' || validSource === 'pi') {
+        sessions = sessions.concat(listSessionInventoryBySource('pi', gatherLimit, scanOptions, { forceRefresh }));
+    }
 
     const dedupedPaths = [];
     const seen = new Set();
@@ -6334,7 +6611,7 @@ function listSessionPaths(params = {}) {
 }
 
 function resolveSessionFilePath(source, filePath, sessionId) {
-    const normalizedSource = source === 'claude' || source === 'gemini' || source === 'codebuddy'
+    const normalizedSource = source === 'claude' || source === 'gemini' || source === 'codebuddy' || source === 'pi'
         ? source
         : 'codex';
     const homeDir = process && process.env && process.env.HOME ? process.env.HOME : '';
@@ -6346,7 +6623,9 @@ function resolveSessionFilePath(source, filePath, sessionId) {
             ? [getGeminiTmpDir()]
             : (normalizedSource === 'codebuddy'
                 ? [getCodeBuddyProjectsDir()]
-                : [getCodexSessionsDir(), derivedCodexDir]));
+                : (normalizedSource === 'pi'
+                    ? [getPiSessionsDir()]
+                    : [getCodexSessionsDir(), derivedCodexDir])));
     const availableRoots = roots.filter((dirPath) => dirPath && fs.existsSync(dirPath));
     if (availableRoots.length === 0) {
         return '';
@@ -6894,13 +7173,21 @@ function buildSessionSummaryFallback(source, filePath, sessionId = '') {
     const resolvedSessionId = sessionId || path.basename(filePath, '.jsonl');
     const sourceLabel = source === 'claude'
         ? 'Claude Code'
-        : (source === 'gemini' ? 'Gemini CLI' : (source === 'codebuddy' ? 'CodeBuddy Code' : 'Codex'));
+        : (source === 'gemini'
+            ? 'Gemini CLI'
+            : (source === 'codebuddy'
+                ? 'CodeBuddy Code'
+                : (source === 'pi' ? 'Pi' : 'Codex')));
     return {
         source,
         sourceLabel,
         provider: source === 'claude'
             ? 'claude'
-            : (source === 'gemini' ? 'gemini' : (source === 'codebuddy' ? 'codebuddy' : 'codex')),
+            : (source === 'gemini'
+                ? 'gemini'
+                : (source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (source === 'pi' ? 'pi' : 'codex'))),
         sessionId: resolvedSessionId,
         title: resolvedSessionId,
         cwd: '',
@@ -6953,7 +7240,9 @@ function normalizeSessionTrashEntry(entry) {
             ? 'codex'
             : (entry.source === 'gemini'
                 ? 'gemini'
-                : (entry.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (entry.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (entry.source === 'pi' ? 'pi' : ''))));
     const trashId = typeof entry.trashId === 'string' ? entry.trashId.trim() : '';
     if (!source || !trashId || trashId.includes('/') || trashId.includes('\\') || trashId.includes('\0')) {
         return null;
@@ -6970,7 +7259,11 @@ function normalizeSessionTrashEntry(entry) {
         source,
         sourceLabel: source === 'claude'
             ? 'Claude Code'
-            : (source === 'gemini' ? 'Gemini CLI' : (source === 'codebuddy' ? 'CodeBuddy Code' : 'Codex')),
+            : (source === 'gemini'
+                ? 'Gemini CLI'
+                : (source === 'codebuddy'
+                    ? 'CodeBuddy Code'
+                    : (source === 'pi' ? 'Pi' : 'Codex'))),
         sessionId: sessionId || trashId,
         title: typeof entry.title === 'string' && entry.title.trim() ? entry.title.trim() : (sessionId || trashId),
         cwd: typeof entry.cwd === 'string' ? entry.cwd : '',
@@ -6986,7 +7279,7 @@ function normalizeSessionTrashEntry(entry) {
         originalFilePath: typeof entry.originalFilePath === 'string' ? entry.originalFilePath : '',
         provider: typeof entry.provider === 'string' && entry.provider.trim()
             ? entry.provider.trim()
-            : (source === 'claude' ? 'claude' : (source === 'gemini' ? 'gemini' : (source === 'codebuddy' ? 'codebuddy' : 'codex'))),
+            : (source === 'claude' ? 'claude' : (source === 'gemini' ? 'gemini' : (source === 'codebuddy' ? 'codebuddy' : (source === 'pi' ? 'pi' : 'codex')))),
         keywords: normalizeKeywords(entry.keywords),
         capabilities: normalizeCapabilities(entry.capabilities),
         claudeIndexPath: typeof entry.claudeIndexPath === 'string' ? entry.claudeIndexPath : '',
@@ -7073,7 +7366,13 @@ function purgeExpiredSessionTrashEntries(retentionDays) {
 }
 
 function buildSessionTrashEntry(summary, options = {}) {
-    const source = options.source === 'claude' ? 'claude' : 'codex';
+    const source = options.source === 'claude'
+        ? 'claude'
+        : (options.source === 'gemini'
+            ? 'gemini'
+            : (options.source === 'codebuddy'
+                ? 'codebuddy'
+                : (options.source === 'pi' ? 'pi' : 'codex')));
     const sessionId = options.sessionId || summary.sessionId || path.basename(options.originalFilePath || summary.filePath || '', '.jsonl');
     const claudeIndexEntry = options.claudeIndexEntry && typeof options.claudeIndexEntry === 'object' && !Array.isArray(options.claudeIndexEntry)
         ? options.claudeIndexEntry
@@ -7081,7 +7380,13 @@ function buildSessionTrashEntry(summary, options = {}) {
     const deletedAt = typeof options.deletedAt === 'string' && options.deletedAt
         ? options.deletedAt
         : new Date().toISOString();
-    const sourceLabel = source === 'claude' ? 'Claude Code' : 'Codex';
+    const sourceLabel = source === 'claude'
+        ? 'Claude Code'
+        : (source === 'gemini'
+            ? 'Gemini CLI'
+            : (source === 'codebuddy'
+                ? 'CodeBuddy Code'
+                : (source === 'pi' ? 'Pi' : 'Codex')));
     const fallbackTitle = truncateText(
         (claudeIndexEntry && (claudeIndexEntry.summary || claudeIndexEntry.firstPrompt)) || sessionId,
         120
@@ -7118,7 +7423,7 @@ function buildSessionTrashEntry(summary, options = {}) {
         originalFilePath: options.originalFilePath || summary.filePath || '',
         provider: (claudeIndexEntry && typeof claudeIndexEntry.provider === 'string' && claudeIndexEntry.provider.trim())
             ? claudeIndexEntry.provider.trim()
-            : (summary.provider || (source === 'claude' ? 'claude' : 'codex')),
+            : (summary.provider || (source === 'claude' ? 'claude' : (source === 'gemini' ? 'gemini' : (source === 'codebuddy' ? 'codebuddy' : (source === 'pi' ? 'pi' : 'codex'))))),
         keywords: normalizedClaudeKeywords.length > 0 ? normalizedClaudeKeywords : normalizedSummaryKeywords,
         capabilities: Object.keys(normalizedClaudeCapabilities).length > 0
             ? normalizedClaudeCapabilities
@@ -7137,7 +7442,9 @@ function resolveSessionRestoreTarget(entry) {
         ? getClaudeProjectsDir()
         : (normalized.source === 'gemini'
             ? getGeminiTmpDir()
-            : (normalized.source === 'codebuddy' ? getCodeBuddyProjectsDir() : getCodexSessionsDir()));
+            : (normalized.source === 'codebuddy'
+                ? getCodeBuddyProjectsDir()
+                : (normalized.source === 'pi' ? getPiSessionsDir() : getCodexSessionsDir())));
     const originalFilePath = typeof normalized.originalFilePath === 'string' ? normalized.originalFilePath.trim() : '';
     if (!root || !originalFilePath) {
         return '';
@@ -7277,7 +7584,9 @@ async function listSessionTrashItems(params = {}) {
             ? 'codex'
             : (params.source === 'gemini'
                 ? 'gemini'
-                : (params.source === 'codebuddy' ? 'codebuddy' : 'all')));
+                : (params.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (params.source === 'pi' ? 'pi' : 'all'))));
     const countOnly = params.countOnly === true;
     const rawLimit = Number(params.limit);
     const limit = Number.isFinite(rawLimit)
@@ -7287,7 +7596,7 @@ async function listSessionTrashItems(params = {}) {
         purgeExpiredSessionTrashEntries(params.retentionDays);
     }
     const allEntries = readSessionTrashEntries();
-    let items = source === 'codex' || source === 'claude' || source === 'gemini' || source === 'codebuddy'
+    let items = source === 'codex' || source === 'claude' || source === 'gemini' || source === 'codebuddy' || source === 'pi'
         ? allEntries.filter((entry) => entry.source === source)
         : allEntries.slice();
     items.sort((a, b) => {
@@ -7473,7 +7782,9 @@ async function trashSessionData(params = {}) {
             ? 'codex'
             : (params.source === 'gemini'
                 ? 'gemini'
-                : (params.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (params.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (params.source === 'pi' ? 'pi' : ''))));
     if (!source) {
         return { error: 'Invalid source' };
     }
@@ -7487,7 +7798,9 @@ async function trashSessionData(params = {}) {
         ? parseClaudeSessionSummary(filePath)
         : (source === 'gemini'
             ? parseGeminiSessionSummary(filePath)
-            : (source === 'codebuddy' ? parseCodeBuddySessionSummary(filePath) : parseCodexSessionSummary(filePath))))
+            : (source === 'codebuddy'
+                ? parseCodeBuddySessionSummary(filePath)
+                : (source === 'pi' ? parsePiSessionSummary(filePath) : parseCodexSessionSummary(filePath)))))
         || buildSessionSummaryFallback(source, filePath, params.sessionId);
     const exactMessageCount = await countConversationMessagesInFile(filePath, source);
     if (Number.isFinite(Number(exactMessageCount))) {
@@ -7584,7 +7897,9 @@ async function deleteSessionData(params = {}) {
             ? 'codex'
             : (params.source === 'gemini'
                 ? 'gemini'
-                : (params.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (params.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (params.source === 'pi' ? 'pi' : ''))));
     if (!source) {
         return { error: 'Invalid source' };
     }
@@ -8054,6 +8369,32 @@ function extractCodeBuddyMessageFromRecord(record, state, lineIndex = -1) {
     }
 }
 
+function extractPiMessageFromRecord(record, state, lineIndex = -1) {
+    if (record && record.timestamp) {
+        state.updatedAt = toIsoTime(record.timestamp, state.updatedAt);
+    }
+    if (record && record.type === 'session') {
+        state.sessionId = record.id || state.sessionId;
+        state.cwd = record.cwd || state.cwd;
+        return;
+    }
+    if (!record || record.type !== 'message' || !record.message || typeof record.message !== 'object') {
+        return;
+    }
+    const role = normalizeRole(record.message.role);
+    if (role === 'user' || role === 'assistant' || role === 'system') {
+        const text = extractMessageText(record.message.content);
+        if (text && canAppendMessage(state)) {
+            state.messages.push({
+                role,
+                text,
+                timestamp: toIsoTime(record.timestamp, ''),
+                recordLineIndex: Number.isInteger(lineIndex) ? lineIndex : -1
+            });
+        }
+    }
+}
+
 function recordHasCodexMessage(record) {
     if (!record || record.type !== 'response_item' || !record.payload) {
         return false;
@@ -8095,9 +8436,22 @@ function recordHasCodeBuddyMessage(record) {
     return !!text;
 }
 
+function recordHasPiMessage(record) {
+    if (!record || record.type !== 'message' || !record.message || typeof record.message !== 'object') {
+        return false;
+    }
+    const role = normalizeRole(record.message.role);
+    if (role !== 'user' && role !== 'assistant' && role !== 'system') {
+        return false;
+    }
+    const text = extractMessageText(record.message.content);
+    return !!text;
+}
+
 function recordHasMessage(record, source) {
     if (source === 'codex') return recordHasCodexMessage(record);
     if (source === 'codebuddy') return recordHasCodeBuddyMessage(record);
+    if (source === 'pi') return recordHasPiMessage(record);
     return recordHasClaudeMessage(record);
 }
 
@@ -8118,6 +8472,8 @@ function extractMessagesFromRecords(records, source, options = {}) {
             extractCodexMessageFromRecord(record, state, lineIndex);
         } else if (source === 'codebuddy') {
             extractCodeBuddyMessageFromRecord(record, state, lineIndex);
+        } else if (source === 'pi') {
+            extractPiMessageFromRecord(record, state, lineIndex);
         } else {
             extractClaudeMessageFromRecord(record, state, lineIndex);
         }
@@ -8181,6 +8537,8 @@ async function extractMessagesFromFile(filePath, source, options = {}) {
                 extractCodexMessageFromRecord(record, state, currentLineIndex);
             } else if (source === 'codebuddy') {
                 extractCodeBuddyMessageFromRecord(record, state, currentLineIndex);
+            } else if (source === 'pi') {
+                extractPiMessageFromRecord(record, state, currentLineIndex);
             } else {
                 extractClaudeMessageFromRecord(record, state, currentLineIndex);
             }
@@ -8211,7 +8569,9 @@ async function readSessionDetail(params = {}) {
             ? 'codex'
             : (params.source === 'gemini'
                 ? 'gemini'
-                : (params.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (params.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (params.source === 'pi' ? 'pi' : ''))));
     if (!source) {
         return { error: 'Invalid source' };
     }
@@ -8273,7 +8633,9 @@ async function readSessionDetail(params = {}) {
         ? 'Codex'
         : (source === 'claude'
             ? 'Claude Code'
-            : (source === 'gemini' ? 'Gemini CLI' : 'CodeBuddy Code'));
+            : (source === 'gemini'
+                ? 'Gemini CLI'
+                : (source === 'pi' ? 'Pi' : 'CodeBuddy Code')));
     const clippedMessages = Array.isArray(extracted.messages) ? extracted.messages : [];
     const hasExactTotalMessages = Number.isFinite(extracted.totalMessages);
     const startIndex = hasExactTotalMessages
@@ -8340,7 +8702,9 @@ async function readSessionPlain(params = {}) {
             ? 'codex'
             : (params.source === 'gemini'
                 ? 'gemini'
-                : (params.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (params.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (params.source === 'pi' ? 'pi' : ''))));
     if (!source) {
         return { error: 'Invalid source' };
     }
@@ -8414,7 +8778,9 @@ async function readSessionPlain(params = {}) {
         ? 'Codex'
         : (source === 'claude'
             ? 'Claude Code'
-            : (source === 'gemini' ? 'Gemini CLI' : 'CodeBuddy Code'));
+            : (source === 'gemini'
+                ? 'Gemini CLI'
+                : (source === 'pi' ? 'Pi' : 'CodeBuddy Code')));
     const messages = removeLeadingSystemMessage(Array.isArray(extracted.messages) ? extracted.messages : []);
     const text = buildSessionPlainText(messages);
 
@@ -8436,7 +8802,9 @@ async function exportSessionData(params = {}) {
             ? 'codex'
             : (params.source === 'gemini'
                 ? 'gemini'
-                : (params.source === 'codebuddy' ? 'codebuddy' : '')));
+                : (params.source === 'codebuddy'
+                    ? 'codebuddy'
+                    : (params.source === 'pi' ? 'pi' : ''))));
     if (!source) {
         return { error: 'Invalid source' };
     }
@@ -8510,7 +8878,9 @@ async function exportSessionData(params = {}) {
         ? 'Codex'
         : (source === 'claude'
             ? 'Claude Code'
-            : (source === 'gemini' ? 'Gemini CLI' : 'CodeBuddy Code'));
+            : (source === 'gemini'
+                ? 'Gemini CLI'
+                : (source === 'pi' ? 'Pi' : 'CodeBuddy Code')));
     const truncated = !!extracted.truncated;
     const maxMessagesLabel = maxMessages === Infinity ? 'all' : maxMessages;
     const markdown = buildSessionMarkdown({
@@ -13260,8 +13630,8 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                         case 'list-sessions':
                             {
                                 const source = typeof params.source === 'string' ? params.source.trim().toLowerCase() : '';
-                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'all') {
-                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' };
+                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi' && source !== 'all') {
+                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' };
                                 } else {
                                     result = {
                                         sessions: await listSessionBrowse(params),
@@ -13274,8 +13644,8 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                             {
                                 const usageParams = isPlainObject(params) ? params : {};
                                 const source = typeof usageParams.source === 'string' ? usageParams.source.trim().toLowerCase() : '';
-                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'all') {
-                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' };
+                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi' && source !== 'all') {
+                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' };
                                 } else {
                                     result = {
                                         sessions: await listSessionUsage({
@@ -13291,8 +13661,8 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                             {
                                 const usageParams = isPlainObject(params) ? params : {};
                                 const source = typeof usageParams.source === 'string' ? usageParams.source.trim().toLowerCase() : '';
-                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'all') {
-                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' };
+                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi' && source !== 'all') {
+                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' };
                                 } else {
                                     result = await exportSessionUsage({
                                         ...usageParams,
@@ -13304,8 +13674,8 @@ function createWebServer({ htmlPath, assetsDir, webDir, host, port, openBrowser 
                         case 'list-session-paths':
                             {
                                 const source = typeof params.source === 'string' ? params.source.trim().toLowerCase() : '';
-                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'all') {
-                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' };
+                                if (source && source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi' && source !== 'all') {
+                                    result = { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' };
                                 } else {
                                     result = {
                                         paths: listSessionPaths(params)
@@ -15877,7 +16247,7 @@ function createWorkflowToolCatalog() {
             handler: async (args = {}) => {
                 const source = normalizeMcpSource(args.source);
                 if (source === null) {
-                    return { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' };
+                    return { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' };
                 }
                 return {
                     source: source || 'all',
@@ -17997,7 +18367,7 @@ function createMcpTools(options = {}) {
             const input = args && typeof args === 'object' ? args : {};
             const source = normalizeMcpSource(input.source);
             if (source === null) {
-                return { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' };
+                return { error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' };
             }
             const normalizedInput = {
                 ...input,
@@ -18457,7 +18827,7 @@ function createMcpResources() {
                         contents: [{
                             uri,
                             mimeType: 'application/json',
-                            text: JSON.stringify({ error: 'Invalid source. Must be codex, claude, gemini, codebuddy, or all' }, null, 2)
+                            text: JSON.stringify({ error: 'Invalid source. Must be codex, claude, gemini, codebuddy, pi, or all' }, null, 2)
                         }]
                     };
                 }

--- a/cli/session-usage.js
+++ b/cli/session-usage.js
@@ -9,11 +9,12 @@ async function listSessionUsageCore(params = {}, deps = {}) {
         parseClaudeSessionSummary,
         parseCodeBuddySessionSummary,
         parseGeminiSessionSummary,
+        parsePiSessionSummary,
         MAX_SESSION_USAGE_LIST_SIZE,
         SESSION_BROWSE_SUMMARY_READ_BYTES
     } = deps;
 
-    const source = params.source === 'codex' || params.source === 'claude' || params.source === 'gemini' || params.source === 'codebuddy'
+    const source = params.source === 'codex' || params.source === 'claude' || params.source === 'gemini' || params.source === 'codebuddy' || params.source === 'pi'
         ? params.source
         : 'all';
     const rawLimit = Number(params.limit);
@@ -87,7 +88,9 @@ async function listSessionUsageCore(params = {}, deps = {}) {
                         ? parseGeminiSessionSummary(filePath, summaryOptions)
                         : (normalized.source === 'codebuddy'
                             ? parseCodeBuddySessionSummary(filePath, summaryOptions)
-                            : parseCodexSessionSummary(filePath, summaryOptions)));
+                            : (normalized.source === 'pi'
+                                ? parsePiSessionSummary(filePath, summaryOptions)
+                                : parseCodexSessionSummary(filePath, summaryOptions))));
             } catch (_) {
                 summary = null;
             }

--- a/lib/cli-sessions.js
+++ b/lib/cli-sessions.js
@@ -204,6 +204,17 @@ function extractMessageFromRecord(record, source) {
         }
         return null;
     }
+    if (source === 'pi') {
+        if (record.type === 'message' && record.message && typeof record.message === 'object') {
+            const role = normalizeRole(record.message.role);
+            const text = extractMessageText(record.message.content);
+            if (!role || !text) {
+                return null;
+            }
+            return { role, text };
+        }
+        return null;
+    }
 
     const role = normalizeRole(record.type);
     if (!role) {
@@ -267,6 +278,14 @@ function applySessionDetailRecordMetadata(record, source, state) {
         if (record.type === 'session_meta' && record.payload) {
             state.sessionId = record.payload.id || state.sessionId;
             state.cwd = record.payload.cwd || state.cwd;
+        }
+        return;
+    }
+
+    if (source === 'pi') {
+        if (record.type === 'session') {
+            state.sessionId = record.id || state.sessionId;
+            state.cwd = record.cwd || state.cwd;
         }
         return;
     }

--- a/site/guide/getting-started.md
+++ b/site/guide/getting-started.md
@@ -66,7 +66,7 @@ codexmate claude <BaseURL> <API_KEY> [model]
 codexmate auth <list|import|switch|delete|status>
 codexmate workflow <list|get|validate|run|runs>
 codexmate qwen [args...]
-codexmate export-session --source <codex|claude|gemini|codebuddy> --session-id <ID>
+codexmate export-session --source <codex|claude|gemini|codebuddy|pi> --session-id <ID>
 ```
 
 ## 校验建议

--- a/site/index.md
+++ b/site/index.md
@@ -34,7 +34,7 @@ Codex Mate 是一个本地优先的配置与会话管理工具，覆盖：
 - Codex provider/model 切换与配置写入
 - Claude Code 配置方案管理（写入 `~/.claude/settings.json`）
 - OpenClaw JSON5 配置与 Workspace `AGENTS.md`
-- Codex / Claude / Gemini CLI / CodeBuddy Code 本地会话浏览、导出、删除
+- Codex / Claude / Gemini CLI / CodeBuddy Code / Pi 本地会话浏览、导出、删除
 
 ## 快速开始
 
@@ -74,7 +74,7 @@ $env:CODEXMATE_PORT=8080; codexmate run
 - `codexmate workflow <list|get|validate|run|runs>`
 - `codexmate qwen [args...]`
 - `codexmate run [--host <HOST>] [--no-browser]`
-- `codexmate export-session --source <codex|claude> ...`
+- `codexmate export-session --source <codex|claude|gemini|codebuddy|pi> ...`
 
 ## 模块能力
 
@@ -98,7 +98,7 @@ $env:CODEXMATE_PORT=8080; codexmate run
 
 ### 会话
 
-- Codex + Claude + Gemini CLI + CodeBuddy Code 会话统一视图
+- Codex + Claude + Gemini CLI + CodeBuddy Code + Pi 会话统一视图
 - 搜索、筛选、导出、删除、批量清理
 
 ## 测试约定

--- a/tests/unit/session-usage-backend.test.mjs
+++ b/tests/unit/session-usage-backend.test.mjs
@@ -69,6 +69,9 @@ function instantiateListSessionUsage(bindings = {}) {
         parseGeminiSessionSummary() {
             throw new Error('should not parse gemini summary in this test');
         },
+        parsePiSessionSummary() {
+            throw new Error('should not parse pi summary in this test');
+        },
         ...(bindings || {})
     };
     const bindingNames = Object.keys(effectiveBindings);

--- a/web-ui/logic.sessions.mjs
+++ b/web-ui/logic.sessions.mjs
@@ -29,14 +29,14 @@ function shouldUseFastSessionBrowseLimit(options = {}) {
 
 export function isSessionQueryEnabled(source) {
     const normalized = normalizeSessionSource(source, '');
-    return normalized === 'codex' || normalized === 'claude' || normalized === 'gemini' || normalized === 'codebuddy' || normalized === 'all';
+    return normalized === 'codex' || normalized === 'claude' || normalized === 'gemini' || normalized === 'codebuddy' || normalized === 'pi' || normalized === 'all';
 }
 
 export function normalizeSessionSource(source, fallback = 'all') {
     const normalized = typeof source === 'string'
         ? source.trim().toLowerCase()
         : '';
-    if (normalized === 'codex' || normalized === 'claude' || normalized === 'gemini' || normalized === 'codebuddy' || normalized === 'all') {
+    if (normalized === 'codex' || normalized === 'claude' || normalized === 'gemini' || normalized === 'codebuddy' || normalized === 'pi' || normalized === 'all') {
         return normalized;
     }
     return fallback;
@@ -209,7 +209,7 @@ export function buildUsageHeatmap(sessions = [], options = {}) {
     for (const session of list) {
         if (!session || typeof session !== 'object') continue;
         const source = normalizeSessionSource(session.source, '');
-        if (source !== 'codex' && source !== 'claude') continue;
+        if (source !== 'codex' && source !== 'claude' && source !== 'pi') continue;
         const updatedAtMs = Date.parse(session.updatedAt || '');
         if (!Number.isFinite(updatedAtMs)) continue;
         normalized.push({
@@ -309,7 +309,7 @@ export function buildUsageHourlyHeatmap(sessions = [], options = {}) {
     for (const session of list) {
         if (!session || typeof session !== 'object') continue;
         const source = normalizeSessionSource(session.source, '');
-        if (source !== 'codex' && source !== 'claude') continue;
+        if (source !== 'codex' && source !== 'claude' && source !== 'pi') continue;
         const updatedAtMs = Date.parse(session.updatedAt || '');
         if (!Number.isFinite(updatedAtMs)) continue;
         const dayStart = toUtcDayStartMs(updatedAtMs);
@@ -402,7 +402,7 @@ export function buildUsageChartGroups(sessions = [], options = {}) {
     for (const [sessionIndex, session] of list.entries()) {
         if (!session || typeof session !== 'object') continue;
         const source = normalizeSessionSource(session.source, '');
-        if (source !== 'codex' && source !== 'claude') continue;
+        if (source !== 'codex' && source !== 'claude' && source !== 'pi') continue;
         const updatedAtMs = Date.parse(session.updatedAt || '');
         if (!Number.isFinite(updatedAtMs)) continue;
         const createdAtMs = Date.parse(session.createdAt || '');

--- a/web-ui/modules/app.computed.session.mjs
+++ b/web-ui/modules/app.computed.session.mjs
@@ -307,7 +307,8 @@ export function createSessionComputed() {
                 { value: "codex", label: this.t("sessions.source.codex") },
                 { value: "claude", label: this.t("sessions.source.claudeCode") },
                 { value: "gemini", label: this.t("sessions.source.gemini") },
-                { value: "codebuddy", label: this.t("sessions.source.codebuddy") }
+                { value: "codebuddy", label: this.t("sessions.source.codebuddy") },
+                { value: "pi", label: this.t("sessions.source.pi") }
             ];
         },
         activeSessionExportKey() {

--- a/web-ui/modules/app.methods.session-actions.mjs
+++ b/web-ui/modules/app.methods.session-actions.mjs
@@ -28,8 +28,8 @@ export function createSessionActionMethods(options = {}) {
                 let error = '';
                 if (!source) {
                     error = '缺少 source 参数';
-                } else if (source !== 'codex' && source !== 'claude') {
-                    error = 'source 仅支持 codex 或 claude';
+                } else if (source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi') {
+                    error = 'source 仅支持 codex、claude、gemini、codebuddy 或 pi';
                 }
                 if (!sessionId && !filePath) {
                     error = error ? `${error}，还缺少 sessionId 或 filePath` : '缺少 sessionId 或 filePath 参数';
@@ -67,7 +67,15 @@ export function createSessionActionMethods(options = {}) {
                 return;
             }
 
-            const sourceLabel = context.params.source === 'codex' ? 'Codex' : 'Claude Code';
+            const sourceLabel = context.params.source === 'codex'
+                ? 'Codex'
+                : (context.params.source === 'claude'
+                    ? 'Claude Code'
+                    : (context.params.source === 'gemini'
+                        ? 'Gemini CLI'
+                        : (context.params.source === 'pi'
+                            ? 'Pi'
+                            : (context.params.source === 'codebuddy' ? 'CodeBuddy Code' : context.params.source))));
             this.activeSession = {
                 source: context.params.source,
                 sourceLabel,
@@ -96,7 +104,7 @@ export function createSessionActionMethods(options = {}) {
         buildSessionStandaloneUrl(session) {
             if (!session) return '';
             const source = typeof session.source === 'string' ? session.source.trim().toLowerCase() : '';
-            if (!source || (source !== 'codex' && source !== 'claude')) return '';
+            if (!source || (source !== 'codex' && source !== 'claude' && source !== 'gemini' && source !== 'codebuddy' && source !== 'pi')) return '';
             const sessionId = typeof session.sessionId === 'string' ? session.sessionId.trim() : '';
             const filePath = typeof session.filePath === 'string' ? session.filePath.trim() : '';
             if (!sessionId && !filePath) return '';

--- a/web-ui/modules/app.methods.session-browser.mjs
+++ b/web-ui/modules/app.methods.session-browser.mjs
@@ -120,7 +120,7 @@ export function createSessionBrowserMethods(options = {}) {
         syncSessionPathOptionsForSource(source, nextOptions, mergeWithExisting = false) {
             const targetSource = source === 'claude'
                 ? 'claude'
-                : (source === 'gemini' ? 'gemini' : (source === 'all' ? 'all' : 'codex'));
+                : (source === 'gemini' ? 'gemini' : (source === 'pi' ? 'pi' : (source === 'all' ? 'all' : 'codex')));
             const current = Array.isArray(this.sessionPathOptionsMap[targetSource])
                 ? this.sessionPathOptionsMap[targetSource]
                 : [];
@@ -137,7 +137,7 @@ export function createSessionBrowserMethods(options = {}) {
         refreshSessionPathOptions(source) {
             const targetSource = source === 'claude'
                 ? 'claude'
-                : (source === 'gemini' ? 'gemini' : (source === 'all' ? 'all' : 'codex'));
+                : (source === 'gemini' ? 'gemini' : (source === 'pi' ? 'pi' : (source === 'all' ? 'all' : 'codex')));
             const base = Array.isArray(this.sessionPathOptionsMap[targetSource])
                 ? [...this.sessionPathOptionsMap[targetSource]]
                 : [];
@@ -161,7 +161,7 @@ export function createSessionBrowserMethods(options = {}) {
         async loadSessionPathOptions(options = {}) {
             const source = options.source === 'claude'
                 ? 'claude'
-                : (options.source === 'gemini' ? 'gemini' : (options.source === 'all' ? 'all' : 'codex'));
+                : (options.source === 'gemini' ? 'gemini' : (options.source === 'pi' ? 'pi' : (options.source === 'all' ? 'all' : 'codex')));
             const forceRefresh = !!options.forceRefresh;
             const loaded = !!this.sessionPathOptionsLoadedMap[source];
             if (!forceRefresh && loaded) {
@@ -507,7 +507,11 @@ export function createSessionBrowserMethods(options = {}) {
                         ? this.t('sessions.source.claudeCode')
                         : (this.sessionFilterSource === 'gemini'
                             ? this.t('sessions.source.gemini')
-                            : (this.sessionFilterSource === 'codebuddy' ? this.t('sessions.source.codebuddy') : this.sessionFilterSource)));
+                            : (this.sessionFilterSource === 'codebuddy'
+                                ? this.t('sessions.source.codebuddy')
+                                : (this.sessionFilterSource === 'pi'
+                                    ? this.t('sessions.source.pi')
+                                    : this.sessionFilterSource))));
                 chips.push({ key: 'source', title: this.t('sessions.filters.source'), value: label });
             }
             if (this.sessionPathFilter) {

--- a/web-ui/modules/app.methods.session-trash.mjs
+++ b/web-ui/modules/app.methods.session-trash.mjs
@@ -10,7 +10,7 @@ export function createSessionTrashMethods(options = {}) {
             const deletedAt = typeof result.deletedAt === 'string' && result.deletedAt
                 ? result.deletedAt
                 : new Date().toISOString();
-            const source = session && (session.source === 'claude' || session.source === 'gemini')
+            const source = session && (session.source === 'claude' || session.source === 'gemini' || session.source === 'codebuddy' || session.source === 'pi')
                 ? session.source
                 : 'codex';
             return {
@@ -18,7 +18,7 @@ export function createSessionTrashMethods(options = {}) {
                 source,
                 sourceLabel: session && typeof session.sourceLabel === 'string' && session.sourceLabel
                     ? session.sourceLabel
-                    : (source === 'claude' ? 'Claude Code' : (source === 'gemini' ? 'Gemini CLI' : 'Codex')),
+                    : (source === 'claude' ? 'Claude Code' : (source === 'gemini' ? 'Gemini CLI' : (source === 'pi' ? 'Pi' : (source === 'codebuddy' ? 'CodeBuddy Code' : 'Codex')))),
                 sessionId: session && typeof session.sessionId === 'string' ? session.sessionId : '',
                 title: session && typeof session.title === 'string' && session.title
                     ? session.title

--- a/web-ui/modules/i18n/locales/en.mjs
+++ b/web-ui/modules/i18n/locales/en.mjs
@@ -645,6 +645,7 @@ const en = Object.freeze({
     'sessions.source.claudeCode': 'Claude Code',
     'sessions.source.gemini': 'Gemini CLI',
     'sessions.source.codebuddy': 'CodeBuddy Code',
+    'sessions.source.pi': 'Pi',
     'sessions.loadingList': 'Loading sessions...',
     'sessions.empty': 'No sessions found',
     'sessions.unknownTime': 'unknown time',

--- a/web-ui/modules/i18n/locales/ja.mjs
+++ b/web-ui/modules/i18n/locales/ja.mjs
@@ -647,6 +647,7 @@ const ja = Object.freeze({
     'sessions.source.claudeCode': 'Claude Code',
     'sessions.source.gemini': 'Gemini',
     'sessions.source.codebuddy': 'CodeBuddy',
+    'sessions.source.pi': 'Pi',
     'sessions.loadingList': 'セッション一覧を読み込み中...',
     'sessions.empty': 'セッションがありません',
     'sessions.unknownTime': '不明な時間',

--- a/web-ui/modules/i18n/locales/vi.mjs
+++ b/web-ui/modules/i18n/locales/vi.mjs
@@ -850,6 +850,7 @@ const vi = Object.freeze({
     'sessions.source.claudeCode': 'Claude Code',
     'sessions.source.gemini': 'Gemini CLI',
     'sessions.source.codebuddy': 'CodeBuddy Code',
+    'sessions.source.pi': 'Pi',
     'sessions.loadingList': 'Đang tải phiên làm việc...',
     'sessions.empty': 'Không tìm thấy phiên nào',
     'sessions.unknownTime': 'thời gian không rõ',

--- a/web-ui/modules/i18n/locales/zh-tw.mjs
+++ b/web-ui/modules/i18n/locales/zh-tw.mjs
@@ -645,6 +645,7 @@ const zhTw = Object.freeze({
     'sessions.source.claudeCode': 'Claude Code',
     'sessions.source.gemini': 'Gemini CLI',
     'sessions.source.codebuddy': 'CodeBuddy Code',
+    'sessions.source.pi': 'Pi',
     'sessions.loadingList': '會話載入中...',
     'sessions.empty': '暫無可用會話記錄',
     'sessions.unknownTime': '未知時間',

--- a/web-ui/modules/i18n/locales/zh.mjs
+++ b/web-ui/modules/i18n/locales/zh.mjs
@@ -645,6 +645,7 @@ const zh = Object.freeze({
     'sessions.source.claudeCode': 'Claude Code',
     'sessions.source.gemini': 'Gemini CLI',
     'sessions.source.codebuddy': 'CodeBuddy Code',
+    'sessions.source.pi': 'Pi',
     'sessions.loadingList': '会话加载中...',
     'sessions.empty': '暂无可用会话记录',
     'sessions.unknownTime': '未知时间',


### PR DESCRIPTION
## Summary

Add `pi` as a valid session source throughout the CodexMate web UI, enabling users to browse Pi coding agent sessions alongside existing codex/claude/gemini/codebuddy sources.

### Changes

**Backend (`cli.js`)**:
- Add `PI_DIR`/`PI_SESSIONS_DIR` constants, `getPiSessionsDir()`, `listPiSessions()`, `parsePiSessionSummary()`, `extractPiUsageFromMessage()`, `extractPiMessageFromRecord()`, `recordHasPiMessage()`
- Add pi to all source normalization chains (12+ functions including `listAllSessions`, `listSessionInventoryBySource`, `resolveSessionFilePath`, `readSessionDetail`, `readSessionPlain`, `exportSessionData`, `trashSessionData`, `deleteSessionData`, `buildSessionTrashEntry`, `normalizeSessionTrashEntry`, `resolveSessionRestoreTarget`, `hydrateSessionTrashEntries`, `buildSessionInventoryCacheKey`, `buildSessionSummaryFallback`, `readSessionProviderFromRecord`, `listSessionTrashItems`)
- Add `g_sessionFileLookupCache` pi key for sessionId-based file resolution

**Backend libs**:
- `lib/cli-sessions.js`: `extractMessageFromRecord` and `applySessionDetailRecordMetadata` pi branches
- `cli/session-usage.js`: source whitelist + `parsePiSessionSummary` dependency + summary selection

**Frontend**:
- `web-ui/logic.sessions.mjs`: `normalizeSessionSource`, `isSessionQueryEnabled`, 3 heatmap source filters
- `web-ui/modules/app.computed.session.mjs`: `sessionSourceOptions` pi entry
- `web-ui/modules/app.methods.session-browser.mjs`: 3 path source normalizations + filterChips pi label
- `web-ui/modules/app.methods.session-trash.mjs`: source normalization + sourceLabel
- `web-ui/modules/app.methods.session-actions.mjs`: standalone route source validation + buildSessionStandaloneUrl + sourceLabel

**i18n** (5 locales: zh, en, ja, vi, zh-tw):
- Add `sessions.source.pi: 'Pi'` label string

**Tests**:
- `tests/unit/session-usage-backend.test.mjs`: add `parsePiSessionSummary` mock

### Verification

- 761 unit tests pass
- 20 e2e tests pass
- 31/31 brute-force API tests pass (list/detail/plain/paths/trash/restore/delete/usage/export/message-counts, case-insensitive source, cross-source consistency, standalone route, frontend bundle)

### Notes

- Pi sessions are stored at `~/.pi/agent/sessions/<project-slug>/<timestamp>_<uuid>.jsonl`
- Token usage extraction maps camelCase pi fields to internal snake_case format
- toolResult messages are excluded from messageCount (consistent with normalizeRole returning empty for toolResult)
- Clone/convert/import-native operations are not supported for pi (conservative — pi CLI has no known equivalent commands)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class support for **Pi** sessions across the CLI and web interface, including discovery, browsing, filtering, and standalone viewing.
  * Extended session usage parsing and usage charts to include **Pi** (models, provider, messages, and token totals).
  * Added **Pi** to session source selectors, filters, and trash management, with localized source labels in supported languages.
* **Bug Fixes**
  * Improved **Pi** session record parsing so message roles/text and session metadata are extracted consistently.
* **Documentation**
  * Updated the README(s) to include **Pi** in Session Browser capabilities and progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->