### PR TITLE
docs(readme): restore Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ Special thanks to all contributors for their contributions to Codex Mate ❤️
   <img src="https://contrib.rocks/image?repo=SakuraByteCore/codexmate" />
 </a>
 
+## Star History
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=SakuraByteCore/codexmate&type=Date)](https://star-history.dera.page/#SakuraByteCore/codexmate&Date)
+
 ## License
 
 Apache-2.0

--- a/README.vi.md
+++ b/README.vi.md
@@ -167,6 +167,10 @@ Cảm ơn tất cả những người đóng góp cho Codex Mate ❤️
   <img src="https://contrib.rocks/image?repo=SakuraByteCore/codexmate" alt="Contributors" />
 </a>
 
+## Lịch sử Star
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=SakuraByteCore/codexmate&type=Date)](https://star-history.dera.page/#SakuraByteCore/codexmate&Date)
+
 ## Giấy phép
 
 Apache-2.0

--- a/README.zh.md
+++ b/README.zh.md
@@ -181,6 +181,10 @@ flowchart TD
   <img src="https://contrib.rocks/image?repo=SakuraByteCore/codexmate" />
 </a>
 
+## Star 历史
+
+[![Star History Chart](https://star-history.dera.page/svg?repos=SakuraByteCore/codexmate&type=Date)](https://star-history.dera.page/#SakuraByteCore/codexmate&Date)
+
 ## 开源协议
 
 Apache-2.0


### PR DESCRIPTION
The Star History chart was removed in 27479dd because the previous service could no longer render it. That problem remains, as the chart relies on GitHub stargazer data that is now restricted, and it is worth fixing since project growth is a useful signal for contributors and users.

This PR restores the Star History chart in README.md, README.vi.md, and README.zh.md at its original location between the contributors section and the license section, pointing to a working chart service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Star History charts and links to the English, Vietnamese, and Chinese README files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->